### PR TITLE
feat(market-data): Binance WebSocket connection + kline stream parsing (#74)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,6 +1718,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2782,6 +2797,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2895,10 +2927,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -3547,6 +3617,7 @@ dependencies = [
  "async-trait",
  "bon",
  "chrono",
+ "futures-util",
  "jiff",
  "reqwest 0.13.2",
  "rust_decimal",
@@ -3555,6 +3626,7 @@ dependencies = [
  "snafu",
  "sqlx",
  "tokio",
+ "tokio-tungstenite 0.26.2",
  "tracing",
 ]
 
@@ -5026,6 +5098,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5055,9 +5137,11 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "rustls",
  "rustls-pki-types",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tungstenite 0.26.2",
  "webpki-roots 0.26.11",
@@ -5348,6 +5432,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.9.2",
  "rustls",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ tempfile = "3"
 chrono = { version = "0.4", features = ["serde"] }
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres", "chrono", "migrate"] }
 reqwest = { version = "0.13", features = ["json", "stream"] }
+tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
+futures-util = "0.3"
 clap = { version = "4", features = ["derive"] }
 config = "0.15"
 toml = "0.8"

--- a/crates/rara-market-data/Cargo.toml
+++ b/crates/rara-market-data/Cargo.toml
@@ -18,6 +18,8 @@ chrono.workspace = true
 async-trait.workspace = true
 reqwest.workspace = true
 sqlx.workspace = true
+tokio-tungstenite.workspace = true
+futures-util.workspace = true
 
 [lints]
 workspace = true

--- a/crates/rara-market-data/src/lib.rs
+++ b/crates/rara-market-data/src/lib.rs
@@ -5,3 +5,4 @@
 
 pub mod fetcher;
 pub mod store;
+pub mod stream;

--- a/crates/rara-market-data/src/stream/binance_ws.rs
+++ b/crates/rara-market-data/src/stream/binance_ws.rs
@@ -1,0 +1,294 @@
+//! Binance WebSocket kline stream client.
+
+use std::pin::Pin;
+
+use futures_util::{Stream, StreamExt};
+use serde::{Deserialize, Serialize};
+use snafu::{ResultExt, Snafu};
+use tokio_tungstenite::tungstenite::Message;
+
+/// Errors from WebSocket streaming operations.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum WsError {
+    /// WebSocket connection failed.
+    #[snafu(display("WebSocket connection failed: {source}"))]
+    Connection {
+        /// The underlying tungstenite error (boxed to keep `WsError` small).
+        source: Box<tokio_tungstenite::tungstenite::Error>,
+    },
+
+    /// Failed to parse kline message.
+    #[snafu(display("failed to parse kline message: {source}"))]
+    Parse {
+        /// The underlying JSON parse error.
+        source: serde_json::Error,
+    },
+
+    /// WebSocket stream ended unexpectedly.
+    #[snafu(display("WebSocket stream ended unexpectedly"))]
+    StreamEnded,
+}
+
+/// Result type for WebSocket operations.
+pub type Result<T> = std::result::Result<T, WsError>;
+
+/// Raw kline data received from a Binance WebSocket stream.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RawKline {
+    /// Symbol (e.g., "BTCUSDT").
+    pub symbol: String,
+    /// Kline open time in milliseconds since epoch.
+    pub open_time: i64,
+    /// Kline close time in milliseconds since epoch.
+    pub close_time: i64,
+    /// Interval string (e.g., "1m", "1h").
+    pub interval: String,
+    /// Open price.
+    pub open: f64,
+    /// High price.
+    pub high: f64,
+    /// Low price.
+    pub low: f64,
+    /// Close price.
+    pub close: f64,
+    /// Base asset volume.
+    pub volume: f64,
+    /// Number of trades in this kline.
+    pub trade_count: i32,
+    /// Whether this kline is closed (final).
+    pub is_closed: bool,
+}
+
+/// Binance kline event wrapper matching the raw JSON structure.
+#[derive(Debug, Deserialize)]
+struct BinanceKlineEvent {
+    #[serde(rename = "s")]
+    symbol: String,
+    #[serde(rename = "k")]
+    kline: BinanceKlineData,
+}
+
+/// Inner kline data fields from the Binance stream.
+#[derive(Debug, Deserialize)]
+struct BinanceKlineData {
+    #[serde(rename = "t")]
+    open_time: i64,
+    #[serde(rename = "T")]
+    close_time: i64,
+    #[serde(rename = "i")]
+    interval: String,
+    #[serde(rename = "o")]
+    open: String,
+    #[serde(rename = "h")]
+    high: String,
+    #[serde(rename = "l")]
+    low: String,
+    #[serde(rename = "c")]
+    close: String,
+    #[serde(rename = "v")]
+    volume: String,
+    #[serde(rename = "n")]
+    trade_count: i32,
+    #[serde(rename = "x")]
+    is_closed: bool,
+}
+
+/// Combined stream wrapper used by Binance multi-symbol endpoints.
+#[derive(Debug, Deserialize)]
+struct CombinedStreamMessage {
+    data: BinanceKlineEvent,
+}
+
+/// Binance WebSocket client for subscribing to real-time kline streams.
+pub struct BinanceWsClient {
+    /// Base WebSocket URL (without path).
+    pub base_url: String,
+}
+
+impl Default for BinanceWsClient {
+    fn default() -> Self {
+        Self {
+            base_url: "wss://stream.binance.com:9443".to_string(),
+        }
+    }
+}
+
+impl BinanceWsClient {
+    /// Create a new client with the default Binance WebSocket URL.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a client with a custom WebSocket URL (useful for testing or proxies).
+    pub fn with_url(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into(),
+        }
+    }
+
+    /// Subscribe to a single symbol's kline stream.
+    ///
+    /// Returns a `Stream` that yields `RawKline` items as they arrive.
+    pub async fn subscribe_klines(
+        &self,
+        symbol: &str,
+        interval: &str,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<RawKline>> + Send>>> {
+        let symbol_lower = symbol.to_lowercase();
+        let url = format!("{}/ws/{}@kline_{}", self.base_url, symbol_lower, interval);
+
+        tracing::info!(%symbol, %interval, %url, "connecting to Binance kline stream");
+
+        let (ws_stream, _) = tokio_tungstenite::connect_async(&url)
+            .await
+            .map_err(|e| WsError::Connection { source: Box::new(e) })?;
+
+        tracing::info!(%symbol, %interval, "WebSocket connected");
+
+        let (_, read) = ws_stream.split();
+
+        let stream = read.filter_map(|msg| {
+            let result = match msg {
+                Ok(Message::Text(text)) => Some(parse_kline_message(&text)),
+                Ok(Message::Ping(_)) => {
+                    tracing::trace!("received ping");
+                    None
+                }
+                Ok(Message::Close(_)) => {
+                    tracing::warn!("WebSocket closed by server");
+                    Some(Err(WsError::StreamEnded))
+                }
+                Err(e) => Some(Err(WsError::Connection { source: Box::new(e) })),
+                _ => None,
+            };
+            std::future::ready(result)
+        });
+
+        Ok(Box::pin(stream))
+    }
+
+    /// Subscribe to multiple symbol kline streams via a combined connection.
+    ///
+    /// Each subscription is a `(symbol, interval)` pair. Binance multiplexes
+    /// all streams over a single WebSocket connection.
+    pub async fn subscribe_klines_multi(
+        &self,
+        subscriptions: &[(&str, &str)],
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<RawKline>> + Send>>> {
+        let streams_param = subscriptions
+            .iter()
+            .map(|(symbol, interval)| format!("{}@kline_{}", symbol.to_lowercase(), interval))
+            .collect::<Vec<_>>()
+            .join("/");
+
+        let url = format!("{}/stream?streams={}", self.base_url, streams_param);
+
+        tracing::info!(?subscriptions, %url, "connecting to combined kline stream");
+
+        let (ws_stream, _) = tokio_tungstenite::connect_async(&url)
+            .await
+            .map_err(|e| WsError::Connection { source: Box::new(e) })?;
+
+        tracing::info!("combined WebSocket connected");
+
+        let (_, read) = ws_stream.split();
+
+        // Combined stream wraps each event in {"stream":"...","data":{...}}
+        let stream = read.filter_map(|msg| {
+            let result = match msg {
+                Ok(Message::Text(text)) => Some(parse_combined_message(&text)),
+                Ok(Message::Close(_)) => {
+                    tracing::warn!("WebSocket closed by server");
+                    Some(Err(WsError::StreamEnded))
+                }
+                Err(e) => Some(Err(WsError::Connection { source: Box::new(e) })),
+                _ => None,
+            };
+            std::future::ready(result)
+        });
+
+        Ok(Box::pin(stream))
+    }
+}
+
+/// Parse a single-stream kline message from Binance.
+fn parse_kline_message(text: &str) -> Result<RawKline> {
+    let event: BinanceKlineEvent = serde_json::from_str(text).context(ParseSnafu)?;
+    Ok(kline_event_to_raw(event))
+}
+
+/// Parse a combined-stream kline message from Binance.
+fn parse_combined_message(text: &str) -> Result<RawKline> {
+    let msg: CombinedStreamMessage = serde_json::from_str(text).context(ParseSnafu)?;
+    Ok(kline_event_to_raw(msg.data))
+}
+
+/// Convert the Binance-specific event structure into our domain `RawKline`.
+///
+/// Binance sends numeric values as strings to preserve decimal precision;
+/// we parse them into `f64` here, defaulting to `0.0` on parse failure.
+fn kline_event_to_raw(event: BinanceKlineEvent) -> RawKline {
+    let k = event.kline;
+    RawKline {
+        symbol: event.symbol,
+        open_time: k.open_time,
+        close_time: k.close_time,
+        interval: k.interval,
+        open: k.open.parse().unwrap_or(0.0),
+        high: k.high.parse().unwrap_or(0.0),
+        low: k.low.parse().unwrap_or(0.0),
+        close: k.close.parse().unwrap_or(0.0),
+        volume: k.volume.parse().unwrap_or(0.0),
+        trade_count: k.trade_count,
+        is_closed: k.is_closed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_single_kline_extracts_all_fields() {
+        let json = r#"{"e":"kline","E":1234567890,"s":"BTCUSDT","k":{"t":1234567800000,"T":1234567859999,"i":"1m","o":"67500.00","h":"67550.00","l":"67480.00","c":"67520.00","v":"1.234","n":42,"x":true}}"#;
+        let kline = parse_kline_message(json).expect("should parse valid kline");
+
+        assert_eq!(kline.symbol, "BTCUSDT");
+        assert_eq!(kline.interval, "1m");
+        assert_eq!(kline.open_time, 1_234_567_800_000);
+        assert_eq!(kline.close_time, 1_234_567_859_999);
+        assert!((kline.open - 67_500.0).abs() < f64::EPSILON);
+        assert!((kline.high - 67_550.0).abs() < f64::EPSILON);
+        assert!((kline.low - 67_480.0).abs() < f64::EPSILON);
+        assert!((kline.close - 67_520.0).abs() < f64::EPSILON);
+        assert!((kline.volume - 1.234).abs() < f64::EPSILON);
+        assert_eq!(kline.trade_count, 42);
+        assert!(kline.is_closed);
+    }
+
+    #[test]
+    fn parse_combined_stream_unwraps_data_envelope() {
+        let json = r#"{"stream":"btcusdt@kline_1m","data":{"e":"kline","E":1234567890,"s":"BTCUSDT","k":{"t":1234567800000,"T":1234567859999,"i":"1m","o":"67500.00","h":"67550.00","l":"67480.00","c":"67520.00","v":"1.234","n":42,"x":false}}}"#;
+        let kline = parse_combined_message(json).expect("should parse combined message");
+
+        assert_eq!(kline.symbol, "BTCUSDT");
+        assert!(!kline.is_closed);
+    }
+
+    #[test]
+    fn parse_kline_invalid_json_returns_error() {
+        let result = parse_kline_message("not json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_kline_handles_zero_volume_and_trades() {
+        let json = r#"{"e":"kline","E":1,"s":"ETHUSDT","k":{"t":0,"T":0,"i":"5m","o":"0.0","h":"0.0","l":"0.0","c":"0.0","v":"0.0","n":0,"x":false}}"#;
+        let kline = parse_kline_message(json).expect("should parse zero-value kline");
+
+        assert_eq!(kline.symbol, "ETHUSDT");
+        assert_eq!(kline.trade_count, 0);
+        assert!((kline.volume).abs() < f64::EPSILON);
+    }
+}

--- a/crates/rara-market-data/src/stream/mod.rs
+++ b/crates/rara-market-data/src/stream/mod.rs
@@ -1,0 +1,5 @@
+//! Real-time market data streaming via WebSocket.
+
+pub mod binance_ws;
+
+pub use binance_ws::{BinanceWsClient, RawKline, WsError};


### PR DESCRIPTION
## Summary
- Add `tokio-tungstenite` and `futures-util` as workspace dependencies
- Implement `BinanceWsClient` with `subscribe_klines` (single symbol) and `subscribe_klines_multi` (combined stream) returning `Stream<Item = Result<RawKline>>`
- Parse Binance kline JSON events into typed `RawKline` struct with all fields (symbol, OHLCV, trade count, is_closed)
- Connection status logging via `tracing`

## Test plan
- [x] `cargo check -p rara-market-data` passes
- [x] `cargo test -p rara-market-data` — 4 tests pass (single kline parsing, combined stream parsing, invalid JSON error, zero-value edge case)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)