### PR TITLE
chore(config): startup validation + environment variable overrides (#73)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,6 +1544,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "envy"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3723,12 +3729,14 @@ dependencies = [
  "serde_json",
  "sled",
  "snafu",
+ "sqlx",
  "tempfile",
  "tokio",
  "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "which",
 ]
 
 [[package]]
@@ -6239,6 +6247,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix 1.1.4",
+ "winsafe",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6723,6 +6743,12 @@ checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "winx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,11 +83,13 @@ rust_decimal_macros = "1"
 serde.workspace = true
 serde_json.workspace = true
 snafu.workspace = true
+sqlx.workspace = true
 tokio.workspace = true
 toml.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
+which = "7"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -159,6 +159,7 @@ impl Default for ServerConfig {
 
 /// Load config from TOML file, falling back to defaults.
 ///
+/// Environment variables take priority over config file values.
 /// The result is cached in a `OnceLock` — subsequent calls return the same
 /// value even after [`save`]. This is fine for CLI usage (one command per
 /// process) but callers using this as a library should be aware of the
@@ -166,7 +167,7 @@ impl Default for ServerConfig {
 pub fn load() -> &'static AppConfig {
     APP_CONFIG.get_or_init(|| {
         let path = crate::paths::config_file();
-        if path.exists() {
+        let mut cfg: AppConfig = if path.exists() {
             let settings = config::Config::builder()
                 .add_source(config::File::from(path.as_ref()))
                 .build()
@@ -174,8 +175,32 @@ pub fn load() -> &'static AppConfig {
             settings.try_deserialize().unwrap_or_default()
         } else {
             AppConfig::default()
-        }
+        };
+        apply_env_overrides(&mut cfg);
+        cfg
     })
+}
+
+/// Apply environment variable overrides to the configuration.
+/// Environment variables take priority over config file values.
+fn apply_env_overrides(cfg: &mut AppConfig) {
+    if let Ok(val) = std::env::var("RARA_DB_URL") {
+        cfg.database.url = val;
+    }
+    if let Ok(val) = std::env::var("RARA_LLM_BACKEND") {
+        cfg.agent.backend = val;
+    }
+    if let Ok(val) = std::env::var("RARA_SERVER_ADDR") {
+        cfg.server.listen_addr = val;
+    }
+    if let Ok(val) = std::env::var("RARA_SERVER_PORT")
+        && let Ok(port) = val.parse()
+    {
+        cfg.server.port = port;
+    }
+    if let Ok(val) = std::env::var("RARA_BROKER") {
+        cfg.trading.broker = val;
+    }
 }
 
 /// Save config to TOML file.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -60,6 +60,9 @@ pub enum Command {
         #[arg(long, default_value = "0.0.0.0:50051")]
         grpc_addr: String,
     },
+
+    /// Validate configuration and check connectivity.
+    Validate,
 }
 
 /// Data management subcommands.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,3 +14,4 @@ pub mod daemon;
 pub mod error;
 pub mod http;
 pub mod paths;
+pub mod validation;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use snafu::ResultExt;
 use rara_trading::agent::{CliBackend, CliExecutor};
 use rara_trading::app_config;
 use rara_trading::cli::{Cli, Command, ConfigAction, DataAction, ResearchAction};
+use rara_trading::validation;
 use rara_trading::error::{
     self, AgentBackendSnafu, AgentExecutionSnafu, ConfigSnafu, DataFetchSnafu, EventBusSnafu,
     IoSnafu, MarketStoreSnafu, PromoterSnafu, PromptRendererSnafu, TraceSnafu,
@@ -56,6 +57,13 @@ struct ConfigInitResponse<'a> {
     ok: bool,
     action: &'static str,
     path: &'a str,
+}
+
+#[derive(Serialize)]
+struct ValidateResponse {
+    ok: bool,
+    action: &'static str,
+    errors: Vec<String>,
 }
 
 #[derive(Serialize)]
