### PR TITLE
feat(tui): events tab — real-time stream + topic filter + search (#93)

### DIFF
--- a/crates/rara-tui/src/app.rs
+++ b/crates/rara-tui/src/app.rs
@@ -77,7 +77,76 @@ pub enum ConnectionStatus {
 }
 
 /// Tab identifiers for the main navigation.
-pub const TAB_NAMES: &[&str] = &["Overview", "Research", "Trading", "Strategies"];
+pub const TAB_NAMES: &[&str] = &["Overview", "Research", "Trading", "Strategies", "Events"];
+
+/// Index of the Events tab in `TAB_NAMES`.
+pub const EVENTS_TAB_INDEX: usize = 4;
+
+/// A single event entry in the events stream.
+#[derive(Debug, Clone)]
+pub struct EventEntry {
+    /// Monotonically increasing sequence number.
+    pub seq: u64,
+    /// Human-readable timestamp string.
+    pub time: String,
+    /// Event topic (trading, research, feedback, sentinel).
+    pub topic: String,
+    /// The type/kind of event within the topic.
+    pub event_type: String,
+    /// One-line summary of the event.
+    pub summary: String,
+    /// Optional strategy identifier associated with this event.
+    pub strategy_id: Option<String>,
+    /// Full event payload, typically JSON.
+    pub payload: String,
+}
+
+/// Topic-level filter for the events stream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EventFilter {
+    /// Show all events regardless of topic.
+    All,
+    /// Show only trading events.
+    Trading,
+    /// Show only research events.
+    Research,
+    /// Show only feedback events.
+    Feedback,
+    /// Show only sentinel events.
+    Sentinel,
+}
+
+/// State for the Events tab.
+pub struct EventsState {
+    /// All received events (unfiltered buffer).
+    pub events: Vec<EventEntry>,
+    /// Current topic filter.
+    pub filter: EventFilter,
+    /// Whether auto-scroll is enabled (newest events stay visible).
+    pub auto_scroll: bool,
+    /// Currently selected row index within the filtered view.
+    pub selected_index: usize,
+    /// Current search query text.
+    pub search_query: String,
+    /// Whether the search input is actively accepting keystrokes.
+    pub search_active: bool,
+    /// Whether the detail pane is expanded.
+    pub detail_expanded: bool,
+}
+
+impl Default for EventsState {
+    fn default() -> Self {
+        Self {
+            events: Vec::new(),
+            filter: EventFilter::All,
+            auto_scroll: true,
+            selected_index: 0,
+            search_query: String::new(),
+            search_active: false,
+            detail_expanded: false,
+        }
+    }
+}
 
 /// Index of the Research tab.
 pub const TAB_RESEARCH: usize = 1;
