### PR TITLE
feat(infra): replace mock with cli executor (#14)

### DIFF
--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -34,7 +34,7 @@ pub struct ExecutionResult {
 }
 
 /// Executor for running prompts through CLI backends.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CliExecutor {
     backend: CliBackend,
 }

--- a/src/infra/llm.rs
+++ b/src/infra/llm.rs
@@ -1,7 +1,9 @@
-//! LLM client trait and mock implementation.
+//! LLM client trait and CLI-based implementation.
 
 use async_trait::async_trait;
 use snafu::Snafu;
+
+use crate::agent::executor::CliExecutor;
 
 /// Errors from LLM client operations.
 #[derive(Debug, Snafu)]
@@ -22,29 +24,24 @@ pub trait LlmClient: Send + Sync {
     async fn complete(&self, prompt: &str) -> Result<String, LlmError>;
 }
 
-/// A mock LLM client that returns pre-configured responses for testing.
-#[derive(Clone)]
-pub struct MockLlmClient {
-    responses: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
-}
-
-impl MockLlmClient {
-    /// Create a new mock client with a queue of responses.
-    pub fn new(responses: Vec<String>) -> Self {
-        Self {
-            responses: std::sync::Arc::new(std::sync::Mutex::new(responses)),
-        }
-    }
-}
-
 #[async_trait]