@@ -339,6 +347,37 @@ async fn run() -> error::Result<()> {
             grpc_addr,
         } => {
             rara_trading::daemon::run(contracts, iterations, grpc_addr).await?;
+        }
+        Command::Validate => {
+            let cfg = app_config::load();
+            let errors = validation::validate_startup(cfg).await;
+            let error_strings: Vec<String> = errors.iter().map(ToString::to_string).collect();
+            if errors.is_empty() {
+                eprintln!("All checks passed");
+                println!(
+                    "{}",
+                    serde_json::to_string(&ValidateResponse {
+                        ok: true,
+                        action: "validate",
+                        errors: vec![],
+                    })
+                    .expect("ValidateResponse must serialize")
+                );
+            } else {
+                for e in &errors {
+                    eprintln!("FAIL: {e}");
+                }
+                println!(
+                    "{}",
+                    serde_json::to_string(&ValidateResponse {
+                        ok: false,
+                        action: "validate",
+                        errors: error_strings,
+                    })
+                    .expect("ValidateResponse must serialize")
+                );
+                std::process::exit(1);
+            }
         }
         Command::Agent { prompt, backend } => {
             let cfg = app_config::load();

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,0 +1,70 @@
+//! Startup configuration validation.
+//!
+//! Checks database connectivity and LLM backend availability at startup,
+//! returning actionable error messages with fix suggestions.
+
+use snafu::{ResultExt, Snafu};
+
+/// Errors from startup validation.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum ValidationError {
+    /// Database connection failed.
+    #[snafu(display(
+        "database connection failed: {source}\n\n\
+         Fix: check that PostgreSQL/TimescaleDB is running and the URL is correct.\n  \
+         Current URL: {url}\n  \
+         Override with: RARA_DB_URL=postgres://user:pass@host:5432/db"
+    ))]
+    DatabaseConnection { url: String, source: sqlx::Error },
+
+    /// LLM backend not available in PATH.
+    #[snafu(display(
+        "LLM backend '{backend}' is not available\n\n\
+         Fix: ensure the agent backend is installed and accessible in PATH.\n  \
+         Override with: RARA_LLM_BACKEND=claude"
+    ))]
+    LlmBackendUnavailable { backend: String },
+}
+
+/// Result type for validation operations.
+pub type Result<T> = std::result::Result<T, ValidationError>;
+
+/// Validate database connectivity by attempting a short-lived connection.
+pub async fn validate_database(url: &str) -> Result<()> {
+    use sqlx::postgres::PgPoolOptions;
+
+    PgPoolOptions::new()
+        .max_connections(1)
+        .acquire_timeout(std::time::Duration::from_secs(5))
+        .connect(url)
+        .await
+        .context(DatabaseConnectionSnafu { url })?;
+
+    Ok(())
+}
+
+/// Validate LLM backend availability by checking whether the command exists in PATH.
+pub fn validate_llm_backend(backend: &str) -> Result<()> {
+    match which::which(backend) {
+        Ok(_) => Ok(()),
+        Err(_) => LlmBackendUnavailableSnafu { backend }.fail(),
+    }
+}
+
+/// Run all startup validations and collect errors.
+///
+/// Returns a list of validation errors. An empty list means all checks passed.
+pub async fn validate_startup(cfg: &crate::app_config::AppConfig) -> Vec<ValidationError> {
+    let mut errors = Vec::new();
+
+    if let Err(e) = validate_database(&cfg.database.url).await {
+        errors.push(e);
+    }
+
+    if let Err(e) = validate_llm_backend(&cfg.agent.backend) {
+        errors.push(e);
+    }
+
+    errors
+}


### PR DESCRIPTION
Closes #73

## Summary
- Add environment variable overrides (`RARA_DB_URL`, `RARA_LLM_BACKEND`, `RARA_SERVER_ADDR`, `RARA_SERVER_PORT`, `RARA_BROKER`) applied after TOML config loading, with env vars taking priority
- Add `src/validation.rs` module with DB connectivity check (5s timeout) and LLM backend PATH check via `which` crate
- Add `validate` CLI subcommand that runs all startup checks and reports actionable errors with fix suggestions

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test` passes