### PR TITLE
feat(market-data): smart fetch + info (#54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,62 @@ flowchart LR
 
 ## Tech Stack
 
-Rust 2024, tokio, sled, barter-rs, ccxt-rust, snafu, jiff, rust_decimal
+Rust 2024, tokio, TimescaleDB, barter-rs, ccxt-rust, snafu, jiff, rust_decimal
+
+## Getting Started
+
+### 1. Start Database
+
+```bash
+docker compose up -d timescaledb
+```
+
+This starts a TimescaleDB instance on `localhost:5432` (user: `rara`, password: `rara`, db: `rara_trading`). Migrations run automatically on first CLI use.
+
+### 2. Fetch Market Data
+
+```bash
+# Fetch BTC/USDT 1m candles from Binance
+rara-trading data fetch --source binance --symbol BTCUSDT --start 2026-01-01 --end 2026-03-25
+
+# Fetch SPY daily candles from Yahoo Finance
+rara-trading data fetch --source yahoo --symbol SPY --start 2025-01-01 --end 2025-12-31
+```
+
+Already-fetched days are skipped automatically — safe to re-run for incremental updates.
+
+### 3. Check Data Coverage
+
+```bash
+rara-trading data info
+```
+
+Returns JSON with all stored instruments, their date ranges, and candle counts.
+
+### 4. Query with DuckDB (optional)
+
+```bash
+duckdb -c "
+LOAD postgres;
+ATTACH 'dbname=rara_trading user=rara password=rara host=localhost port=5432' AS ts (TYPE POSTGRES);
+SELECT * FROM ts.public.candles LIMIT 10;
+"
+```
+
+## CLI Reference
+
+| Command | Description |
+|---------|-------------|
+| `data fetch --source <binance\|yahoo> --symbol SYM --start DATE --end DATE` | Fetch historical candles (idempotent) |
+| `data info` | Show data coverage per instrument (JSON) |
+| `research run [--iterations N] [--contract C]` | Run N research loop iterations |
+| `research list [--limit N]` | List experiment history |
+| `research show --experiment-id ID` | Show experiment details |
+| `research promoted` | List promoted strategies |
+| `config set\|get\|list` | Manage configuration |
+| `agent <prompt> [--backend B]` | Run a prompt through the LLM backend |
+
+All commands output structured JSON to stdout (human-readable logs go to stderr), making them suitable for agent/LLM consumption.
 
 ## Development
 

--- a/crates/rara-market-data/src/fetcher/binance.rs
+++ b/crates/rara-market-data/src/fetcher/binance.rs
@@ -82,6 +82,19 @@ impl HistoryFetcher for BinanceFetcher {
         let mut current = start;
 
         while current <= end {
+            // Skip days already fully stored (1440 = 24h * 60m)
+            let existing = store
+                .count_candles_for_day(instrument_id, "1m", current)
+                .await
+                .context(StoreSnafu)?;
+            if existing >= 1440 {
+                info!(date = %current, existing, "binance: day complete, skipping");
+                current = current
+                    .checked_add_days(Days::new(1))
+                    .expect("date overflow");
+                continue;
+            }
+
             let day_start_ms = current
                 .and_time(NaiveTime::MIN)
                 .and_utc()

--- a/crates/rara-market-data/src/fetcher/yahoo.rs
+++ b/crates/rara-market-data/src/fetcher/yahoo.rs
@@ -133,6 +133,21 @@ impl HistoryFetcher for YahooFetcher {
             "1d"
         };
 
+        // Skip if range already has expected candle count
+        let existing = store
+            .query_candles(instrument_id, interval, start, end)
+            .await
+            .context(StoreSnafu)?;
+        let expected = if interval == "1d" {
+            range_days
+        } else {
+            range_days * 1440
+        };
+        if i64::try_from(existing.len()).unwrap_or(i64::MAX) >= expected {
+            info!(existing = existing.len(), expected, "yahoo: range complete, skipping");
+            return Ok(0);
+        }
+
         let mut candles = self.fetch_range(period1, period2, interval).await?;
 
         for c in &mut candles {

--- a/crates/rara-market-data/src/store/candle.rs
+++ b/crates/rara-market-data/src/store/candle.rs
@@ -1,10 +1,26 @@
 //! Candle CRUD operations against `TimescaleDB`.
 
 use chrono::{DateTime, NaiveDate, NaiveTime, Utc};
+use serde::Serialize;
 use snafu::ResultExt;
 use tracing::debug;
 
 use super::{DatabaseSnafu, MarketStore, Result};
+
+/// Coverage summary for one instrument+interval pair.
+#[derive(Debug, Clone, Serialize)]
+pub struct CandleCoverage {
+    /// Instrument identifier.
+    pub instrument_id: String,
+    /// Candle interval.
+    pub interval: String,
+    /// Total candle count.
+    pub count: i64,
+    /// Earliest candle timestamp.
+    pub min_ts: Option<DateTime<Utc>>,
+    /// Latest candle timestamp.
+    pub max_ts: Option<DateTime<Utc>>,
+}
 
 /// A single OHLCV candle row, used for both insert and query.
 #[derive(Debug, Clone)]
@@ -104,6 +120,69 @@ impl MarketStore {
 
         Ok(rows.into_iter().map(CandleRow::from).collect())
     }
+
+    /// Get coverage summary for all instrument+interval pairs in the store.
+    pub async fn get_coverage(&self) -> Result<Vec<CandleCoverage>> {
+        let rows = sqlx::query_as::<_, CoverageRow>(
+            "SELECT instrument_id, interval, count(*) as count, min(ts) as min_ts, max(ts) as max_ts
+             FROM candles
+             GROUP BY instrument_id, interval
+             ORDER BY instrument_id, interval",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .context(DatabaseSnafu)?;
+
+        Ok(rows
+            .into_iter()
+            .map(|r| CandleCoverage {
+                instrument_id: r.instrument_id,
+                interval: r.interval,
+                count: r.count.unwrap_or(0),
+                min_ts: r.min_ts,
+                max_ts: r.max_ts,
+            })
+            .collect())
+    }
+
+    /// Count candles for a specific instrument+interval on a single day.
+    pub async fn count_candles_for_day(
+        &self,
+        instrument_id: &str,
+        interval: &str,
+        day: NaiveDate,
+    ) -> Result<i64> {
+        let day_start = day.and_time(NaiveTime::MIN).and_utc();
+        let day_end = day
+            .succ_opt()
+            .unwrap_or(day)
+            .and_time(NaiveTime::MIN)
+            .and_utc();
+
+        let row = sqlx::query_scalar::<_, i64>(
+            "SELECT count(*) FROM candles
+             WHERE instrument_id = $1 AND interval = $2 AND ts >= $3 AND ts < $4",
+        )
+        .bind(instrument_id)
+        .bind(interval)
+        .bind(day_start)
+        .bind(day_end)
+        .fetch_one(&self.pool)
+        .await
+        .context(DatabaseSnafu)?;
+
+        Ok(row)
+    }
+}
+
+/// Internal query result for coverage aggregation.
+#[derive(sqlx::FromRow)]
+struct CoverageRow {
+    instrument_id: String,
+    interval: String,
+    count: Option<i64>,
+    min_ts: Option<DateTime<Utc>>,
+    max_ts: Option<DateTime<Utc>>,
 }
 
 /// Internal query result type that implements `sqlx::FromRow`.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -52,6 +52,7 @@ pub enum Command {
 #[derive(Subcommand, Debug)]
 pub enum DataAction {
     /// Fetch historical candles from an exchange into `TimescaleDB`.
+    /// Days already fully stored are skipped automatically.
     Fetch {
         /// Data source: "binance" or "yahoo".
         #[arg(long)]
@@ -66,6 +67,9 @@ pub enum DataAction {
         #[arg(long)]
         end: String,
     },
+
+    /// Show data coverage for all stored instruments (JSON output).
+    Info,
 }
 
 /// Research loop subcommands.

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,13 @@ struct DataFetchResponse<'a> {
 }
 
 #[derive(Serialize)]
+struct DataInfoResponse {
+    ok: bool,
+    action: &'static str,
+    instruments: Vec<rara_market_data::store::candle::CandleCoverage>,
+}
+
+#[derive(Serialize)]
 struct ExperimentListItem {
     index: u64,
     experiment_id: String,
@@ -386,6 +393,7 @@ async fn run_data(action: DataAction) -> error::Result<()> {
             start,
             end,
         } => run_data_fetch(&source, &symbol, &start, &end).await,
+        DataAction::Info => run_data_info().await,
     }
 }
 
@@ -443,6 +451,28 @@ async fn run_data_fetch(
             candles: count,
         })
         .expect("DataFetchResponse must serialize")
+    );
+    Ok(())
+}
+
+/// Show data coverage for all stored instruments.
+async fn run_data_info() -> error::Result<()> {
+    let cfg = app_config::load();
+    let store = rara_market_data::store::MarketStore::connect(&cfg.database.url)
+        .await
+        .context(MarketStoreSnafu)?;
+    store.migrate().await.context(MarketStoreSnafu)?;
+
+    let coverage = store.get_coverage().await.context(MarketStoreSnafu)?;
+
+    println!(
+        "{}",
+        serde_json::to_string(&DataInfoResponse {
+            ok: true,
+            action: "data.info",
+            instruments: coverage,
+        })
+        .expect("DataInfoResponse must serialize")
     );
     Ok(())
 }


### PR DESCRIPTION
Closes #54

## Summary
- Add `MarketStore::get_coverage()` and `count_candles_for_day()` for querying existing data
- Binance fetcher skips days with 1440+ candles already stored; Yahoo fetcher skips complete ranges
- Add `data info` CLI subcommand — returns JSON coverage per instrument for agent consumption
- Update README with database setup, CLI reference table, and DuckDB query example

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] CI green