@@ -106,12 +175,14 @@ pub struct App {
     pub research_progress: Option<ResearchProgress>,
     /// State for the Research tab.
     pub research: ResearchState,
+    /// State for the Events tab.
+    pub events_state: EventsState,
 }
 
 impl App {
     /// Create a new app instance targeting the given gRPC server address.
     #[must_use]
-    pub const fn new(server_addr: String) -> Self {
+    pub fn new(server_addr: String) -> Self {
         Self {
             active_tab: 0,
             running: true,
@@ -124,6 +195,7 @@ impl App {
             alerts: Vec::new(),
             research_progress: None,
             research: ResearchState::empty(),
+            events_state: EventsState::default(),
         }
     }
 

--- a/crates/rara-tui/src/event_loop.rs
+++ b/crates/rara-tui/src/event_loop.rs
@@ -20,8 +20,9 @@ use tracing::{info, warn};
 use rara_server::rara_proto::rara_service_client::RaraServiceClient;
 use rara_server::rara_proto::Empty;
 
-use crate::app::{App, ConnectionStatus, TAB_RESEARCH};
+use crate::app::{App, ConnectionStatus, EventFilter, EVENTS_TAB_INDEX, TAB_RESEARCH};
 use crate::error::{IoSnafu, Result};
+use crate::tabs;
 use crate::ui;
 
 /// Duration between status poll ticks.
@@ -91,8 +92,8 @@ async fn event_loop(
     Ok(())
 }
 
-/// Handle a key press event, dispatching tab-specific keys as needed.
-const fn handle_key(app: &mut App, key: KeyCode) {
+/// Handle a key press event, dispatching to tab-specific handlers when needed.
+fn handle_key(app: &mut App, key: KeyCode) {
     // Research tab DAG popup intercepts Esc to close instead of quitting
     if app.active_tab == TAB_RESEARCH && app.research.show_dag {
         match key {
@@ -103,23 +104,119 @@ const fn handle_key(app: &mut App, key: KeyCode) {
         return;
     }
 
+    // When search is active on the events tab, capture all input for search
+    if app.active_tab == EVENTS_TAB_INDEX && app.events_state.search_active {
+        handle_events_search_key(app, key);
+        return;
+    }
+
     match key {
         KeyCode::Char('q') | KeyCode::Esc => app.quit(),
         KeyCode::Char('1') => app.select_tab(0),
         KeyCode::Char('2') => app.select_tab(1),
         KeyCode::Char('3') => app.select_tab(2),
         KeyCode::Char('4') => app.select_tab(3),
+        KeyCode::Char('5') => app.select_tab(4),
+        _ if app.active_tab == EVENTS_TAB_INDEX => handle_events_key(app, key),
+        _ if app.active_tab == TAB_RESEARCH => handle_research_key(app, key),
         _ => {}
     }
+}
 
-    // Tab-specific keys
-    if app.active_tab == TAB_RESEARCH {
-        match key {
-            KeyCode::Char('j') | KeyCode::Down => app.research.select_next(),
-            KeyCode::Char('k') | KeyCode::Up => app.research.select_prev(),
-            KeyCode::Char('p') => app.research.toggle_dag(),
-            _ => {}
+/// Handle key presses specific to the Events tab (non-search mode).
+fn handle_events_key(app: &mut App, key: KeyCode) {
+    let state = &mut app.events_state;
+    match key {
+        // Topic filters
+        KeyCode::Char('a') => {
+            state.filter = EventFilter::All;
+            state.selected_index = 0;
         }
+        KeyCode::Char('t') => {
+            state.filter = EventFilter::Trading;
+            state.selected_index = 0;
+        }
+        KeyCode::Char('r') => {
+            state.filter = EventFilter::Research;
+            state.selected_index = 0;
+        }
+        KeyCode::Char('f') => {
+            state.filter = EventFilter::Feedback;
+            state.selected_index = 0;
+        }
+        KeyCode::Char('s') => {
+            state.filter = EventFilter::Sentinel;
+            state.selected_index = 0;
+        }
+        // Pause/resume auto-scroll
+        KeyCode::Char(' ') => {
+            state.auto_scroll = !state.auto_scroll;
+        }
+        // Navigation (when paused)
+        KeyCode::Char('j') | KeyCode::Down => {
+            state.auto_scroll = false;
+            let count = tabs::events::filtered_count(state);
+            if count > 0 && state.selected_index < count - 1 {
+                state.selected_index += 1;
+            }
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            state.auto_scroll = false;
+            if state.selected_index > 0 {
+                state.selected_index -= 1;
+            }
+        }
+        // Jump to latest
+        KeyCode::Char('G') => {
+            let count = tabs::events::filtered_count(state);
+            if count > 0 {
+                state.selected_index = count - 1;
+            }
+            state.auto_scroll = true;
+        }
+        // Enter search mode
+        KeyCode::Char('/') => {
+            state.search_active = true;
+            state.search_query.clear();
+        }
+        // Toggle detail pane
+        KeyCode::Enter => {
+            state.detail_expanded = !state.detail_expanded;
+        }
+        _ => {}
+    }
+}
+
+/// Handle key presses while search input is active on the Events tab.
+fn handle_events_search_key(app: &mut App, key: KeyCode) {
+    let state = &mut app.events_state;
+    match key {
+        KeyCode::Esc => {
+            state.search_active = false;
+            state.search_query.clear();
+            state.selected_index = 0;
+        }
+        KeyCode::Enter => {
+            state.search_active = false;
+            state.selected_index = 0;
+        }
+        KeyCode::Backspace => {
+            state.search_query.pop();
+        }
+        KeyCode::Char(c) => {
+            state.search_query.push(c);
+        }
+        _ => {}
+    }
+}
+
+/// Handle key presses specific to the Research tab.
+fn handle_research_key(app: &mut App, key: KeyCode) {
+    match key {
+        KeyCode::Char('j') | KeyCode::Down => app.research.select_next(),
+        KeyCode::Char('k') | KeyCode::Up => app.research.select_prev(),
+        KeyCode::Char('p') => app.research.toggle_dag(),
+        _ => {}
     }
 }
 

--- a/crates/rara-tui/src/tabs/events.rs
+++ b/crates/rara-tui/src/tabs/events.rs
@@ -1,0 +1,207 @@
+//! Events tab — real-time event stream with topic filtering and search.
+//!
+//! Displays system events in a `tail -f` style view with topic-based color
+//! coding, pause/resume auto-scroll, keyboard navigation, and text search.
+
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, Wrap};
+use ratatui::Frame;
+
+use crate::app::{EventFilter, EventsState};
+use crate::theme;
+
+/// Map a topic string to its display color.
+fn topic_color(topic: &str) -> ratatui::style::Color {
+    match topic.to_lowercase().as_str() {
+        "trading" => theme::PINE,
+        "research" => theme::IRIS,
+        "feedback" => theme::FOAM,
+        "sentinel" => theme::GOLD,
+        _ => theme::TEXT,
+    }
+}
+
+/// Render the filter bar at the top of the events tab.
+fn render_filter_bar(frame: &mut Frame, state: &EventsState, area: Rect) {
+    let filters = [
+        ("a", "All", EventFilter::All),
+        ("t", "Trading", EventFilter::Trading),
+        ("r", "Research", EventFilter::Research),
+        ("f", "Feedback", EventFilter::Feedback),
+        ("s", "Sentinel", EventFilter::Sentinel),
+    ];
+
+    let mut spans = vec![Span::styled(" Filter: ", theme::muted())];
+
+    for (key, label, variant) in &filters {
+        let is_active = std::mem::discriminant(&state.filter) == std::mem::discriminant(variant);
+        let style = if is_active {
+            theme::emphasis().add_modifier(Modifier::REVERSED)
+        } else {
+            theme::muted()
+        };
+        spans.push(Span::styled(format!("[{key}]"), theme::info()));
+        spans.push(Span::styled(format!("{label} "), style));
+    }
+
+    // Show search query if active
+    if state.search_active {
+        spans.push(Span::styled(" │ ", theme::muted()));
+        spans.push(Span::styled("/", theme::warning()));
+        spans.push(Span::styled(&state.search_query, theme::text()));
+        spans.push(Span::styled("_", theme::warning()));
+    } else if !state.search_query.is_empty() {
+        spans.push(Span::styled(" │ ", theme::muted()));
+        spans.push(Span::styled(
+            format!("search: {}", state.search_query),
+            theme::muted(),
+        ));
+    }
+
+    let bar = Paragraph::new(Line::from(spans)).style(Style::default().bg(theme::SURFACE));
+    frame.render_widget(bar, area);
+}
+
+/// Render the event list table.
+fn render_event_list(frame: &mut Frame, state: &EventsState, area: Rect) {
+    let filtered = filtered_events(state);
+
+    let header = Row::new(vec![
+        Cell::from("Seq").style(theme::muted()),
+        Cell::from("Time").style(theme::muted()),
+        Cell::from("Topic").style(theme::muted()),
+        Cell::from("Type").style(theme::muted()),
+        Cell::from("Summary").style(theme::muted()),
+    ])
+    .height(1);
+
+    let rows: Vec<Row> = filtered
+        .iter()
+        .enumerate()
+        .map(|(i, entry)| {
+            let color = topic_color(&entry.topic);
+            let row_style = if i == state.selected_index {
+                Style::default().fg(color).add_modifier(Modifier::REVERSED)
+            } else {
+                Style::default().fg(color)
+            };
+            Row::new(vec![
+                Cell::from(entry.seq.to_string()),
+                Cell::from(entry.time.as_str()),
+                Cell::from(entry.topic.as_str()),
+                Cell::from(entry.event_type.as_str()),
+                Cell::from(entry.summary.as_str()),
+            ])
+            .style(row_style)
+        })
+        .collect();
+
+    let paused_title = if state.auto_scroll {
+        " Events "
+    } else {
+        " Events ─ ─ ─ PAUSED ─ ─ ─ "
+    };
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(6),
+            Constraint::Length(12),
+            Constraint::Length(10),
+            Constraint::Length(14),
+            Constraint::Min(20),
+        ],
+    )
+    .header(header)
+    .block(
+        Block::default()
+            .title(paused_title)
+            .borders(Borders::ALL)
+            .border_style(theme::muted()),
+    );
+
+    frame.render_widget(table, area);
+}
+
+/// Render the detail pane showing the selected event's payload.
+fn render_detail_pane(frame: &mut Frame, state: &EventsState, area: Rect) {
+    let filtered = filtered_events(state);
+    let detail_text = filtered.get(state.selected_index).map_or_else(
+        || "No event selected".to_string(),
+        |entry| {
+            use std::fmt::Write;
+            let mut text = format!(
+                "Seq: {}  Time: {}  Topic: {}  Type: {}\n",
+                entry.seq, entry.time, entry.topic, entry.event_type
+            );
+            if let Some(sid) = &entry.strategy_id {
+                let _ = writeln!(text, "Strategy: {sid}");
+            }
+            let _ = write!(text, "\n{}", entry.payload);
+            text
+        },
+    );
+
+    let detail = Paragraph::new(detail_text)
+        .wrap(Wrap { trim: false })
+        .style(theme::text())
+        .block(
+            Block::default()
+                .title(" Detail ")
+                .borders(Borders::ALL)
+                .border_style(theme::muted()),
+        );
+
+    frame.render_widget(detail, area);
+}
+
+/// Return events filtered by current topic filter and search query.
+fn filtered_events(state: &EventsState) -> Vec<&crate::app::EventEntry> {
+    state
+        .events
+        .iter()
+        .filter(|e| match state.filter {
+            EventFilter::All => true,
+            EventFilter::Trading => e.topic.eq_ignore_ascii_case("trading"),
+            EventFilter::Research => e.topic.eq_ignore_ascii_case("research"),
+            EventFilter::Feedback => e.topic.eq_ignore_ascii_case("feedback"),
+            EventFilter::Sentinel => e.topic.eq_ignore_ascii_case("sentinel"),
+        })
+        .filter(|e| {
+            if state.search_query.is_empty() {
+                return true;
+            }
+            let q = state.search_query.to_lowercase();
+            e.summary.to_lowercase().contains(&q)
+                || e.topic.to_lowercase().contains(&q)
+                || e.event_type.to_lowercase().contains(&q)
+                || e.payload.to_lowercase().contains(&q)
+        })
+        .collect()
+}
+
+/// Render the full events tab into the given area.
+pub fn render(frame: &mut Frame, state: &EventsState, area: Rect) {
+    let detail_height = if state.detail_expanded { 10 } else { 0 };
+
+    let chunks = Layout::vertical([
+        Constraint::Length(1),                    // filter bar
+        Constraint::Min(5),                       // event list
+        Constraint::Length(detail_height),         // detail pane
+    ])
+    .split(area);
+
+    render_filter_bar(frame, state, chunks[0]);
+    render_event_list(frame, state, chunks[1]);
+
+    if state.detail_expanded {
+        render_detail_pane(frame, state, chunks[2]);
+    }
+}
+
+/// Count of events matching current filters (used for navigation bounds).
+pub fn filtered_count(state: &EventsState) -> usize {
+    filtered_events(state).len()
+}

--- a/crates/rara-tui/src/tabs/mod.rs
+++ b/crates/rara-tui/src/tabs/mod.rs
@@ -1,4 +1,5 @@
 //! Tab rendering modules for the TUI dashboard.
 
+pub mod events;
 pub mod overview;
 pub mod research;

--- a/crates/rara-tui/src/ui.rs
+++ b/crates/rara-tui/src/ui.rs
@@ -20,7 +20,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Tabs};
 use ratatui::Frame;
 
-use crate::app::{App, ConnectionStatus, TAB_NAMES, TAB_RESEARCH};
+use crate::app::{App, ConnectionStatus, EVENTS_TAB_INDEX, TAB_NAMES, TAB_RESEARCH};
 use crate::tabs;
 use crate::tabs::research;
 use crate::theme;
@@ -124,7 +124,7 @@ fn render_tab_bar(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
     frame.render_widget(tabs, area);
 }
 
-/// Render the main content area — dispatches to tab-specific renderers.
+/// Render the main content area, dispatching to tab-specific renderers.
 fn render_content(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
     // Show connection overlay when not connected, regardless of tab
     match &app.connection_status {
@@ -165,6 +165,8 @@ fn render_content(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         tabs::overview::render(frame, app, area);
     } else if app.active_tab == TAB_RESEARCH {
         research::render(frame, &app.research, area);
+    } else if app.active_tab == EVENTS_TAB_INDEX {
+        tabs::events::render(frame, &app.events_state, area);
     } else {
         let tab_name = TAB_NAMES
             .get(app.active_tab)
@@ -191,9 +193,17 @@ fn render_footer(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
             format!("Connection lost. Reconnecting... (attempt {retry_count})  │  q:Quit")
         }
         _ if app.active_tab == TAB_RESEARCH => {
-            "q:Quit  1-4:Tab  j/k:Navigate  p:DAG  ?:Help".to_string()
+            "q:Quit  1-5:Tab  j/k:Navigate  p:DAG  ?:Help".to_string()
         }
-        _ => "q:Quit  1-4:Tab  ?:Help".to_string(),
+        _ if app.active_tab == EVENTS_TAB_INDEX => {
+            if app.events_state.search_active {
+                "Esc:Cancel  Enter:Confirm search".to_string()
+            } else {
+                "q:Quit  1-5:Tab  Space:Pause  j/k:Nav  /:Search  G:Latest  Enter:Detail"
+                    .to_string()
+            }
+        }
+        _ => "q:Quit  1-5:Tab  ?:Help".to_string(),
     };
 
     let footer = Paragraph::new(footer_text).style(theme::footer());


### PR DESCRIPTION
Closes #93

## Summary
- Add Events tab (index 5) with real-time event stream display
- Topic filter bar with `a/t/r/f/s` keys for All/Trading/Research/Feedback/Sentinel
- Event list table with topic-colored rows (PINE/IRIS/FOAM/GOLD from Rose Pine theme)
- Detail pane toggled with Enter showing full event payload
- Auto-scroll with Space pause/resume, `j/k` navigation, `G` jump to latest
- `/` search mode filtering events by summary, topic, type, or payload text