-impl LlmClient for MockLlmClient {
-    async fn complete(&self, _prompt: &str) -> Result<String, LlmError> {
-        let mut queue = self.responses.lock().expect("mock lock poisoned");
-        if queue.is_empty() {
-            Ok("mock response".to_owned())
+impl LlmClient for CliExecutor {
+    async fn complete(&self, prompt: &str) -> Result<String, LlmError> {
+        let result = self.execute_capture(prompt).await.map_err(|e| {
+            LlmError::RequestFailed {
+                message: e.to_string(),
+            }
+        })?;
+        if result.success {
+            Ok(result.output.trim().to_owned())
         } else {
-            Ok(queue.remove(0))
+            Err(LlmError::RequestFailed {
+                message: format!(
+                    "CLI exited with code {:?}: {}",
+                    result.exit_code,
+                    result.stderr.trim()
+                ),
+            })
         }
     }
 }

--- a/src/research/hypothesis_gen.rs
+++ b/src/research/hypothesis_gen.rs
@@ -112,8 +112,20 @@ impl<L: LlmClient> HypothesisGenerator<L> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent::backend::{CliBackend, OutputFormat, PromptMode};
+    use crate::agent::executor::CliExecutor;
     use crate::domain::research::Experiment;
-    use crate::infra::llm::MockLlmClient;
+
+    fn echo_executor(response: &str) -> CliExecutor {
+        CliExecutor::new(CliBackend {
+            command: "printf".to_string(),
+            args: vec![format!("{response}\n")],
+            prompt_mode: PromptMode::Stdin,
+            prompt_flag: None,
+            output_format: OutputFormat::Text,
+            env_vars: vec![],
+        })
+    }
 
     #[tokio::test]
     async fn generate_links_parent_to_best_experiment() {
@@ -141,8 +153,8 @@ mod tests {
             .build();
         trace.save_feedback(&fb).unwrap();
 
-        let mock = MockLlmClient::new(vec!["momentum crossover\nSMA cross signals trend reversal".to_owned()]);
-        let generator = HypothesisGenerator::new(mock);
+        let executor = echo_executor("momentum crossover\nSMA cross signals trend reversal");
+        let generator = HypothesisGenerator::new(executor);
 
         let h = generator.generate(&trace, "BTC market").await.unwrap();
         assert_eq!(h.text(), "momentum crossover");

--- a/src/research/research_loop.rs
+++ b/src/research/research_loop.rs
@@ -223,9 +223,21 @@ mod tests {
     use rust_decimal::Decimal;
 
     use super::*;
+    use crate::agent::backend::{CliBackend, OutputFormat, PromptMode};
+    use crate::agent::executor::CliExecutor;
     use crate::domain::research::BacktestResult;
-    use crate::infra::llm::MockLlmClient;
     use crate::research::backtester::MockBacktester;
+
+    fn echo_executor(response: &str) -> CliExecutor {
+        CliExecutor::new(CliBackend {
+            command: "printf".to_string(),
+            args: vec![format!("{response}\n")],
+            prompt_mode: PromptMode::Stdin,
+            prompt_flag: None,
+            output_format: OutputFormat::Text,
+            env_vars: vec![],
+        })
+    }
 
     #[tokio::test]
     async fn run_iteration_accepts_good_result() {
@@ -235,10 +247,10 @@ mod tests {
         let trace = Trace::open(trace_dir.path()).unwrap();
         let event_bus = Arc::new(EventBus::open(bus_dir.path()).unwrap());
 
-        let mock_llm = MockLlmClient::new(vec![
-            "momentum crossover\nSMA signals trend".to_owned(),
-            "fn strategy() { buy_on_cross() }".to_owned(),
-        ]);
+        // Both hypothesis generator and strategy coder receive the same output.
+        // The hypothesis generator parses line 1 as text and line 2 as reasoning.
+        // The strategy coder treats the full output as code (acceptable for testing).
+        let executor = echo_executor("momentum crossover\nSMA signals trend");
 
         let good_result = BacktestResult::builder()
             .pnl(Decimal::new(5000, 0))
@@ -250,7 +262,7 @@ mod tests {
 
         let mock_bt = MockBacktester::new(vec![good_result]);
 
-        let loop_ = ResearchLoop::new(mock_llm, mock_bt, trace, event_bus.clone());
+        let loop_ = ResearchLoop::new(executor, mock_bt, trace, event_bus.clone());
 
         let result = loop_.run_iteration("BTC trending").await.unwrap();
 
@@ -275,10 +287,7 @@ mod tests {
         let trace = Trace::open(trace_dir.path()).unwrap();
         let event_bus = Arc::new(EventBus::open(bus_dir.path()).unwrap());
 
-        let mock_llm = MockLlmClient::new(vec![
-            "mean reversion\nPrice reverts to mean".to_owned(),
-            "fn strategy() { sell_on_spike() }".to_owned(),
-        ]);
+        let executor = echo_executor("mean reversion\nPrice reverts to mean");
 
         let bad_result = BacktestResult::builder()
             .pnl(Decimal::new(-2000, 0))
@@ -290,7 +299,7 @@ mod tests {
 
         let mock_bt = MockBacktester::new(vec![bad_result]);
 
-        let loop_ = ResearchLoop::new(mock_llm, mock_bt, trace, event_bus.clone());
+        let loop_ = ResearchLoop::new(executor, mock_bt, trace, event_bus.clone());
 
         let result = loop_.run_iteration("ETH volatile").await.unwrap();
 

--- a/src/research/strategy_coder.rs
+++ b/src/research/strategy_coder.rs
@@ -54,12 +54,24 @@ impl<L: LlmClient> StrategyCoder<L> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::infra::llm::MockLlmClient;
+    use crate::agent::backend::{CliBackend, OutputFormat, PromptMode};
+    use crate::agent::executor::CliExecutor;
+
+    fn echo_executor(response: &str) -> CliExecutor {
+        CliExecutor::new(CliBackend {
+            command: "printf".to_string(),
+            args: vec![format!("{response}\n")],
+            prompt_mode: PromptMode::Stdin,
+            prompt_flag: None,
+            output_format: OutputFormat::Text,
+            env_vars: vec![],
+        })
+    }
 
     #[tokio::test]
     async fn generate_code_returns_llm_response() {
-        let mock = MockLlmClient::new(vec!["fn strategy() { buy() }".to_owned()]);
-        let coder = StrategyCoder::new(mock);
+        let executor = echo_executor("fn strategy() { buy() }");
+        let coder = StrategyCoder::new(executor);
 
         let h = Hypothesis::builder()
             .text("momentum works")

--- a/src/sentinel/analyzer.rs
+++ b/src/sentinel/analyzer.rs
@@ -145,9 +145,21 @@ fn parse_signal_type(s: &str) -> Result<SignalType, AnalyzerError> {
 
 #[cfg(test)]
 mod tests {
-    use crate::infra::llm::MockLlmClient;
+    use crate::agent::backend::{CliBackend, OutputFormat, PromptMode};
+    use crate::agent::executor::CliExecutor;
 
     use super::*;
+
+    fn echo_executor(response: &str) -> CliExecutor {
+        CliExecutor::new(CliBackend {
+            command: "printf".to_string(),
+            args: vec![format!("{response}\n")],
+            prompt_mode: PromptMode::Stdin,
+            prompt_flag: None,
+            output_format: OutputFormat::Text,
+            env_vars: vec![],
+        })
+    }
 
     fn make_raw_signal() -> RawSignal {
         RawSignal {
@@ -160,14 +172,10 @@ mod tests {
 
     #[tokio::test]
     async fn parses_critical_signal_correctly() {
-        let llm = MockLlmClient::new(vec![
-            "SEVERITY: Critical\n\
-             TYPE: BlackSwan\n\
-             CONTRACTS: BTC-PERP,ETH-PERP\n\
-             SUMMARY: Major exchange hack detected"
-                .to_owned(),
-        ]);
-        let analyzer = SignalAnalyzer::new(llm);
+        let executor = echo_executor(
+            "SEVERITY: Critical\nTYPE: BlackSwan\nCONTRACTS: BTC-PERP,ETH-PERP\nSUMMARY: Major exchange hack detected",
+        );
+        let analyzer = SignalAnalyzer::new(executor);
         let raw = make_raw_signal();
 
         let result = analyzer.analyze(&raw).await.expect("analysis should succeed");
@@ -180,14 +188,10 @@ mod tests {
 
     #[tokio::test]
     async fn none_severity_returns_none() {
-        let llm = MockLlmClient::new(vec![
-            "SEVERITY: None\n\
-             TYPE: SentimentShift\n\
-             CONTRACTS: \n\
-             SUMMARY: No actionable signal"
-                .to_owned(),
-        ]);
-        let analyzer = SignalAnalyzer::new(llm);
+        let executor = echo_executor(
+            "SEVERITY: None\nTYPE: SentimentShift\nCONTRACTS: \nSUMMARY: No actionable signal",
+        );
+        let analyzer = SignalAnalyzer::new(executor);
         let raw = make_raw_signal();
 
         let result = analyzer.analyze(&raw).await.expect("analysis should succeed");

--- a/src/sentinel/engine.rs
+++ b/src/sentinel/engine.rs
@@ -103,11 +103,23 @@ mod tests {
 
     use serde_json::json;
 
-    use crate::infra::llm::MockLlmClient;
+    use crate::agent::backend::{CliBackend, OutputFormat, PromptMode};
+    use crate::agent::executor::CliExecutor;
     use crate::sentinel::source::RawSignal;
     use crate::sentinel::sources::mock::MockDataSource;
 
     use super::*;
+
+    fn echo_executor(response: &str) -> CliExecutor {
+        CliExecutor::new(CliBackend {
+            command: "printf".to_string(),
+            args: vec![format!("{response}\n")],
+            prompt_mode: PromptMode::Stdin,
+            prompt_flag: None,
+            output_format: OutputFormat::Text,
+            env_vars: vec![],
+        })
+    }
 
     #[tokio::test]
     async fn poll_and_analyze_publishes_critical_signals() {
@@ -123,15 +135,11 @@ mod tests {
 
         let source = MockDataSource::new("mock-news", vec![raw]);
 
-        let llm = MockLlmClient::new(vec![
-            "SEVERITY: Critical\n\
-             TYPE: BlackSwan\n\
-             CONTRACTS: BTC-PERP\n\
-             SUMMARY: Exchange hack detected"
-                .to_owned(),
-        ]);
+        let executor = echo_executor(
+            "SEVERITY: Critical\nTYPE: BlackSwan\nCONTRACTS: BTC-PERP\nSUMMARY: Exchange hack detected",
+        );
 
-        let analyzer = SignalAnalyzer::new(llm);
+        let analyzer = SignalAnalyzer::new(executor);
         let engine = SentinelEngine::new(vec![Box::new(source)], analyzer, event_bus.clone());
 
         let signals = engine.poll_and_analyze().await.unwrap();
@@ -158,15 +166,11 @@ mod tests {
 
         let source = MockDataSource::new("mock-news", vec![raw]);
 
-        let llm = MockLlmClient::new(vec![
-            "SEVERITY: None\n\
-             TYPE: SentimentShift\n\
-             CONTRACTS: \n\
-             SUMMARY: No actionable signal"
-                .to_owned(),
-        ]);
+        let executor = echo_executor(
+            "SEVERITY: None\nTYPE: SentimentShift\nCONTRACTS: \nSUMMARY: No actionable signal",
+        );
 
-        let analyzer = SignalAnalyzer::new(llm);
+        let analyzer = SignalAnalyzer::new(executor);
         let engine = SentinelEngine::new(vec![Box::new(source)], analyzer, event_bus.clone());
 
         let signals = engine.poll_and_analyze().await.unwrap();

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -14,7 +14,8 @@ use rara_trading::event_bus::bus::EventBus;
 use rara_trading::feedback::aggregator::MetricsAggregator;
 use rara_trading::feedback::engine::FeedbackBridge;
 use rara_trading::feedback::evaluator::StrategyEvaluator;
-use rara_trading::infra::llm::MockLlmClient;
+use rara_trading::agent::backend::{CliBackend, OutputFormat, PromptMode};
+use rara_trading::agent::executor::CliExecutor;
 use rara_trading::research::backtester::MockBacktester;
 use rara_trading::research::research_loop::ResearchLoop;
 use rara_trading::research::trace::Trace;
@@ -22,6 +23,17 @@ use rara_trading::trading::broker::OrderStatus;
 use rara_trading::trading::brokers::mock::MockBroker;
 use rara_trading::trading::engine::TradingEngine;
 use rara_trading::trading::guard_pipeline::GuardPipeline;
+
+fn printf_executor(response: &str) -> CliExecutor {
+    CliExecutor::new(CliBackend {
+        command: "printf".to_string(),
+        args: vec![format!("{response}\n")],
+        prompt_mode: PromptMode::Stdin,
+        prompt_flag: None,
+        output_format: OutputFormat::Text,
+        env_vars: vec![],
+    })
+}
 
 #[tokio::test]
 async fn full_research_to_feedback_loop() {
@@ -32,10 +44,7 @@ async fn full_research_to_feedback_loop() {
     let trace = Trace::open(trace_dir.path()).unwrap();
 
     // --- Phase 1: Research — generate a candidate strategy ---
-    let mock_llm = MockLlmClient::new(vec![
-        "momentum crossover\nSMA 20/50 crossover signals trend change".to_owned(),
-        "fn strategy() { buy_on_golden_cross() }".to_owned(),
-    ]);
+    let executor = printf_executor("momentum crossover\nSMA 20/50 crossover signals trend change");
 
     let good_backtest = BacktestResult::builder()
         .pnl(Decimal::new(5000, 0))
@@ -46,7 +55,7 @@ async fn full_research_to_feedback_loop() {
         .build();
 
     let mock_bt = MockBacktester::new(vec![good_backtest]);
-    let research = ResearchLoop::new(mock_llm, mock_bt, trace, Arc::clone(&event_bus));
+    let research = ResearchLoop::new(executor, mock_bt, trace, Arc::clone(&event_bus));
 
     let iteration = research.run_iteration("BTC trending up").await.unwrap();
     assert!(iteration.accepted, "research should accept good backtest");


### PR DESCRIPTION
## Summary
- Implement `LlmClient` trait for `CliExecutor`, enabling real CLI agent backends
- Remove `MockLlmClient` entirely
- Update all tests to use `printf`/`echo` CLI backends instead of mocks

## Test plan
- [x] All 68 tests pass
- [x] cargo clippy clean

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)