### PR TITLE
docs: update README and add architecture guide for v0.0.1 (#124)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,85 @@ flowchart LR
     EVAL -->|Retrain| RE["Event Bus → Research Engine<br/>(trigger new hypothesis)"]
 ```
 
+## Architecture
+
+### Client / Server
+
+The system uses a **C/S architecture** with gRPC, allowing the TUI dashboard to connect locally or remotely.
+
+```
+rara run ──► rara-server (gRPC :50051)
+                    │
+                    ▼
+           rara-tui (client)
+           ratatui + crossterm
+```
+
+- `rara run` — starts the full daemon (research + paper trading + feedback + gRPC server)
+- `rara serve` — starts the gRPC server standalone
+- `rara tui` — connects to a running server for real-time monitoring
+
+### WASM Strategy Pipeline
+
+Strategies are compiled to **WebAssembly** (`wasm32-wasip1`) for sandboxed execution:
+
+```
+Hypothesis → LLM codes Rust → cargo build → .wasm artifact → wasmtime runtime
+```
+
+1. **Code generation** — LLM writes strategy code implementing `on_candles()`, `risk_levels()`, `meta()`
+2. **Compilation** — `StrategyCompiler` builds against `strategies/template/` targeting `wasm32-wasip1`
+3. **Backtesting** — `WasmExecutor` loads the WASM binary via wasmtime, runs against historical data
+4. **Promotion** — accepted strategies saved to `~/.rara-trading/strategies/promoted/`
+5. **Execution** — paper/live trading loads promoted WASM strategies at runtime
+
+The **Strategy API** (`rara-strategy-api` crate) defines the contract:
+
+| Export | Purpose |
+|--------|---------|
+| `wasm_meta()` | Returns `StrategyMeta` (name, version, api_version) |
+| `wasm_on_candles()` | Processes `Vec<Candle>` → returns `Signal` (Entry/Exit/Hold) |
+| `wasm_risk_levels()` | Computes stop-loss and take-profit for a position |
+
+API versioning (`API_VERSION = 1`) ensures compatibility between the runtime and strategy artifacts.
+
+### Strategy Registry
+
+Pre-built strategies from [`rara-strategies`](https://github.com/rararulab/rara-strategies) can be fetched directly:
+
+```bash
+rara-trading strategy list              # List available strategies
+rara-trading strategy fetch btc-momentum  # Download, validate, install
+rara-trading strategy installed         # List locally installed
+```
+
+The registry downloads WASM artifacts from GitHub Releases, validates API version compatibility via `WasmExecutor`, and saves to the promoted strategies directory.
+
+### Crate Layout
+
+```
+rara-trading (workspace root — CLI binary)
+├── rara-domain         Core domain models (Hypothesis, Experiment, Contract, etc.)
+├── rara-event-bus      Sled-backed persistent event bus
+├── rara-research       Research loop, WASM compilation, backtesting, promotion
+├── rara-strategy-api   Shared types for WASM strategy interface (Candle, Signal, etc.)
+├── rara-market-data    TimescaleDB market data storage + Binance/Yahoo fetchers
+├── rara-trading-engine Order execution, guard pipeline, broker abstraction
+├── rara-feedback       Strategy evaluation and lifecycle management
+├── rara-sentinel       External signal monitoring (RSS, webhooks)
+├── rara-agent          LLM backend abstraction (Claude, Codex)
+├── rara-infra          Shared infrastructure (config, logging, database)
+├── rara-server         gRPC server (tonic) — SystemStatus + EventStream
+└── rara-tui            Terminal dashboard (ratatui) — 4-tab cockpit view
+```
+
 ## Key Design Principles
 
 1. **Components are decoupled** — each runs independently, communicates via event bus polling
 2. **Stage gates with clear thresholds** — strategies must earn their way from research → paper → live
 3. **Agent-driven research** — hypotheses come from analyzing both market data AND past trading performance
-4. **No mocks** — all components are real implementations (ccxt-rust, barter-rs, RSS feeds)
+4. **WASM sandbox** — strategies execute in wasmtime with fuel limits, preventing runaway computation
+5. **No mocks** — all components are real implementations (ccxt-rust, barter-rs, RSS feeds)
 
 ## Supported Markets
 
@@ -132,7 +205,7 @@ flowchart LR
 
 ## Tech Stack
 
-Rust 2024, tokio, TimescaleDB, barter-rs, ccxt-rust, snafu, jiff, rust_decimal
+Rust 2024, tokio, TimescaleDB, wasmtime, barter-rs, ccxt-rust, tonic/prost (gRPC), ratatui, snafu, jiff, rust_decimal
 
 ## Getting Started
 
@@ -164,7 +237,41 @@ rara-trading data info
 
 Returns JSON with all stored instruments, their date ranges, and candle counts.
 
-### 4. Query with DuckDB (optional)
+### 4. Run Research Loop
+
+```bash
+# Run 10 iterations of hypothesis → code → backtest
+rara-trading research run --iterations 10 --contract BTC-USDT
+```
+
+### 5. Start Full System
+
+```bash
+# Start all components: research + paper trading + feedback + gRPC server
+rara-trading run --contracts BTC-USDT --iterations 10 --grpc-addr 0.0.0.0:50051
+```
+
+### 6. Launch TUI Dashboard
+
+```bash
+# Connect to local server
+rara-trading tui
+
+# Connect to remote server
+rara-trading tui --server http://192.168.1.100:50051
+```
+
+### 7. Fetch Pre-built Strategies
+
+```bash
+# List available from rara-strategies registry
+rara-trading strategy list
+
+# Download and validate
+rara-trading strategy fetch btc-momentum
+```
+
+### 8. Query with DuckDB (optional)
 
 ```bash
 duckdb -c "
@@ -178,16 +285,41 @@ SELECT * FROM ts.public.candles LIMIT 10;
 
 | Command | Description |
 |---------|-------------|
+| `run [--contracts C] [--iterations N] [--grpc-addr ADDR]` | Run full loop (research + paper + feedback + gRPC) |
+| `serve [--port PORT]` | Start gRPC server standalone |
+| `tui [--server URL]` | Launch TUI dashboard |
 | `data fetch --source <binance\|yahoo> --symbol SYM --start DATE --end DATE` | Fetch historical candles (idempotent) |
 | `data info` | Show data coverage per instrument (JSON) |
-| `research run [--iterations N] [--contract C]` | Run N research loop iterations |
+| `research run [--iterations N] [--contract C] [--quiet]` | Run N research loop iterations |
 | `research list [--limit N]` | List experiment history |
 | `research show --experiment-id ID` | Show experiment details |
-| `research promoted` | List promoted strategies |
-| `config set\|get\|list` | Manage configuration |
-| `agent <prompt> [--backend B]` | Run a prompt through the LLM backend |
+| `research promoted [--promoted-dir DIR]` | List promoted strategies |
+| `strategy list [--repo REPO]` | List strategies from GitHub registry |
+| `strategy fetch NAME [--repo REPO]` | Fetch, validate, and install a strategy |
+| `strategy installed` | List locally installed registry strategies |
+| `paper start [--contracts C]` | Start paper trading with promoted strategies |
+| `paper status` | Show paper trading status |
+| `paper stop` | Stop paper trading |
+| `feedback report [--strategy ID] [--limit N]` | Show strategy evaluation history |
+| `config init [--force]` | Generate config template |
+| `config set KEY VALUE` / `config get KEY` / `config list` | Manage configuration |
+| `validate` | Validate config and check connectivity |
+| `agent PROMPT [--backend B]` | Run a prompt through the LLM backend |
 
 All commands output structured JSON to stdout (human-readable logs go to stderr), making them suitable for agent/LLM consumption.
+
+## TUI Dashboard
+
+The TUI provides a real-time cockpit view with 4 tabs:
+
+| Tab | Content |
+|-----|---------|
+| **Overview** | Strategies, positions, events, system status, alerts, research progress |
+| **Research** | Hypothesis list, backtest results, progress gauge, SOTA tracker |
+| **Trading** | Account summary, positions, order log, PnL sparkline |
+| **Strategies** | Strategy lifecycle (promoted/active/demoted/retired), evaluation timeline |
+
+Responsive layout: dual-column at ≥120 cols, single-column below. Rosé Pine color theme.
 
 ## Development
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,217 @@
+# Architecture
+
+This document describes the technical architecture of rara-trading: crate responsibilities, data flow, and key design decisions.
+
+## Crate Dependency Graph
+
+```
+                    rara-trading (CLI binary)
+                    ├── rara-research
+                    │   ├── rara-domain
+                    │   ├── rara-event-bus
+                    │   ├── rara-infra
+                    │   ├── rara-market-data
+                    │   ├── rara-strategy-api
+                    │   └── wasmtime
+                    ├── rara-trading-engine
+                    │   ├── rara-domain
+                    │   ├── rara-event-bus
+                    │   └── rara-infra
+                    ├── rara-feedback
+                    │   ├── rara-domain
+                    │   └── rara-event-bus
+                    ├── rara-sentinel
+                    │   ├── rara-domain
+                    │   └── rara-event-bus
+                    ├── rara-server (gRPC)
+                    │   └── rara-event-bus
+                    ├── rara-tui (TUI client)
+                    │   └── rara-server (proto types)
+                    ├── rara-agent
+                    └── rara-infra
+```
+
+## Crate Responsibilities
+
+### rara-domain
+
+Core domain models shared across all components. No I/O, no side effects.
+
+- `Hypothesis` — a testable market hypothesis with parent lineage
+- `Experiment` — a single research iteration (hypothesis + code + backtest result)
+- `Contract` — trading pair abstraction (e.g. BTC-USDT)
+- `BacktestResult` — PnL, Sharpe, drawdown, win rate, trade count
+- `ResearchStrategy` — strategy lifecycle (Compiled → Accepted → Promoted → Archived)
+
+### rara-event-bus
+
+Sled-backed persistent event bus. Components publish and subscribe to events asynchronously. Each subscriber tracks its own read cursor, enabling independent consumption rates.
+
+Key event topics: `research.*`, `trading.*`, `feedback.*`, `sentinel.*`
+
+### rara-research
+
+The autonomous research engine. Contains the most complex subsystems:
+
+| Module | Purpose |
+|--------|---------|
+| `research_loop` | Orchestrates the hypothesis → code → compile → backtest → evaluate cycle |
+| `hypothesis_gen` | LLM-driven hypothesis generation from market data and past results |
+| `strategy_coder` | LLM generates Rust strategy code from a hypothesis |
+| `compiler` | Compiles generated Rust code to `wasm32-wasip1` using a template scaffold |
+| `wasm_executor` | Loads and runs WASM strategies via wasmtime with fuel limits |
+| `backtester` | Evaluates strategies against historical data using barter-rs |
+| `backtest_pool` | Parallel multi-timeframe backtesting |
+| `strategy_store` | Sled + filesystem persistence for strategy artifacts |
+| `strategy_promoter` | Saves accepted strategies to the promoted directory |
+| `strategy_registry` | Fetches pre-built WASM strategies from GitHub Releases |
+| `trace` | Persistent experiment history for analysis and lineage tracking |
+
+### rara-strategy-api
+
+Minimal crate (~73 lines) that compiles to both native and `wasm32-wasip1`. Defines the contract between the host runtime and WASM strategies:
+
+```rust
+pub const API_VERSION: u32 = 1;
+
+pub struct Candle { timestamp, open, high, low, close, volume }
+pub enum Signal { Entry { side, strength }, Exit, Hold }
+pub struct RiskLevels { stop_loss, take_profit }
+pub struct StrategyMeta { name, version, api_version, description }
+```
+
+Communication uses JSON serialization through WASM linear memory. The host allocates input buffers, the strategy writes output buffers.
+
+### rara-market-data
+
+TimescaleDB-backed market data storage with smart fetching:
+
+- **Binance fetcher** — REST API for historical 1m klines, auto-pagination
+- **Yahoo fetcher** — Daily OHLCV via yahoo-finance API
+- **Smart fetch** — skips already-stored date ranges, only fetches gaps
+- **Store** — TimescaleDB hypertable with `(exchange, symbol, interval, ts)` primary key
+
+### rara-trading-engine
+
+Order execution with risk controls:
+
+- **Guard pipeline** — configurable chain of pre-trade checks (max position, drawdown limit, sentinel gate)
+- **PaperBroker** — simulated execution with realistic fills
+- **CcxtBroker** — real exchange execution via ccxt-rust
+
+### rara-feedback
+
+Strategy evaluation and lifecycle management:
+
+- Aggregates paper trading metrics (Sharpe, drawdown, win rate)
+- Makes promote/hold/demote decisions based on configurable thresholds
+- Publishes lifecycle events to the event bus
+
+### rara-sentinel
+
+External signal monitoring for risk management:
+
+- RSS feed polling for market-moving news
+- Webhook receiver for external alerts
+- LLM-based signal classification (Critical / Warning / Info)
+- Critical signals block all trading via the event bus
+
+### rara-agent
+
+LLM backend abstraction:
+
+- Supports Claude (Anthropic API) and Codex (OpenAI) backends
+- CLI executor with timeout and streaming support
+- Configured via `config.toml`
+
+### rara-server
+
+gRPC server providing real-time system access:
+
+```protobuf
+service RaraService {
+    rpc GetSystemStatus(Empty) returns (SystemStatus);
+    rpc StreamEvents(StreamEventsRequest) returns (stream Event);
+}
+```
+
+- `SystemStatus` — connection states, strategy count, uptime
+- `StreamEvents` — real-time event stream with optional topic filtering
+
+### rara-tui
+
+Terminal dashboard built with ratatui + crossterm:
+
+- **4 tabs**: Overview, Research, Trading, Strategies
+- **Responsive layout**: dual-column (≥120 cols) / single-column (<120 cols)
+- **Rosé Pine theme**: consistent semantic colors (green=positive, red=negative, yellow=warning)
+- **gRPC client**: connects to rara-server for real-time data
+
+## Data Flow
+
+### Research → Paper Trading
+
+```
+LLM generates hypothesis
+    → LLM codes Rust strategy
+    → StrategyCompiler builds WASM (wasm32-wasip1)
+    → WasmExecutor loads + backtests via barter-rs
+    → If accepted: StrategyPromoter saves to ~/.rara-trading/strategies/promoted/
+    → Paper trading discovers and loads promoted WASM strategies
+    → WasmExecutor.on_candles() generates Signals
+    → Guard pipeline validates → PaperBroker executes
+```
+
+### Feedback Loop
+
+```
+Paper trading publishes order.filled events to EventBus
+    → Feedback aggregates metrics over evaluation window
+    → Promote: strategy graduates to live trading
+    → Hold: continue paper trading
+    → Demote: remove from paper trading
+    → Retrain: publish feedback to Research for new hypothesis generation
+```
+
+### Strategy Registry (External)
+
+```
+rara-strategies repo publishes WASM via GitHub Releases
+    → rara-trading strategy fetch <name>
+    → Download .wasm artifact from GitHub API
+    → WasmExecutor loads and extracts StrategyMeta
+    → Validate API_VERSION compatibility
+    → Save to ~/.rara-trading/strategies/promoted/
+    → Available for paper/live trading
+```
+
+## Key Directories
+
+| Path | Purpose |
+|------|---------|
+| `~/.rara-trading/config.toml` | Application configuration |
+| `~/.rara-trading/strategies/generated/` | Research-generated strategy artifacts |
+| `~/.rara-trading/strategies/promoted/` | Accepted strategies ready for trading |
+| `strategies/template/` | WASM compilation scaffold (Cargo.toml + lib.rs template) |
+
+## Design Decisions
+
+### Why WASM?
+
+- **Sandboxing** — strategies run in wasmtime with fuel limits, preventing infinite loops or excessive resource usage
+- **Portability** — compiled once, runs on any platform with wasmtime
+- **Safety** — WASM modules cannot access the filesystem, network, or host memory directly
+- **Hot-loading** — new strategies can be loaded without restarting the system
+
+### Why gRPC C/S?
+
+- **Remote monitoring** — TUI can connect from a different machine
+- **Multiple clients** — future web dashboard or mobile app can connect simultaneously
+- **Decoupled deployment** — server and client can be updated independently
+
+### Why sled for Event Bus?
+
+- **Embedded** — no external dependency, runs in-process
+- **Persistent** — events survive process restarts
+- **Fast** — B-tree based, handles high-throughput event publishing
+- **Simple** — single file storage, no configuration needed


### PR DESCRIPTION
Closes #124

## Summary

- **README.md**: rewritten with C/S architecture, WASM strategy pipeline, strategy registry integration, complete CLI reference (25 commands), TUI dashboard overview, crate layout diagram
- **docs/architecture.md**: new doc covering crate dependency graph, module responsibilities, data flow (research → paper → feedback), strategy registry flow, key directories, design decisions (why WASM, why gRPC, why sled)

## Test plan

- [ ] Review rendered markdown on GitHub
- [ ] Verify all CLI commands listed match `rara-trading --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)