### PR TITLE
feat(tui): display real installed strategies instead of sample data (#127)

### DIFF
--- a/crates/rara-tui/Cargo.toml
+++ b/crates/rara-tui/Cargo.toml
@@ -14,6 +14,7 @@ tracing.workspace = true
 snafu.workspace = true
 strum.workspace = true
 rara-server.workspace = true
+rara-research.workspace = true
 
 [lints]
 workspace = true

--- a/crates/rara-tui/src/app.rs
+++ b/crates/rara-tui/src/app.rs
@@ -1,7 +1,11 @@
 //! Application state for the TUI dashboard.
 
+use std::path::PathBuf;
+
+use rara_research::strategy_registry::{FetchedStrategy, StrategyRegistry};
 use rara_server::rara_proto::SystemStatus;
 use strum::{Display, EnumString};
+use tracing::warn;
 
 use crate::tabs::research::ResearchState;
 
@@ -293,60 +297,38 @@ impl TradingState {
 pub const STRATEGIES_TAB: usize = 3;
 
 /// Lifecycle status of a strategy.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Display, EnumString)]
 pub enum StrategyLifecycle {
-    /// Strategy has been promoted to live trading.
-    Promoted,
-    /// Strategy is actively being evaluated.
-    Active,
-    /// Strategy was demoted from live trading.
-    Demoted,
-    /// Strategy has been retired permanently.
-    Retired,
-    /// Strategy is archived for historical reference.
-    Archived,
+    /// Strategy is installed and available for use.
+    #[strum(serialize = "Installed")]
+    Installed,
 }
 
 /// A single strategy entry displayed in the strategy list table.
+///
+/// Populated from real installed strategies via `StrategyRegistry::list_installed()`.
 #[derive(Debug, Clone)]
 pub struct StrategyEntry {
     /// Display name of the strategy.
     pub name: String,
-    /// Version number of the strategy.
+    /// Version number of the strategy (from WASM metadata).
     pub version: u32,
+    /// Release tag from the GitHub registry.
+    pub tag: String,
+    /// Release version string (e.g. "v0.1.0").
+    pub release_version: String,
+    /// API version the strategy was compiled against.
+    pub api_version: u32,
+    /// Brief description from the WASM metadata.
+    pub description: String,
     /// Current lifecycle status.
     pub status: StrategyLifecycle,
-    /// Sharpe ratio from the most recent evaluation.
-    pub sharpe: f64,
-    /// Maximum drawdown percentage (negative value).
-    pub max_drawdown: f64,
-    /// Total number of trades executed.
-    pub trade_count: u32,
-    /// Date of the last evaluation, if any.
-    pub last_eval: Option<String>,
-    /// The original hypothesis that spawned this strategy.
-    pub origin_hypothesis: String,
-    /// Date the strategy was created.
-    pub created_at: String,
-    /// Date the strategy was promoted to live, if ever.
-    pub promoted_at: Option<String>,
-}
-
-/// A single evaluation record in the evaluation timeline.
-#[derive(Debug, Clone)]
-pub struct EvaluationEntry {
-    /// Timestamp of the evaluation.
-    pub time: String,
-    /// Number of trades in the evaluation window.
-    pub trades: u32,
-    /// Sharpe ratio for this evaluation period.
-    pub sharpe: f64,
-    /// Drawdown percentage during this evaluation period.
-    pub drawdown: f64,
-    /// Decision made (Promote, Demote, Retire, Hold).
-    pub decision: String,
-    /// Human-readable reason for the decision.
-    pub reason: String,
+    /// Local filesystem path to the WASM binary.
+    pub wasm_path: PathBuf,
+    /// WASM file size in bytes.
+    pub file_size: u64,
+    /// WASM asset download URL from the registry.
+    pub wasm_url: String,
 }
 
 /// State for the Strategies tab, managing list selection and detail expansion.
@@ -355,24 +337,22 @@ pub struct StrategiesState {
     pub strategies: Vec<StrategyEntry>,
     /// Index of the currently selected strategy in the list.
     pub selected_index: usize,
-    /// Evaluation history for the selected strategy.
-    pub evaluations: Vec<EvaluationEntry>,
-    /// Whether the full hypothesis text is shown in the detail panel.
+    /// Whether the full description is shown in the detail panel.
     pub show_detail: bool,
-    /// Whether the DAG popup is visible.
-    pub show_dag: bool,
 }
 
 impl StrategiesState {
-    /// Create a new strategies state populated with sample data.
+    /// Create a new strategies state by reading installed strategies from disk.
+    ///
+    /// Reads `.registry.json` files from the promoted strategies directory.
+    /// If no strategies are installed or reading fails, returns an empty list.
     #[must_use]
-    pub fn new_with_samples() -> Self {
+    pub fn from_installed(promoted_dir: PathBuf) -> Self {
+        let strategies = load_installed_strategies(promoted_dir);
         Self {
-            strategies: sample_strategies(),
+            strategies,
             selected_index: 0,
-            evaluations: sample_evaluations(),
             show_detail: false,
-            show_dag: false,
         }
     }
 
@@ -391,11 +371,6 @@ impl StrategiesState {
     /// Toggle the detail expansion for the selected strategy.
     pub const fn toggle_detail(&mut self) {
         self.show_detail = !self.show_detail;
-    }
-
-    /// Toggle the DAG popup.
-    pub const fn toggle_dag(&mut self) {
-        self.show_dag = !self.show_dag;
     }
 }
 
@@ -433,8 +408,10 @@ pub struct App {
 
 impl App {
     /// Create a new app instance targeting the given gRPC server address.
+    ///
+    /// Loads installed strategies from the promoted directory on disk.
     #[must_use]
-    pub fn new(server_addr: String) -> Self {
+    pub fn new(server_addr: String, promoted_dir: PathBuf) -> Self {
         Self {
             active_tab: 0,
             running: true,
@@ -449,7 +426,7 @@ impl App {
             research: ResearchState::empty(),
             events_state: EventsState::default(),
             trading: TradingState::default(),
-            strategies_state: StrategiesState::new_with_samples(),
+            strategies_state: StrategiesState::from_installed(promoted_dir),
         }
     }
 
@@ -466,106 +443,35 @@ impl App {
     }
 }
 
-/// Generate sample strategy entries for development/demo purposes.
-fn sample_strategies() -> Vec<StrategyEntry> {
-    vec![
-        StrategyEntry {
-            name: "MeanRev-BTC-4h".to_string(),
-            version: 3,
-            status: StrategyLifecycle::Promoted,
-            sharpe: 1.42,
-            max_drawdown: -8.3,
-            trade_count: 142,
-            last_eval: Some("2026-03-25".to_string()),
-            origin_hypothesis: "BTC mean reversion on 4h RSI oversold conditions with volume confirmation shows consistent alpha in ranging markets".to_string(),
-            created_at: "2026-01-15".to_string(),
-            promoted_at: Some("2026-02-10".to_string()),
-        },
-        StrategyEntry {
-            name: "Momentum-ETH-1h".to_string(),
-            version: 2,
-            status: StrategyLifecycle::Active,
-            sharpe: 1.18,
-            max_drawdown: -11.2,
-            trade_count: 89,
-            last_eval: Some("2026-03-24".to_string()),
-            origin_hypothesis: "ETH momentum breakout on 1h timeframe using VWAP crossover".to_string(),
-            created_at: "2026-02-01".to_string(),
-            promoted_at: None,
-        },
-        StrategyEntry {
-            name: "StatArb-SOL".to_string(),
-            version: 1,
-            status: StrategyLifecycle::Demoted,
-            sharpe: 0.91,
-            max_drawdown: -15.7,
-            trade_count: 67,
-            last_eval: Some("2026-03-20".to_string()),
-            origin_hypothesis: "SOL statistical arbitrage against BTC using cointegration z-score".to_string(),
-            created_at: "2026-01-20".to_string(),
-            promoted_at: Some("2026-02-15".to_string()),
-        },
-        StrategyEntry {
-            name: "GridBot-BNB".to_string(),
-            version: 4,
-            status: StrategyLifecycle::Retired,
-            sharpe: 0.45,
-            max_drawdown: -22.1,
-            trade_count: 312,
-            last_eval: Some("2026-03-10".to_string()),
-            origin_hypothesis: "BNB grid trading in stable range-bound periods".to_string(),
-            created_at: "2025-11-05".to_string(),
-            promoted_at: Some("2025-12-01".to_string()),
-        },
-        StrategyEntry {
-            name: "DCA-Weekly".to_string(),
-            version: 1,
-            status: StrategyLifecycle::Archived,
-            sharpe: 0.62,
-            max_drawdown: -18.4,
-            trade_count: 52,
-            last_eval: None,
-            origin_hypothesis: "Weekly dollar cost averaging with volatility-adjusted sizing".to_string(),
-            created_at: "2025-09-01".to_string(),
-            promoted_at: None,
-        },
-    ]
+/// Convert a `FetchedStrategy` from the registry into a TUI view model.
+fn fetched_to_entry(fetched: FetchedStrategy) -> StrategyEntry {
+    StrategyEntry {
+        name: fetched.meta.name,
+        version: fetched.meta.version,
+        tag: fetched.entry.tag,
+        release_version: fetched.entry.version,
+        api_version: fetched.meta.api_version,
+        description: fetched.meta.description,
+        status: StrategyLifecycle::Installed,
+        wasm_path: fetched.wasm_path,
+        file_size: fetched.entry.size,
+        wasm_url: fetched.entry.wasm_url,
+    }
 }
 
-/// Generate sample evaluation entries for development/demo purposes.
-fn sample_evaluations() -> Vec<EvaluationEntry> {
-    vec![
-        EvaluationEntry {
-            time: "2026-03-25".to_string(),
-            trades: 42,
-            sharpe: 1.42,
-            drawdown: -8.3,
-            decision: "Promote".to_string(),
-            reason: "Consistent alpha over 30-day window".to_string(),
-        },
-        EvaluationEntry {
-            time: "2026-03-18".to_string(),
-            trades: 38,
-            sharpe: 1.31,
-            drawdown: -9.1,
-            decision: "Hold".to_string(),
-            reason: "Needs more data for confidence".to_string(),
-        },
-        EvaluationEntry {
-            time: "2026-03-11".to_string(),
-            trades: 35,
-            sharpe: 1.15,
-            drawdown: -10.2,
-            decision: "Hold".to_string(),
-            reason: "Market regime shift detected".to_string(),
-        },
-        EvaluationEntry {
-            time: "2026-03-04".to_string(),
-            trades: 27,
-            sharpe: 0.88,
-            drawdown: -12.5,
-            decision: "Demote".to_string(),
-            reason: "Drawdown exceeds threshold".to_string(),
-        },
-    ]
+/// Load installed strategies from the promoted directory on disk.
+///
+/// Returns an empty vec if the directory doesn't exist or reading fails.
+fn load_installed_strategies(promoted_dir: PathBuf) -> Vec<StrategyEntry> {
+    let registry = StrategyRegistry::builder()
+        .promoted_dir(promoted_dir)
+        .build();
+
+    match registry.list_installed() {
+        Ok(strategies) => strategies.into_iter().map(fetched_to_entry).collect(),
+        Err(err) => {
+            warn!(%err, "failed to load installed strategies");
+            Vec::new()
+        }
+    }
 }

--- a/crates/rara-tui/src/event_loop.rs
+++ b/crates/rara-tui/src/event_loop.rs
@@ -4,6 +4,7 @@
 //! terminal setup/teardown.
 
 use std::io;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use crossterm::event::{self, Event, KeyCode, KeyEventKind};
@@ -41,7 +42,7 @@ const POLL_TIMEOUT: Duration = Duration::from_millis(100);
 /// This function takes ownership of the terminal for the duration of the
 /// application. On exit (or panic), the terminal is restored and any spawned
 /// server subprocess is killed.
-pub async fn run(server_addr: Option<&str>) -> Result<()> {
+pub async fn run(server_addr: Option<&str>, promoted_dir: PathBuf) -> Result<()> {
     // In standalone mode, spawn a server subprocess
     let mut server_process = if server_addr.is_some() {
         None
@@ -55,7 +56,6 @@ pub async fn run(server_addr: Option<&str>) -> Result<()> {
         (_, Some(addr)) => addr.to_string(),
         _ => unreachable!(),
     };
-
     // Terminal setup
     enable_raw_mode().context(IoSnafu)?;
     let mut stdout = io::stdout();
@@ -63,7 +63,7 @@ pub async fn run(server_addr: Option<&str>) -> Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend).context(IoSnafu)?;
 
-    let mut app = App::new(effective_addr.clone());
+    let mut app = App::new(effective_addr.clone(), promoted_dir);
 
     // Try initial connection
     let mut client = try_connect(&effective_addr).await;
@@ -274,7 +274,6 @@ fn handle_strategies_key(app: &mut App, key: KeyCode) {
         KeyCode::Char('j') | KeyCode::Down => app.strategies_state.select_next(),
         KeyCode::Char('k') | KeyCode::Up => app.strategies_state.select_previous(),
         KeyCode::Enter => app.strategies_state.toggle_detail(),
-        KeyCode::Char('d') => app.strategies_state.toggle_dag(),
         _ => {}
     }
 }

--- a/crates/rara-tui/src/tabs/strategies.rs
+++ b/crates/rara-tui/src/tabs/strategies.rs
@@ -1,19 +1,17 @@
-//! Strategies tab — lifecycle master-detail view with evaluation timeline.
+//! Strategies tab — displays real installed strategies from the registry.
 //!
 //! Layout:
 //! ```text
-//! ┌─ Strategy List ──────────────────────────────────────────────┐
-//! │ Strategy  Ver  Status  Sharpe  DD  Trades  Last Eval         │
-//! │ > MeanRev  3   ● Active  1.42  -8%  142   2026-03-25        │
-//! │   Momentum 2   ○ Demoted 0.91  -12% 89    2026-03-24        │
-//! ├─ Detail ─────────────────────────────────────────────────────┤
-//! │ Origin: "BTC mean reversion on 4h RSI oversold"              │
-//! │ Created: 2026-01-15  Promoted: 2026-02-10                    │
-//! ├─ Evaluation Timeline ────────────────────────────────────────┤
-//! │ Time       Trades  Sharpe  DD    Decision  Reason            │
-//! │ 2026-03-25  42     1.42   -8%   ✓Promote  Consistent alpha  │
-//! │ 2026-03-18  38     1.31   -9%   —Hold     Needs more data   │
-//! └─────────────────────────────────────────────────────────────┘
+//! ┌─ Installed Strategies ─────────────────────────────────────────┐
+//! │ Name       Ver  API  Release    Size    Status                  │
+//! │ > btc-mom   1   v1   v0.1.0    128KB   ● Installed             │
+//! │   hmm-reg   2   v1   v0.2.0    256KB   ● Installed             │
+//! ├─ Detail ───────────────────────────────────────────────────────┤
+//! │ Tag: btc-momentum-v0.1.0                                       │
+//! │ Description: "BTC momentum breakout strategy"                  │
+//! │ WASM: ~/.rara-trading/strategies/promoted/btc-momentum.wasm    │
+//! │ Download URL: https://github.com/...                           │
+//! └───────────────────────────────────────────────────────────────┘
 //! ```
 
 use ratatui::layout::{Constraint, Layout, Rect};
@@ -22,33 +20,64 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
 use ratatui::Frame;
 
-use crate::app::StrategiesState;
+use crate::app::{StrategiesState, StrategyLifecycle};
 use crate::theme;
 
 /// Render the full strategies tab into the given area.
 pub fn render(frame: &mut Frame, state: &StrategiesState, area: Rect) {
+    if state.strategies.is_empty() {
+        render_empty(frame, area);
+        return;
+    }
+
     let chunks = Layout::vertical([
-        Constraint::Percentage(40), // strategy list
-        Constraint::Percentage(25), // detail panel
-        Constraint::Percentage(35), // evaluation timeline
+        Constraint::Percentage(55), // strategy list
+        Constraint::Percentage(45), // detail panel
     ])
     .split(area);
 
     render_strategy_list(frame, state, chunks[0]);
     render_detail(frame, state, chunks[1]);
-    render_evaluation_timeline(frame, state, chunks[2]);
 }
 
-/// Render the strategy list table with colored status indicators.
+/// Render a placeholder message when no strategies are installed.
+fn render_empty(frame: &mut Frame, area: Rect) {
+    let content = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "No strategies installed",
+            Style::default()
+                .fg(theme::MUTED)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Use `rara-trading strategies fetch <name>` to install strategies from the registry.",
+            theme::muted(),
+        )),
+    ];
+
+    let block = Paragraph::new(content)
+        .block(
+            Block::default()
+                .title(" Strategies ")
+                .borders(Borders::ALL)
+                .border_style(theme::muted()),
+        )
+        .alignment(ratatui::layout::Alignment::Center);
+
+    frame.render_widget(block, area);
+}
+
+/// Render the strategy list table with status indicators.
 fn render_strategy_list(frame: &mut Frame, state: &StrategiesState, area: Rect) {
     let header = Row::new(vec![
-        Cell::from("Strategy").style(theme::emphasis()),
+        Cell::from("Name").style(theme::emphasis()),
         Cell::from("Ver").style(theme::emphasis()),
+        Cell::from("API").style(theme::emphasis()),
+        Cell::from("Release").style(theme::emphasis()),
+        Cell::from("Size").style(theme::emphasis()),
         Cell::from("Status").style(theme::emphasis()),
-        Cell::from("Sharpe").style(theme::emphasis()),
-        Cell::from("DD").style(theme::emphasis()),
-        Cell::from("Trades").style(theme::emphasis()),
-        Cell::from("Last Eval").style(theme::emphasis()),
     ])
     .height(1);
 
@@ -69,21 +98,13 @@ fn render_strategy_list(frame: &mut Frame, state: &StrategiesState, area: Rect) 
             Row::new(vec![
                 Cell::from(entry.name.clone()).style(base_style),
                 Cell::from(format!("v{}", entry.version)).style(base_style),
+                Cell::from(format!("v{}", entry.api_version)).style(base_style),
+                Cell::from(entry.release_version.clone()).style(base_style),
+                Cell::from(format_file_size(entry.file_size)).style(base_style),
                 Cell::from(Line::from(vec![
                     Span::styled(status_icon, status_style),
                     Span::styled(format!(" {status_label}"), status_style),
                 ])),
-                Cell::from(format!("{:.2}", entry.sharpe)).style(base_style),
-                Cell::from(format!("{:.1}%", entry.max_drawdown)).style(base_style),
-                Cell::from(format!("{}", entry.trade_count)).style(base_style),
-                Cell::from(
-                    entry
-                        .last_eval
-                        .as_deref()
-                        .unwrap_or("—")
-                        .to_string(),
-                )
-                .style(theme::muted()),
             ])
         })
         .collect();
@@ -91,19 +112,18 @@ fn render_strategy_list(frame: &mut Frame, state: &StrategiesState, area: Rect) 
     let table = Table::new(
         rows,
         [
-            Constraint::Percentage(20),
+            Constraint::Percentage(25),
             Constraint::Length(5),
-            Constraint::Percentage(14),
-            Constraint::Length(7),
-            Constraint::Length(7),
-            Constraint::Length(7),
+            Constraint::Length(5),
+            Constraint::Percentage(15),
+            Constraint::Length(9),
             Constraint::Percentage(15),
         ],
     )
     .header(header)
     .block(
         Block::default()
-            .title(" Strategies ")
+            .title(" Installed Strategies ")
             .borders(Borders::ALL)
             .border_style(theme::muted()),
     )
@@ -122,39 +142,41 @@ fn render_detail(frame: &mut Frame, state: &StrategiesState, area: Rect) {
             ))]
         },
         |entry| {
-            let hypothesis_text = if state.show_detail {
-                entry.origin_hypothesis.clone()
+            let description_text = if state.show_detail {
+                entry.description.clone()
             } else {
-                // Truncate to first line or 80 chars
-                let truncated: String =
-                    entry.origin_hypothesis.chars().take(80).collect();
-                if entry.origin_hypothesis.len() > 80 {
+                let truncated: String = entry.description.chars().take(80).collect();
+                if entry.description.len() > 80 {
                     format!("{truncated}... [Enter to expand]")
                 } else {
                     truncated
                 }
             };
 
-            let promoted_text = entry.promoted_at.as_deref().unwrap_or("\u{2014}");
-
             vec![
                 Line::from(vec![
-                    Span::styled("Origin: ", theme::muted()),
-                    Span::styled(format!("\"{hypothesis_text}\""), theme::highlight()),
+                    Span::styled("Tag: ", theme::muted()),
+                    Span::styled(entry.tag.clone(), theme::text()),
                 ]),
                 Line::from(vec![
-                    Span::styled("Created: ", theme::muted()),
-                    Span::styled(entry.created_at.clone(), theme::text()),
-                    Span::styled("  Promoted: ", theme::muted()),
-                    Span::styled(promoted_text.to_string(), theme::text()),
+                    Span::styled("Description: ", theme::muted()),
+                    Span::styled(format!("\"{description_text}\""), theme::highlight()),
                 ]),
                 Line::from(vec![
-                    Span::styled("Sharpe: ", theme::muted()),
-                    Span::styled(format!("{:.2}", entry.sharpe), theme::text()),
-                    Span::styled("  Max DD: ", theme::muted()),
-                    Span::styled(format!("{:.1}%", entry.max_drawdown), theme::text()),
-                    Span::styled("  Trades: ", theme::muted()),
-                    Span::styled(format!("{}", entry.trade_count), theme::text()),
+                    Span::styled("WASM: ", theme::muted()),
+                    Span::styled(entry.wasm_path.display().to_string(), theme::text()),
+                ]),
+                Line::from(vec![
+                    Span::styled("Size: ", theme::muted()),
+                    Span::styled(format_file_size(entry.file_size), theme::text()),
+                    Span::styled("  API version: ", theme::muted()),
+                    Span::styled(format!("v{}", entry.api_version), theme::text()),
+                    Span::styled("  Strategy version: ", theme::muted()),
+                    Span::styled(format!("v{}", entry.version), theme::text()),
+                ]),
+                Line::from(vec![
+                    Span::styled("Download URL: ", theme::muted()),
+                    Span::styled(entry.wasm_url.clone(), theme::muted()),
                 ]),
             ]
         },
@@ -170,102 +192,27 @@ fn render_detail(frame: &mut Frame, state: &StrategiesState, area: Rect) {
     frame.render_widget(detail, area);
 }
 
-/// Render the evaluation history timeline table.
-fn render_evaluation_timeline(frame: &mut Frame, state: &StrategiesState, area: Rect) {
-    let header = Row::new(vec![
-        Cell::from("Time").style(theme::emphasis()),
-        Cell::from("Trades").style(theme::emphasis()),
-        Cell::from("Sharpe").style(theme::emphasis()),
-        Cell::from("DD").style(theme::emphasis()),
-        Cell::from("Decision").style(theme::emphasis()),
-        Cell::from("Reason").style(theme::emphasis()),
-    ])
-    .height(1);
-
-    let rows: Vec<Row> = state
-        .evaluations
-        .iter()
-        .map(|eval| {
-            let decision_span = decision_styled(&eval.decision);
-
-            Row::new(vec![
-                Cell::from(eval.time.clone()).style(theme::muted()),
-                Cell::from(format!("{}", eval.trades)).style(theme::text()),
-                Cell::from(format!("{:.2}", eval.sharpe)).style(theme::text()),
-                Cell::from(format!("{:.1}%", eval.drawdown)).style(theme::text()),
-                Cell::from(Line::from(decision_span)),
-                Cell::from(eval.reason.clone()).style(theme::muted()),
-            ])
-        })
-        .collect();
-
-    let table = Table::new(
-        rows,
-        [
-            Constraint::Percentage(15),
-            Constraint::Length(7),
-            Constraint::Length(7),
-            Constraint::Length(7),
-            Constraint::Percentage(13),
-            Constraint::Percentage(30),
-        ],
-    )
-    .header(header)
-    .block(
-        Block::default()
-            .title(" Evaluation Timeline ")
-            .borders(Borders::ALL)
-            .border_style(theme::muted()),
-    );
-
-    frame.render_widget(table, area);
-}
-
 /// Return the status icon, label, and style for a lifecycle status.
 fn lifecycle_style(status: &StrategyLifecycle) -> (&'static str, &'static str, Style) {
-    use StrategyLifecycle::{Active, Archived, Demoted, Promoted, Retired};
     match status {
-        Promoted => (
+        StrategyLifecycle::Installed => (
             "\u{25cf}",
-            "Promoted",
+            "Installed",
             Style::default()
                 .fg(theme::FOAM)
                 .add_modifier(Modifier::BOLD),
         ),
-        Active => ("\u{25cf}", "Active", Style::default().fg(theme::IRIS)),
-        Demoted => ("\u{25cb}", "Demoted", Style::default().fg(theme::GOLD)),
-        Retired => ("\u{25cb}", "Retired", Style::default().fg(theme::LOVE)),
-        Archived => ("\u{25cb}", "Archived", Style::default().fg(theme::MUTED)),
     }
 }
 
-/// Return a styled span for an evaluation decision string.
-fn decision_styled(decision: &str) -> Vec<Span<'static>> {
-    match decision.to_lowercase().as_str() {
-        "promote" => vec![Span::styled(
-            "\u{2713}Promote".to_string(),
-            Style::default().fg(theme::FOAM),
-        )],
-        "demote" => vec![Span::styled(
-            "\u{2717}Demote".to_string(),
-            Style::default().fg(theme::LOVE),
-        )],
-        "retire" => vec![Span::styled(
-            "\u{2717}Retire".to_string(),
-            Style::default()
-                .fg(theme::LOVE)
-                .add_modifier(Modifier::BOLD),
-        )],
-        "hold" => vec![Span::styled(
-            "\u{2014}Hold".to_string(),
-            Style::default().fg(theme::MUTED),
-        )],
-        _ => vec![Span::styled(
-            decision.to_string(),
-            theme::text(),
-        )],
+/// Format a byte count into a human-readable size string.
+#[allow(clippy::cast_precision_loss)] // file sizes are well within f64 precision
+fn format_file_size(bytes: u64) -> String {
+    if bytes >= 1_048_576 {
+        format!("{:.1} MB", bytes as f64 / 1_048_576.0)
+    } else if bytes >= 1024 {
+        format!("{:.0} KB", bytes as f64 / 1024.0)
+    } else {
+        format!("{bytes} B")
     }
 }
-
-// Re-export the lifecycle enum so render functions can reference it directly
-use crate::app::StrategyLifecycle;

--- a/crates/rara-tui/tests/app_test.rs
+++ b/crates/rara-tui/tests/app_test.rs
@@ -1,10 +1,20 @@
 //! Tests for the TUI application state logic.
 
+use std::path::PathBuf;
+
 use rara_tui::app::{App, TAB_NAMES};
+
+/// Create an app with a non-existent promoted dir (yields empty strategy list).
+fn test_app() -> App {
+    App::new(
+        "http://localhost:50051".to_owned(),
+        PathBuf::from("/tmp/rara-tui-test-nonexistent"),
+    )
+}
 
 #[test]
 fn app_tab_navigation_clamps_to_valid_range() {
-    let mut app = App::new("http://localhost:50051".to_owned());
+    let mut app = test_app();
     assert_eq!(app.active_tab, 0);
 
     // Navigate to last valid tab
@@ -33,7 +43,7 @@ fn app_tab_navigation_clamps_to_valid_range() {
 
 #[test]
 fn app_quit_sets_running_false() {
-    let mut app = App::new("http://localhost:50051".to_owned());
+    let mut app = test_app();
     assert!(app.running, "app should start in running state");
 
     app.quit();

--- a/src/main.rs
+++ b/src/main.rs
@@ -440,7 +440,9 @@ async fn run() -> error::Result<()> {
             run_serve(port).await?;
         }
         Command::Tui { server } => {
-            rara_tui::event_loop::run(server.as_deref()).await.context(TuiSnafu)?;
+            rara_tui::event_loop::run(server.as_deref(), crate::paths::strategies_promoted_dir())
+                .await
+                .context(TuiSnafu)?;
         }
         Command::Feedback { action } => {
             run_feedback(action)?;


### PR DESCRIPTION
Closes #127

## Summary
- Replace `sample_strategies()` / `sample_evaluations()` with `StrategyRegistry::list_installed()` to display real installed WASM strategies from the promoted directory
- Update `StrategyEntry` fields to match `FetchedStrategy` data model: name, version, api_version, description, wasm_path, file_size, tag, release_version, wasm_url
- Remove evaluation timeline panel (no real data source yet); show strategy detail panel with registry metadata
- Show empty-state message when no strategies are installed
- Add `rara-research` dependency to `rara-tui`; pass `promoted_dir` through `App::new()` and `event_loop::run()`

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test -p rara-tui` passes (2 tests)
- [ ] Manual: run `rara-trading tui` with no installed strategies — verify empty state message
- [ ] Manual: run `rara-trading strategies fetch <name>` then `rara-trading tui` — verify strategy appears in list

🤖 Generated with [Claude Code](https://claude.com/claude-code)