### PR TITLE
feat(research): integrate rara-strategies registry — fetch WASM from GitHub Releases (#122)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4042,6 +4042,7 @@ dependencies = [
  "rara-infra",
  "rara-market-data",
  "rara-strategy-api",
+ "reqwest 0.13.2",
  "rust_decimal",
  "rust_decimal_macros",
  "serde",

--- a/crates/rara-research/Cargo.toml
+++ b/crates/rara-research/Cargo.toml
@@ -33,6 +33,7 @@ smol_str = "0.3"
 wasmtime.workspace = true
 wasmtime-wasi.workspace = true
 rara-strategy-api.workspace = true
+reqwest.workspace = true
 
 [dev-dependencies]
 rara-agent.workspace = true

--- a/crates/rara-research/src/lib.rs
+++ b/crates/rara-research/src/lib.rs
@@ -18,3 +18,4 @@ pub mod wasm_strategy_manager;
 pub mod trace;
 pub mod wasm_executor;
 pub mod barter_strategy;
+pub mod strategy_registry;

--- a/crates/rara-research/src/strategy_registry.rs
+++ b/crates/rara-research/src/strategy_registry.rs
@@ -1,0 +1,342 @@
+//! Strategy registry — fetch pre-built WASM strategies from GitHub Releases.
+//!
+//! Connects to the `rararulab/rara-strategies` GitHub repository, lists
+//! available releases, downloads WASM artifacts, validates API version
+//! compatibility, and saves them to the promoted strategies directory.
+
+use std::path::PathBuf;
+
+use bon::Builder;
+use serde::{Deserialize, Serialize};
+use snafu::{ResultExt, Snafu};
+use tracing::{debug, info};
+
+use rara_strategy_api::API_VERSION;
+
+use crate::strategy_executor::StrategyExecutor;
+use crate::wasm_executor::WasmExecutor;
+
+/// Errors from strategy registry operations.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum RegistryError {
+    /// HTTP request to GitHub API failed.
+    #[snafu(display("GitHub API request failed: {source}"))]
+    Http {
+        /// The underlying reqwest error.
+        source: reqwest::Error,
+    },
+
+    /// GitHub API returned a non-success status.
+    #[snafu(display("GitHub API error {status}: {body}"))]
+    GitHubApi {
+        /// HTTP status code.
+        status: u16,
+        /// Response body.
+        body: String,
+    },
+
+    /// No WASM asset found in the release.
+    #[snafu(display("no .wasm asset found in release {tag}"))]
+    NoWasmAsset {
+        /// The release tag name.
+        tag: String,
+    },
+
+    /// WASM module API version is incompatible.
+    #[snafu(display(
+        "API version mismatch: strategy requires v{strategy_version}, runtime supports v{runtime_version}"
+    ))]
+    ApiVersionMismatch {
+        /// The strategy's API version.
+        strategy_version: u32,
+        /// The runtime's supported API version.
+        runtime_version: u32,
+    },
+
+    /// WASM runtime validation failed.
+    #[snafu(display("WASM validation failed: {source}"))]
+    WasmValidation {
+        /// The underlying executor error.
+        source: crate::strategy_executor::ExecutorError,
+    },
+
+    /// Filesystem I/O failed.
+    #[snafu(display("I/O error: {source}"))]
+    Io {
+        /// The underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// JSON serialization/deserialization failed.
+    #[snafu(display("JSON error: {source}"))]
+    Json {
+        /// The underlying serde error.
+        source: serde_json::Error,
+    },
+}
+
+/// Module-level result alias.
+pub type Result<T> = std::result::Result<T, RegistryError>;
+
+/// A release entry from the GitHub strategy registry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegistryEntry {
+    /// Release tag name (e.g. "btc-momentum-v0.1.0").
+    pub tag: String,
+    /// Strategy name derived from the tag.
+    pub name: String,
+    /// Version string derived from the tag.
+    pub version: String,
+    /// WASM asset download URL.
+    pub wasm_url: String,
+    /// WASM asset filename.
+    pub wasm_filename: String,
+    /// Asset size in bytes.
+    pub size: u64,
+}
+
+/// Metadata saved alongside a fetched registry strategy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FetchedStrategy {
+    /// Original registry entry.
+    pub entry: RegistryEntry,
+    /// Strategy metadata extracted from the WASM module.
+    pub meta: rara_strategy_api::StrategyMeta,
+    /// Local filesystem path to the saved WASM binary.
+    pub wasm_path: PathBuf,
+}
+
+/// GitHub Release asset from the API response.
+#[derive(Debug, Deserialize)]
+struct GitHubAsset {
+    name: String,
+    size: u64,
+    browser_download_url: String,
+}
+
+/// GitHub Release from the API response.
+#[derive(Debug, Deserialize)]
+struct GitHubRelease {
+    tag_name: String,
+    assets: Vec<GitHubAsset>,
+}
+
+/// Client for the rara-strategies GitHub Release registry.
+#[derive(Debug, Builder)]
+pub struct StrategyRegistry {
+    /// GitHub repository in "owner/repo" format.
+    #[builder(default = "rararulab/rara-strategies".to_string())]
+    repo: String,
+
+    /// Directory to save fetched WASM artifacts.
+    promoted_dir: PathBuf,
+}
+
+impl StrategyRegistry {
+    /// List all available strategies from the GitHub registry.
+    pub async fn list_available(&self) -> Result<Vec<RegistryEntry>> {
+        let url = format!(
+            "https://api.github.com/repos/{}/releases",
+            self.repo
+        );
+
+        let client = reqwest::Client::new();
+        let response = client
+            .get(&url)
+            .header("User-Agent", "rara-trading")
+            .header("Accept", "application/vnd.github+json")
+            .send()
+            .await
+            .context(HttpSnafu)?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(RegistryError::GitHubApi {
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        let releases: Vec<GitHubRelease> = response.json().await.context(HttpSnafu)?;
+
+        let entries = releases
+            .into_iter()
+            .filter_map(|release| {
+                let wasm_asset = release
+                    .assets
+                    .into_iter()
+                    .find(|a| {
+                        std::path::Path::new(&a.name)
+                            .extension()
+                            .is_some_and(|ext| ext.eq_ignore_ascii_case("wasm"))
+                    })?;
+
+                let (name, version) = parse_tag(&release.tag_name)?;
+
+                Some(RegistryEntry {
+                    tag: release.tag_name,
+                    name,
+                    version,
+                    wasm_url: wasm_asset.browser_download_url,
+                    wasm_filename: wasm_asset.name,
+                    size: wasm_asset.size,
+                })
+            })
+            .collect();
+
+        Ok(entries)
+    }
+
+    /// Fetch a strategy by name, validate it, and save to the promoted directory.
+    pub async fn fetch(&self, strategy_name: &str) -> Result<FetchedStrategy> {
+        let entries = self.list_available().await?;
+
+        let entry = entries
+            .into_iter()
+            .find(|e| e.name == strategy_name)
+            .ok_or_else(|| RegistryError::NoWasmAsset {
+                tag: strategy_name.to_string(),
+            })?;
+
+        self.fetch_entry(&entry).await
+    }
+
+    /// Fetch a specific registry entry, validate, and save.
+    async fn fetch_entry(&self, entry: &RegistryEntry) -> Result<FetchedStrategy> {
+        info!(strategy = %entry.name, version = %entry.version, "fetching strategy from registry");
+
+        // Download the WASM binary
+        let client = reqwest::Client::new();
+        let wasm_bytes = client
+            .get(&entry.wasm_url)
+            .header("User-Agent", "rara-trading")
+            .send()
+            .await
+            .context(HttpSnafu)?
+            .bytes()
+            .await
+            .context(HttpSnafu)?;
+
+        debug!(
+            strategy = %entry.name,
+            size = wasm_bytes.len(),
+            "downloaded WASM artifact"
+        );
+
+        // Validate: load into WASM runtime and extract metadata
+        let executor = WasmExecutor::builder().build();
+        let mut handle = executor.load(&wasm_bytes).context(WasmValidationSnafu)?;
+        let meta = handle.meta().context(WasmValidationSnafu)?;
+
+        // Check API version compatibility
+        if meta.api_version != API_VERSION {
+            return Err(RegistryError::ApiVersionMismatch {
+                strategy_version: meta.api_version,
+                runtime_version: API_VERSION,
+            });
+        }
+
+        info!(
+            strategy = %meta.name,
+            version = meta.version,
+            api_version = meta.api_version,
+            "WASM validation passed"
+        );
+
+        // Save to promoted directory
+        std::fs::create_dir_all(&self.promoted_dir).context(IoSnafu)?;
+
+        let wasm_path = self
+            .promoted_dir
+            .join(format!("{}.wasm", entry.name));
+        std::fs::write(&wasm_path, &wasm_bytes).context(IoSnafu)?;
+
+        // Save metadata JSON alongside the WASM file
+        let meta_path = self
+            .promoted_dir
+            .join(format!("{}.registry.json", entry.name));
+        let fetched = FetchedStrategy {
+            entry: entry.clone(),
+            meta,
+            wasm_path: wasm_path.clone(),
+        };
+        let json = serde_json::to_string_pretty(&fetched).context(JsonSnafu)?;
+        std::fs::write(&meta_path, json).context(IoSnafu)?;
+
+        info!(
+            strategy = %entry.name,
+            path = %wasm_path.display(),
+            "strategy saved to promoted directory"
+        );
+
+        Ok(fetched)
+    }
+
+    /// List strategies that have been fetched from the registry and saved locally.
+    pub fn list_installed(&self) -> Result<Vec<FetchedStrategy>> {
+        if !self.promoted_dir.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut installed = Vec::new();
+        let entries = std::fs::read_dir(&self.promoted_dir).context(IoSnafu)?;
+
+        for entry in entries {
+            let entry = entry.context(IoSnafu)?;
+            let path = entry.path();
+            if path.extension().is_some_and(|ext| ext == "json")
+                && path
+                    .file_name()
+                    .is_some_and(|n| n.to_string_lossy().ends_with(".registry.json"))
+            {
+                let content = std::fs::read_to_string(&path).context(IoSnafu)?;
+                let strategy: FetchedStrategy =
+                    serde_json::from_str(&content).context(JsonSnafu)?;
+                installed.push(strategy);
+            }
+        }
+
+        Ok(installed)
+    }
+}
+
+/// Parse a release tag like "btc-momentum-v0.1.0" into (name, version).
+///
+/// Expects the pattern `{name}-v{semver}` where version starts with a digit
+/// after the `v`.
+fn parse_tag(tag: &str) -> Option<(String, String)> {
+    let idx = tag.rfind("-v")?;
+    let version = &tag[idx + 1..]; // includes the "v"
+    // Ensure there's a digit after "v" (not just any word starting with v)
+    if version.len() < 2 || !version.as_bytes()[1].is_ascii_digit() {
+        return None;
+    }
+    let name = &tag[..idx];
+    Some((name.to_string(), version.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_tag_extracts_name_and_version() {
+        let (name, version) = parse_tag("btc-momentum-v0.1.0").unwrap();
+        assert_eq!(name, "btc-momentum");
+        assert_eq!(version, "v0.1.0");
+    }
+
+    #[test]
+    fn parse_tag_handles_complex_names() {
+        let (name, version) = parse_tag("hmm-regime-v0.1.0").unwrap();
+        assert_eq!(name, "hmm-regime");
+        assert_eq!(version, "v0.1.0");
+    }
+
+    #[test]
+    fn parse_tag_returns_none_for_invalid() {
+        assert!(parse_tag("no-version-here").is_none());
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -90,6 +90,12 @@ pub enum Command {
         #[command(subcommand)]
         action: PaperAction,
     },
+
+    /// Manage strategies from the rara-strategies registry.
+    Strategy {
+        #[command(subcommand)]
+        action: StrategyAction,
+    },
 }
 
 /// Feedback loop subcommands.
@@ -193,6 +199,29 @@ pub enum ResearchAction {
         #[arg(long)]
         promoted_dir: Option<String>,
     },
+}
+
+/// Strategy registry subcommands.
+#[derive(Subcommand, Debug)]
+pub enum StrategyAction {
+    /// List available strategies from the rara-strategies GitHub registry.
+    List {
+        /// GitHub repository in "owner/repo" format.
+        #[arg(long, default_value = "rararulab/rara-strategies")]
+        repo: String,
+    },
+
+    /// Fetch a strategy from the registry, validate it, and install locally.
+    Fetch {
+        /// Strategy name to fetch (e.g. "btc-momentum").
+        name: String,
+        /// GitHub repository in "owner/repo" format.
+        #[arg(long, default_value = "rararulab/rara-strategies")]
+        repo: String,
+    },
+
+    /// List locally installed strategies fetched from the registry.
+    Installed,
 }
 
 /// Config management subcommands.

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,6 +65,11 @@ pub enum AppError {
 
     #[snafu(display("TUI error: {source}"))]
     Tui { source: rara_tui::error::TuiError },
+
+    #[snafu(display("strategy registry error: {source}"))]
+    Registry {
+        source: crate::research::strategy_registry::RegistryError,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, AppError>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,12 +11,12 @@ use snafu::ResultExt;
 
 use rara_trading::agent::{CliBackend, CliExecutor};
 use rara_trading::app_config;
-use rara_trading::cli::{Cli, Command, ConfigAction, DataAction, FeedbackAction, PaperAction, ResearchAction};
+use rara_trading::cli::{Cli, Command, ConfigAction, DataAction, FeedbackAction, PaperAction, ResearchAction, StrategyAction};
 use rara_trading::validation;
 use rara_trading::error::{
     self, AgentBackendSnafu, AgentExecutionSnafu, ConfigSnafu, DataFetchSnafu, EventBusSnafu,
-    GrpcServeSnafu, IoSnafu, MarketStoreSnafu, PromoterSnafu, PromptRendererSnafu, TraceSnafu,
-    TuiSnafu,
+    GrpcServeSnafu, IoSnafu, MarketStoreSnafu, PromoterSnafu, PromptRendererSnafu, RegistrySnafu,
+    TraceSnafu, TuiSnafu,
 };
 use rara_trading::event_bus::bus::EventBus;
 use rara_trading::logging::{self, LoggingConfig};
@@ -447,6 +447,9 @@ async fn run() -> error::Result<()> {
         }
         Command::Paper { action } => {
             run_paper(action).await?;
+        }
+        Command::Strategy { action } => {
+            run_strategy(action).await?;
         }
         Command::Agent { prompt, backend } => {
             let cfg = app_config::load();
@@ -1613,4 +1616,144 @@ fn list_promoted_from_dir(
     }
 
     Ok(promoted)
+}
+
+// ---------------------------------------------------------------------------
+// Strategy registry commands
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct StrategyListResponse {
+    ok: bool,
+    action: &'static str,
+    strategies: Vec<StrategyListItem>,
+}
+
+#[derive(Serialize)]
+struct StrategyListItem {
+    name: String,
+    version: String,
+    tag: String,
+    size: u64,
+}
+
+#[derive(Serialize)]
+struct StrategyFetchResponse {
+    ok: bool,
+    action: &'static str,
+    name: String,
+    version: String,
+    api_version: u32,
+    wasm_path: String,
+}
+
+#[derive(Serialize)]
+struct StrategyInstalledResponse {
+    ok: bool,
+    action: &'static str,
+    strategies: Vec<StrategyInstalledItem>,
+}
+
+#[derive(Serialize)]
+struct StrategyInstalledItem {
+    name: String,
+    version: String,
+    api_version: u32,
+    wasm_path: String,
+}
+
+async fn run_strategy(action: StrategyAction) -> error::Result<()> {
+    match action {
+        StrategyAction::List { repo } => run_strategy_list(&repo).await,
+        StrategyAction::Fetch { name, repo } => run_strategy_fetch(&name, &repo).await,
+        StrategyAction::Installed => run_strategy_installed(),
+    }
+}
+
+async fn run_strategy_list(repo: &str) -> error::Result<()> {
+    let registry = rara_trading::research::strategy_registry::StrategyRegistry::builder()
+        .repo(repo.to_string())
+        .promoted_dir(paths::strategies_promoted_dir())
+        .build();
+
+    let entries = registry.list_available().await.context(RegistrySnafu)?;
+
+    let items: Vec<StrategyListItem> = entries
+        .iter()
+        .map(|e| StrategyListItem {
+            name: e.name.clone(),
+            version: e.version.clone(),
+            tag: e.tag.clone(),
+            size: e.size,
+        })
+        .collect();
+
+    println!(
+        "{}",
+        serde_json::to_string(&StrategyListResponse {
+            ok: true,
+            action: "strategy.list",
+            strategies: items,
+        })
+        .expect("StrategyListResponse must serialize")
+    );
+
+    Ok(())
+}
+
+async fn run_strategy_fetch(name: &str, repo: &str) -> error::Result<()> {
+    let promoted_dir = paths::strategies_promoted_dir();
+    std::fs::create_dir_all(&promoted_dir).context(IoSnafu)?;
+
+    let registry = rara_trading::research::strategy_registry::StrategyRegistry::builder()
+        .repo(repo.to_string())
+        .promoted_dir(promoted_dir)
+        .build();
+
+    let fetched = registry.fetch(name).await.context(RegistrySnafu)?;
+
+    println!(
+        "{}",
+        serde_json::to_string(&StrategyFetchResponse {
+            ok: true,
+            action: "strategy.fetch",
+            name: fetched.meta.name,
+            version: format!("v{}", fetched.meta.version),
+            api_version: fetched.meta.api_version,
+            wasm_path: fetched.wasm_path.display().to_string(),
+        })
+        .expect("StrategyFetchResponse must serialize")
+    );
+
+    Ok(())
+}
+
+fn run_strategy_installed() -> error::Result<()> {
+    let registry = rara_trading::research::strategy_registry::StrategyRegistry::builder()
+        .promoted_dir(paths::strategies_promoted_dir())
+        .build();
+
+    let installed = registry.list_installed().context(RegistrySnafu)?;
+
+    let items: Vec<StrategyInstalledItem> = installed
+        .iter()
+        .map(|s| StrategyInstalledItem {
+            name: s.meta.name.clone(),
+            version: format!("v{}", s.meta.version),
+            api_version: s.meta.api_version,
+            wasm_path: s.wasm_path.display().to_string(),
+        })
+        .collect();
+
+    println!(
+        "{}",
+        serde_json::to_string(&StrategyInstalledResponse {
+            ok: true,
+            action: "strategy.installed",
+            strategies: items,
+        })
+        .expect("StrategyInstalledResponse must serialize")
+    );
+
+    Ok(())
 }


### PR DESCRIPTION
Closes #122

## Summary

- Add `StrategyRegistry` in `crates/rara-research/src/strategy_registry.rs` that connects to `rararulab/rara-strategies` GitHub Releases
- Downloads WASM artifacts, validates API_VERSION compatibility via `WasmExecutor`, and saves to `strategies/promoted/`
- New CLI commands: `rara strategy list`, `rara strategy fetch <name>`, `rara strategy installed`
- Adds `RegistryError` variant to `AppError` for proper error propagation

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy -p rara-research` clean
- [x] 3 unit tests for tag parsing pass
- [ ] Manual: `rara strategy list` returns btc-momentum and hmm-regime
- [ ] Manual: `rara strategy fetch btc-momentum` downloads and validates WASM

🤖 Generated with [Claude Code](https://claude.com/claude-code)