### PR TITLE
feat(observability): structured logging with tracing crate (#85)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,6 +1142,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,6 +1332,15 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -2863,6 +2881,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3220,6 +3244,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -3582,6 +3612,7 @@ dependencies = [
  "snafu",
  "tempfile",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3727,6 +3758,7 @@ dependencies = [
  "tokio",
  "toml 0.8.23",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "uuid",
 ]
@@ -5037,6 +5069,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5351,6 +5414,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ wasmtime-wasi = "41"
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "io-util", "time", "sync", "signal"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-appender = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 sled = "0.34"
 tempfile = "3"
 chrono = { version = "0.4", features = ["serde"] }
@@ -86,6 +87,7 @@ snafu.workspace = true
 tokio.workspace = true
 toml.workspace = true
 tracing.workspace = true
+tracing-appender.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
 

--- a/crates/rara-event-bus/Cargo.toml
+++ b/crates/rara-event-bus/Cargo.toml
@@ -11,6 +11,7 @@ sled.workspace = true
 serde_json.workspace = true
 snafu.workspace = true
 tokio.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/rara-event-bus/src/bus.rs
+++ b/crates/rara-event-bus/src/bus.rs
@@ -31,6 +31,7 @@ impl EventBus {
 
     /// Publish an event: persist it and broadcast the sequence number to
     /// online subscribers.
+    #[tracing::instrument(skip(self, event), fields(event_type = %event.event_type, event_id = %event.event_id))]
     pub fn publish(&self, event: &Event) -> Result<u64> {
         let seq = self.store.append(event)?;
         // Ignore send error — it just means no active subscribers

--- a/crates/rara-feedback/src/engine.rs
+++ b/crates/rara-feedback/src/engine.rs
@@ -77,6 +77,7 @@ impl FeedbackBridge {
     /// 3. Evaluate metrics + sentinel context → decision
     /// 4. Publish feedback event based on decision
     /// 5. Return the full strategy report
+    #[tracing::instrument(skip(self, sentinel_event_ids), fields(sentinel_count = sentinel_event_ids.len()))]
     pub fn evaluate_strategy(
         &self,
         strategy_id: &str,

--- a/crates/rara-market-data/src/store/candle.rs
+++ b/crates/rara-market-data/src/store/candle.rs
@@ -49,6 +49,7 @@ impl MarketStore {
     /// Batch insert candles with ON CONFLICT DO NOTHING for idempotency.
     ///
     /// Returns the number of rows actually inserted (excluding conflicts).
+    #[tracing::instrument(skip(self, candles), fields(candle_count = candles.len()))]
     pub async fn insert_candles(&self, candles: &[CandleRow]) -> Result<u64> {
         if candles.is_empty() {
             return Ok(0);
@@ -87,6 +88,7 @@ impl MarketStore {
     }
 
     /// Query candles for a given instrument and time range, ordered by time ascending.
+    #[tracing::instrument(skip(self))]
     pub async fn query_candles(
         &self,
         instrument_id: &str,

--- a/crates/rara-research/src/research_loop.rs
+++ b/crates/rara-research/src/research_loop.rs
@@ -150,6 +150,7 @@ impl ResearchLoop {
     /// Steps: generate hypothesis -> generate code -> compile ->
     /// load into runtime -> backtest -> generate feedback -> record in DAG ->
     /// publish events.
+    #[tracing::instrument(skip(self, context), fields(context_len = context.len()))]
     pub async fn run_iteration(&self, context: &str) -> Result<IterationResult> {
         // 1. Generate hypothesis
         let hypothesis = self
@@ -279,6 +280,7 @@ impl ResearchLoop {
     ///
     /// Only persists the strategy record and artifact after a successful compilation,
     /// avoiding orphaned records from failed attempts.
+    #[tracing::instrument(skip(self, code, hypothesis), fields(hypothesis_id = %hypothesis.id))]
     async fn compile_with_retries(
         &self,
         code: &mut String,

--- a/crates/rara-trading-engine/src/engine.rs
+++ b/crates/rara-trading-engine/src/engine.rs
@@ -97,6 +97,7 @@ impl TradingEngine {
     }
 
     /// Execute a trading commit: run guards, push to broker, publish events.
+    #[tracing::instrument(skip(self, commit), fields(strategy_id = %commit.strategy_id, actions = commit.actions.len()))]
     pub async fn execute_commit(&self, commit: TradingCommit) -> Result<Vec<OrderResult>> {
         // Run guard pipeline
         let account = self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,4 +13,5 @@ pub mod cli;
 pub mod daemon;
 pub mod error;
 pub mod http;
+pub mod logging;
 pub mod paths;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,151 @@
+//! Centralized structured logging initialization.
+//!
+//! Supports dual-output logging: pretty-printed to stderr for development,
+//! and JSON-formatted to a log file for production analysis.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Layer};
+
+/// Logging configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct LoggingConfig {
+    /// Default log level (trace, debug, info, warn, error).
+    pub level: String,
+    /// Path to log file directory. If set, JSON logs are written here.
+    pub log_dir: Option<String>,
+    /// Log format for stderr: "pretty" or "json".
+    pub stderr_format: String,
+}
+
+impl Default for LoggingConfig {
+    fn default() -> Self {
+        Self {
+            level: "info".to_string(),
+            log_dir: None,
+            stderr_format: "pretty".to_string(),
+        }
+    }
+}
+
+/// Initialize the global tracing subscriber based on the given configuration.
+///
+/// Returns a [`WorkerGuard`] when file logging is enabled. The caller **must**
+/// hold this guard for the lifetime of the program to ensure buffered log
+/// entries are flushed to disk on shutdown.
+///
+/// # Layers
+///
+/// - **stderr layer**: always active; uses pretty or JSON format based on
+///   `config.stderr_format`.
+/// - **file layer**: only active when `config.log_dir` is set; writes
+///   JSON-formatted logs via a non-blocking appender.
+///
+/// The log level is controlled by the `RUST_LOG` environment variable,
+/// falling back to `config.level` if `RUST_LOG` is not set.
+pub fn init_logging(config: &LoggingConfig) -> Option<WorkerGuard> {
+    let env_filter = build_env_filter(&config.level);
+
+    match (&config.log_dir, config.stderr_format.as_str()) {
+        // File logging enabled + pretty stderr
+        (Some(dir), "pretty") => {
+            let (file_layer, guard) = build_file_layer(dir);
+            tracing_subscriber::registry()
+                .with(env_filter)
+                .with(build_pretty_stderr_layer())
+                .with(file_layer)
+                .init();
+            Some(guard)
+        }
+        // File logging enabled + JSON stderr
+        (Some(dir), _) => {
+            let (file_layer, guard) = build_file_layer(dir);
+            tracing_subscriber::registry()
+                .with(env_filter)
+                .with(build_json_stderr_layer())
+                .with(file_layer)
+                .init();
+            Some(guard)
+        }
+        // No file logging + pretty stderr
+        (None, "pretty") => {
+            tracing_subscriber::registry()
+                .with(env_filter)
+                .with(build_pretty_stderr_layer())
+                .init();
+            None
+        }
+        // No file logging + JSON stderr
+        (None, _) => {
+            tracing_subscriber::registry()
+                .with(env_filter)
+                .with(build_json_stderr_layer())
+                .init();
+            None
+        }
+    }
+}
+
+/// Build an `EnvFilter` from `RUST_LOG`, falling back to the configured level.
+fn build_env_filter(default_level: &str) -> EnvFilter {
+    EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        EnvFilter::new(default_level)
+    })
+}
+
+/// Build a pretty-formatted stderr layer.
+fn build_pretty_stderr_layer<S>() -> impl Layer<S>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    tracing_subscriber::fmt::layer()
+        .with_writer(std::io::stderr)
+        .with_target(true)
+        .with_thread_ids(false)
+        .with_file(false)
+        .with_line_number(false)
+}
+
+/// Build a JSON-formatted stderr layer.
+fn build_json_stderr_layer<S>() -> impl Layer<S>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    tracing_subscriber::fmt::layer()
+        .json()
+        .with_writer(std::io::stderr)
+        .with_target(true)
+}
+
+/// Build a JSON-formatted file layer with non-blocking writes.
+///
+/// Creates the log directory if it does not exist. Log files are
+/// automatically rotated daily with the prefix `rara-trading`.
+fn build_file_layer<S>(
+    dir: &str,
+) -> (impl Layer<S>, WorkerGuard)
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    let path = Path::new(dir);
+    // Ensure the directory exists before the appender tries to write
+    if let Err(e) = std::fs::create_dir_all(path) {
+        eprintln!("warning: failed to create log directory {dir}: {e}");
+    }
+
+    let file_appender = tracing_appender::rolling::daily(path, "rara-trading.log");
+    let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+
+    let layer = tracing_subscriber::fmt::layer()
+        .json()
+        .with_writer(non_blocking)
+        .with_target(true)
+        .with_ansi(false);
+
+    (layer, guard)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use rara_trading::error::{
     IoSnafu, MarketStoreSnafu, PromoterSnafu, PromptRendererSnafu, TraceSnafu,
 };
 use rara_trading::event_bus::bus::EventBus;
+use rara_trading::logging::{self, LoggingConfig};
 use rara_trading::paths;
 use uuid::Uuid;
 
@@ -210,15 +211,12 @@ use rara_trading::research::wasm_strategy_manager::WasmStrategyManager;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::from_default_env()
-                .add_directive(tracing::Level::WARN.into()),
-        )
-        .init();
+    let logging_config = LoggingConfig::default();
+    // Hold the guard so file logs flush on shutdown
+    let _log_guard = logging::init_logging(&logging_config);
 
     if let Err(e) = run().await {
-        eprintln!("Error: {e}");
+        tracing::error!(error = %e, "application error");
         println!(
             "{}",
             serde_json::to_string(&ErrorResponse {
@@ -269,7 +267,7 @@ async fn run() -> error::Result<()> {
                 let mut cfg = app_config::load().clone();
                 set_config_field(&mut cfg, &key, &value)?;
                 app_config::save(&cfg).context(IoSnafu)?;
-                eprintln!("set {key} = {value}");
+                tracing::info!(key = %key, value = %value, "config updated");
                 println!(
                     "{}",
                     serde_json::to_string(&ConfigSetResponse {
@@ -316,7 +314,7 @@ async fn run() -> error::Result<()> {
         },
         Command::Hello { name } => {
             let greeting = format!("Hello, {name}!");
-            eprintln!("{greeting}");
+            tracing::info!(name = %name, "hello command executed");
             println!(
                 "{}",
                 serde_json::to_string(&HelloResponse {
@@ -630,7 +628,7 @@ async fn run_data_fetch(
         .await
         .context(DataFetchSnafu)?;
 
-    eprintln!("fetched {count} candles for {instrument_id} from {source}");
+    tracing::info!(count, instrument_id, source, "data fetch completed");
     println!(
         "{}",
         serde_json::to_string(&DataFetchResponse {
@@ -762,9 +760,7 @@ async fn run_research_loop(
     let mut error_count: u32 = 0;
 
     for i in 1..=iterations {
-        if !quiet {
-            eprintln!("[{i}/{iterations}] running...");
-        }
+        tracing::info!(iteration = i, total = iterations, "research iteration starting");
         let result = research_loop.run_iteration(contract).await;
         match result {
             Ok(ir) => {
@@ -774,8 +770,15 @@ async fn run_research_loop(
                     rejected_count += 1;
                 }
 
+                tracing::info!(
+                    iteration = i,
+                    total = iterations,
+                    accepted = ir.accepted,
+                    hypothesis = %ir.hypothesis.text,
+                    "research iteration completed"
+                );
+
                 if !quiet {
-                    // Truncate hypothesis to first 60 chars for readability
                     let hyp_summary: String = ir.hypothesis.text.chars().take(60).collect();
                     eprintln!("[{i}/{iterations}] Hypothesis: {hyp_summary}...");
 
@@ -805,6 +808,12 @@ async fn run_research_loop(
             }
             Err(e) => {
                 error_count += 1;
+                tracing::error!(
+                    iteration = i,
+                    total = iterations,
+                    error = %e,
+                    "research iteration failed"
+                );
                 if !quiet {
                     eprintln!("[{i}/{iterations}] ERROR: {e}");
                 }


### PR DESCRIPTION
Closes #85

## Summary
- Add centralized `logging` module with `LoggingConfig` supporting dual-output: pretty stderr for dev + JSON file logging via `tracing-appender` (non-blocking, daily rotation)
- Replace inline `tracing_subscriber::fmt().init()` in `main.rs` with `logging::init_logging()`
- Replace `eprintln!` calls with structured `tracing` macros (`tracing::info!`, `tracing::error!`) including structured fields
- Add `#[tracing::instrument]` to key functions: `run_iteration`, `compile_with_retries`, `execute_commit`, `evaluate_strategy`, `publish`, `insert_candles`, `query_candles`

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)