### PR TITLE
feat(tui): standalone mode — auto-spawn gRPC server subprocess (#126)

### DIFF
--- a/crates/rara-tui/src/event_loop.rs
+++ b/crates/rara-tui/src/event_loop.rs
@@ -22,6 +22,7 @@ use rara_server::rara_proto::Empty;
 
 use crate::app::{App, ConnectionStatus, EventFilter, EVENTS_TAB_INDEX, STRATEGIES_TAB, TAB_RESEARCH, TRADING_TAB};
 use crate::error::{IoSnafu, Result};
+use crate::server_process::ServerProcess;
 use crate::tabs;
 use crate::ui;
 
@@ -31,11 +32,30 @@ const TICK_RATE: Duration = Duration::from_millis(1000);
 /// Duration for crossterm event polling.
 const POLL_TIMEOUT: Duration = Duration::from_millis(100);
 
-/// Run the TUI event loop, connecting to the given gRPC server address.
+/// Run the TUI event loop.
+///
+/// When `server_addr` is `Some`, connects to an existing gRPC server.
+/// When `None` (standalone mode), auto-spawns a `rara-trading serve` child
+/// process on a random available port and connects to it.
 ///
 /// This function takes ownership of the terminal for the duration of the
-/// application. On exit (or panic), the terminal is restored.
-pub async fn run(server_addr: &str) -> Result<()> {
+/// application. On exit (or panic), the terminal is restored and any spawned
+/// server subprocess is killed.
+pub async fn run(server_addr: Option<&str>) -> Result<()> {
+    // In standalone mode, spawn a server subprocess
+    let mut server_process = if server_addr.is_some() {
+        None
+    } else {
+        info!("no --server provided, spawning gRPC server subprocess (standalone mode)");
+        Some(ServerProcess::spawn().await?)
+    };
+
+    let effective_addr = match (&server_process, server_addr) {
+        (Some(proc), _) => proc.server_addr(),
+        (_, Some(addr)) => addr.to_string(),
+        _ => unreachable!(),
+    };
+
     // Terminal setup
     enable_raw_mode().context(IoSnafu)?;
     let mut stdout = io::stdout();
@@ -43,10 +63,10 @@ pub async fn run(server_addr: &str) -> Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend).context(IoSnafu)?;
 
-    let mut app = App::new(server_addr.to_string());
+    let mut app = App::new(effective_addr.clone());
 
     // Try initial connection
-    let mut client = try_connect(server_addr).await;
+    let mut client = try_connect(&effective_addr).await;
     if client.is_some() {
         app.connection_status = ConnectionStatus::Connected;
     }
@@ -59,6 +79,11 @@ pub async fn run(server_addr: &str) -> Result<()> {
     disable_raw_mode().context(IoSnafu)?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen).context(IoSnafu)?;
     terminal.show_cursor().context(IoSnafu)?;
+
+    // Shutdown spawned server subprocess if we started one
+    if let Some(proc) = server_process.as_mut() {
+        proc.shutdown().await;
+    }
 
     result
 }
@@ -234,7 +259,7 @@ fn handle_events_search_key(app: &mut App, key: KeyCode) {
 }
 
 /// Handle key presses specific to the Research tab.
-fn handle_research_key(app: &mut App, key: KeyCode) {
+const fn handle_research_key(app: &mut App, key: KeyCode) {
     match key {
         KeyCode::Char('j') | KeyCode::Down => app.research.select_next(),
         KeyCode::Char('k') | KeyCode::Up => app.research.select_prev(),

--- a/crates/rara-tui/src/lib.rs
+++ b/crates/rara-tui/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::result_large_err)]
 //! TUI client for the rara-trading dashboard.
 //!
 //! Built on ratatui + crossterm, connects to the gRPC server to display
@@ -6,6 +7,7 @@
 pub mod app;
 pub mod error;
 pub mod event_loop;
+pub mod server_process;
 pub mod tabs;
 pub mod theme;
 pub mod ui;

--- a/crates/rara-tui/src/server_process.rs
+++ b/crates/rara-tui/src/server_process.rs
@@ -1,0 +1,89 @@
+//! Manages a child gRPC server process for standalone TUI mode.
+//!
+//! When the TUI is launched without an explicit `--server` address, this module
+//! spawns the same binary with `serve --port <port>` and ensures cleanup on exit.
+
+use std::net::TcpListener;
+use std::process::Stdio;
+
+use snafu::ResultExt;
+use tokio::process::{Child, Command};
+use tracing::{info, warn};
+
+use crate::error::{IoSnafu, Result};
+
+/// Guard that owns a spawned gRPC server child process.
+///
+/// When dropped, it attempts to kill the child process to prevent orphans.
+/// The `port` field records which port the server is listening on.
+pub struct ServerProcess {
+    pub port: u16,
+    child: Child,
+}
+
+impl ServerProcess {
+    /// Spawn a `rara-trading serve --port <port>` child process.
+    ///
+    /// Uses `std::env::current_exe()` to locate the binary, picks an available
+    /// port via ephemeral binding, and redirects stdout/stderr to `/dev/null`.
+    pub async fn spawn() -> Result<Self> {
+        let port = pick_available_port()?;
+        let exe = std::env::current_exe().context(IoSnafu)?;
+
+        info!(port, ?exe, "spawning gRPC server subprocess");
+
+        let child = Command::new(exe)
+            .args(["serve", "--port", &port.to_string()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .kill_on_drop(true)
+            .spawn()
+            .context(IoSnafu)?;
+
+        let process = Self { port, child };
+
+        // Give the server a moment to bind the port
+        process.wait_for_ready().await;
+
+        Ok(process)
+    }
+
+    /// Build the gRPC server address string for this child process.
+    pub fn server_addr(&self) -> String {
+        format!("http://127.0.0.1:{}", self.port)
+    }
+
+    /// Gracefully shut down the child process.
+    ///
+    /// Sends SIGKILL via `tokio::process::Child::kill` and waits for exit.
+    /// Errors are logged but not propagated since this runs during cleanup.
+    pub async fn shutdown(&mut self) {
+        info!(port = self.port, "shutting down gRPC server subprocess");
+        if let Err(e) = self.child.kill().await {
+            warn!("failed to kill server subprocess: {e}");
+        }
+    }
+
+    /// Poll the port until it accepts a TCP connection, with a timeout.
+    async fn wait_for_ready(&self) {
+        let addr = format!("127.0.0.1:{}", self.port);
+        for _ in 0..20 {
+            if std::net::TcpStream::connect(&addr).is_ok() {
+                info!(port = self.port, "gRPC server subprocess is ready");
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        warn!(
+            port = self.port,
+            "gRPC server subprocess did not become ready within 2s, proceeding anyway"
+        );
+    }
+}
+
+/// Find an available TCP port by binding to port 0 and reading the assigned port.
+fn pick_available_port() -> Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0").context(IoSnafu)?;
+    let port = listener.local_addr().context(IoSnafu)?.port();
+    Ok(port)
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -72,10 +72,13 @@ pub enum Command {
     },
 
     /// Launch the TUI dashboard.
+    ///
+    /// When `--server` is provided, connects to an existing gRPC server.
+    /// When omitted, automatically spawns a server subprocess (standalone mode).
     Tui {
-        /// gRPC server address to connect to.
-        #[arg(long, default_value = "http://127.0.0.1:50051")]
-        server: String,
+        /// gRPC server address to connect to. Omit for standalone mode.
+        #[arg(long)]
+        server: Option<String>,
     },
 
     /// Feedback loop operations.

--- a/src/main.rs
+++ b/src/main.rs
@@ -440,7 +440,7 @@ async fn run() -> error::Result<()> {
             run_serve(port).await?;
         }
         Command::Tui { server } => {
-            rara_tui::event_loop::run(&server).await.context(TuiSnafu)?;
+            rara_tui::event_loop::run(server.as_deref()).await.context(TuiSnafu)?;
         }
         Command::Feedback { action } => {
             run_feedback(action)?;


### PR DESCRIPTION
Closes #126

## Summary
- When `--server` is omitted from `rara-trading tui`, automatically spawns a `rara-trading serve` child process on a random available port (standalone mode)
- `ServerProcess` guard uses `kill_on_drop(true)` + explicit `shutdown()` to prevent orphaned server processes
- Waits up to 2s for the server to become ready before connecting
- When `--server <addr>` is provided, behavior is unchanged (connects to existing server)

## Test plan
- [ ] `cargo check` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `rara-trading tui` launches in standalone mode (spawns server subprocess)
- [ ] `rara-trading tui --server http://127.0.0.1:50051` connects to existing server
- [ ] Quitting TUI with `q` kills the spawned server subprocess