### PR TITLE
refactor(market-data): use max_ts pattern (#56)

### DIFF
--- a/crates/rara-market-data/src/fetcher/binance.rs
+++ b/crates/rara-market-data/src/fetcher/binance.rs
@@ -2,6 +2,7 @@
 //!
 //! Uses the public `/api/v3/klines` endpoint (no authentication required).
 //! Paginates at 1000 candles per request (~16.6 hours of 1m data).
+//! Resumes from the latest stored candle via `MAX(ts)` query.
 
 use async_trait::async_trait;
 use chrono::{DateTime, Days, NaiveDate, NaiveTime, Utc};
@@ -78,42 +79,43 @@ impl HistoryFetcher for BinanceFetcher {
         start: NaiveDate,
         end: NaiveDate,
     ) -> Result<usize> {
+        let range_start_ms = start
+            .and_time(NaiveTime::MIN)
+            .and_utc()
+            .timestamp_millis();
+        let range_end_ms = end
+            .checked_add_days(Days::new(1))
+            .expect("date overflow")
+            .and_time(NaiveTime::MIN)
+            .and_utc()
+            .timestamp_millis()
+            - 1;
+
+        // Resume from last stored candle + 1 minute
+        let resume_ms = store
+            .max_ts(instrument_id, "1m")
+            .await
+            .context(StoreSnafu)?
+            .map_or(i64::MIN, |ts| ts.timestamp_millis() + 60_000);
+
+        let fetch_start_ms = range_start_ms.max(resume_ms);
+        if fetch_start_ms > range_end_ms {
+            info!("binance: already up to date, nothing to fetch");
+            return Ok(0);
+        }
+
         let mut total = 0usize;
-        let mut current = start;
+        let mut cursor_ms = fetch_start_ms;
 
-        while current <= end {
-            // Skip days already fully stored (1440 = 24h * 60m)
-            let existing = store
-                .count_candles_for_day(instrument_id, "1m", current)
-                .await
-                .context(StoreSnafu)?;
-            if existing >= 1440 {
-                info!(date = %current, existing, "binance: day complete, skipping");
-                current = current
-                    .checked_add_days(Days::new(1))
-                    .expect("date overflow");
-                continue;
+        while cursor_ms <= range_end_ms {
+            let page = self.fetch_page(cursor_ms, range_end_ms).await?;
+            if page.is_empty() {
+                break;
             }
 
-            let day_start_ms = current
-                .and_time(NaiveTime::MIN)
-                .and_utc()
-                .timestamp_millis();
-            let day_end_ms = day_start_ms + 86_400_000 - 1;
+            cursor_ms = page.last().expect("non-empty page").open_time_ms + 60_001;
 
-            let mut klines = Vec::new();
-            let mut page_start = day_start_ms;
-
-            while page_start <= day_end_ms {
-                let page = self.fetch_page(page_start, day_end_ms).await?;
-                if page.is_empty() {
-                    break;
-                }
-                page_start = page.last().expect("non-empty page").open_time_ms + 60_001;
-                klines.extend(page);
-            }
-
-            let candle_rows: Vec<CandleRow> = klines
+            let candle_rows: Vec<CandleRow> = page
                 .iter()
                 .map(|k| CandleRow {
                     ts: DateTime::from_timestamp_millis(k.open_time_ms)
@@ -130,14 +132,10 @@ impl HistoryFetcher for BinanceFetcher {
                 .collect();
 
             let count = store.insert_candles(&candle_rows).await.context(StoreSnafu)?;
-            info!(date = %current, candles = count, "binance: ingested day");
             total += usize::try_from(count).expect("candle count fits in usize");
-
-            current = current
-                .checked_add_days(Days::new(1))
-                .expect("date overflow");
         }
 
+        info!(total, "binance: fetch complete");
         Ok(total)
     }
 }

--- a/crates/rara-market-data/src/fetcher/yahoo.rs
+++ b/crates/rara-market-data/src/fetcher/yahoo.rs
@@ -3,6 +3,7 @@
 //! Uses the public chart API (no authentication required).
 //! Automatically selects 1m interval for recent data (<=7 days)
 //! or 1d interval for older history.
+//! Resumes from the latest stored candle via `MAX(ts)` query.
 
 use async_trait::async_trait;
 use chrono::{DateTime, Days, NaiveDate, NaiveTime, Utc};
@@ -116,8 +117,8 @@ impl HistoryFetcher for YahooFetcher {
         start: NaiveDate,
         end: NaiveDate,
     ) -> Result<usize> {
-        let period1 = start.and_time(NaiveTime::MIN).and_utc().timestamp();
-        let period2 = end
+        let range_start = start.and_time(NaiveTime::MIN).and_utc().timestamp();
+        let range_end = end
             .checked_add_days(Days::new(1))
             .expect("date overflow")
             .and_time(NaiveTime::MIN)
@@ -133,22 +134,21 @@ impl HistoryFetcher for YahooFetcher {
             "1d"
         };
 
-        // Skip if range already has expected candle count
-        let existing = store
-            .query_candles(instrument_id, interval, start, end)
+        // Resume from last stored candle + 1 interval
+        let interval_secs: i64 = if interval == "1m" { 60 } else { 86_400 };
+        let resume_ts = store
+            .max_ts(instrument_id, interval)
             .await
-            .context(StoreSnafu)?;
-        let expected = if interval == "1d" {
-            range_days
-        } else {
-            range_days * 1440
-        };
-        if i64::try_from(existing.len()).unwrap_or(i64::MAX) >= expected {
-            info!(existing = existing.len(), expected, "yahoo: range complete, skipping");
+            .context(StoreSnafu)?
+            .map_or(i64::MIN, |ts| ts.timestamp() + interval_secs);
+
+        let period1 = range_start.max(resume_ts);
+        if period1 >= range_end {
+            info!("yahoo: already up to date, nothing to fetch");
             return Ok(0);
         }
 
-        let mut candles = self.fetch_range(period1, period2, interval).await?;
+        let mut candles = self.fetch_range(period1, range_end, interval).await?;
 
         for c in &mut candles {
             c.instrument_id = instrument_id.to_string();

--- a/crates/rara-market-data/src/store/candle.rs
+++ b/crates/rara-market-data/src/store/candle.rs
@@ -145,28 +145,21 @@ impl MarketStore {
             .collect())
     }
 
-    /// Count candles for a specific instrument+interval on a single day.
-    pub async fn count_candles_for_day(
+    /// Get the latest stored candle timestamp for an instrument+interval.
+    ///
+    /// Returns `None` if no data exists. Used by fetchers to resume
+    /// from where the last fetch left off.
+    pub async fn max_ts(
         &self,
         instrument_id: &str,
         interval: &str,
-        day: NaiveDate,
-    ) -> Result<i64> {
-        let day_start = day.and_time(NaiveTime::MIN).and_utc();
-        let day_end = day
-            .succ_opt()
-            .unwrap_or(day)
-            .and_time(NaiveTime::MIN)
-            .and_utc();
-
-        let row = sqlx::query_scalar::<_, i64>(
-            "SELECT count(*) FROM candles
-             WHERE instrument_id = $1 AND interval = $2 AND ts >= $3 AND ts < $4",
+    ) -> Result<Option<DateTime<Utc>>> {
+        let row = sqlx::query_scalar::<_, Option<DateTime<Utc>>>(
+            "SELECT max(ts) FROM candles
+             WHERE instrument_id = $1 AND interval = $2",
         )
         .bind(instrument_id)
         .bind(interval)
-        .bind(day_start)
-        .bind(day_end)
         .fetch_one(&self.pool)
         .await
         .context(DatabaseSnafu)?;


### PR DESCRIPTION
Closes #56

## Summary
- Replace per-day `COUNT` checks with single `MAX(ts)` query (Freqtrade pattern)
- Binance fetcher: flat linear pagination from `max_ts` to end, no per-day loop
- Yahoo fetcher: adjust `period1` from `max_ts`, no `query_candles` full-load check
- Net -9 lines, simpler logic, 1 DB query instead of N

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] CI green