### PR TITLE
fix(server): implement real health probes for system status indicators (#140)

### DIFF
--- a/crates/rara-server/Cargo.toml
+++ b/crates/rara-server/Cargo.toml
@@ -15,6 +15,7 @@ snafu.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 async-stream = "0.3"
+which = "7"
 rara-domain.workspace = true
 rara-event-bus.workspace = true
 

--- a/crates/rara-server/src/health.rs
+++ b/crates/rara-server/src/health.rs
@@ -1,0 +1,101 @@
+//! Lightweight health probes for external service dependencies.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use tokio::net::TcpStream;
+use tracing::debug;
+
+/// Configuration for health probes.
+pub struct HealthConfig {
+    /// `PostgreSQL` connection URL (parsed for host:port TCP probe).
+    pub database_url: String,
+    /// Agent backend command name to look up in PATH.
+    pub llm_backend: String,
+    /// Shared flag set by the WebSocket layer when a connection is active.
+    pub ws_connected: Arc<AtomicBool>,
+}
+
+/// Probe results for a single status poll.
+pub struct HealthStatus {
+    /// Whether the database TCP port is reachable.
+    pub database_connected: bool,
+    /// Whether the WebSocket market-data feed is active.
+    pub websocket_connected: bool,
+    /// Whether the configured LLM backend CLI is found in PATH.
+    pub llm_available: bool,
+}
+
+/// Run all health probes and return aggregated status.
+pub async fn probe(config: &HealthConfig) -> HealthStatus {
+    let database_connected = probe_database(&config.database_url).await;
+    let llm_available = probe_llm(&config.llm_backend);
+    let websocket_connected = config.ws_connected.load(Ordering::Relaxed);
+
+    HealthStatus {
+        database_connected,
+        websocket_connected,
+        llm_available,
+    }
+}
+
+/// TCP connect probe to the `PostgreSQL` host:port extracted from the URL.
+async fn probe_database(url: &str) -> bool {
+    let Some(addr) = parse_pg_host_port(url) else {
+        debug!("failed to parse database URL for health probe");
+        return false;
+    };
+
+    tokio::time::timeout(
+        std::time::Duration::from_millis(500),
+        TcpStream::connect(&addr),
+    )
+    .await
+    .is_ok_and(|r| r.is_ok())
+}
+
+/// Check if the LLM backend command exists in PATH.
+fn probe_llm(backend: &str) -> bool {
+    which::which(backend).is_ok()
+}
+
+/// Extract `host:port` from a `PostgreSQL` URL.
+///
+/// Handles both `postgres://user:pass@host:port/db` and
+/// `postgres://user:pass@host/db` (defaults to port 5432).
+fn parse_pg_host_port(url: &str) -> Option<String> {
+    // Strip scheme
+    let after_scheme = url.split("://").nth(1)?;
+    // Strip userinfo
+    let after_at = after_scheme.rsplit('@').next()?;
+    // Strip database path and query
+    let host_port = after_at.split('/').next()?;
+
+    if host_port.contains(':') {
+        Some(host_port.to_string())
+    } else {
+        Some(format!("{host_port}:5432"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_pg_url_with_port() {
+        let result = parse_pg_host_port("postgres://user:pass@db.example.com:5433/mydb");
+        assert_eq!(result.as_deref(), Some("db.example.com:5433"));
+    }
+
+    #[test]
+    fn parse_pg_url_without_port() {
+        let result = parse_pg_host_port("postgres://user:pass@localhost/mydb");
+        assert_eq!(result.as_deref(), Some("localhost:5432"));
+    }
+
+    #[test]
+    fn parse_pg_url_invalid() {
+        assert!(parse_pg_host_port("not-a-url").is_none());
+    }
+}

--- a/crates/rara-server/src/lib.rs
+++ b/crates/rara-server/src/lib.rs
@@ -3,6 +3,7 @@
 //! Exposes system status and event streaming over gRPC so that the TUI client
 //! can render a live dashboard without direct access to internal state.
 
+pub mod health;
 pub mod service;
 
 /// Generated protobuf types for the rara gRPC service.

--- a/crates/rara-server/src/service.rs
+++ b/crates/rara-server/src/service.rs
@@ -10,6 +10,7 @@ use tracing::info;
 
 use rara_event_bus::bus::EventBus;
 
+use crate::health::{self, HealthConfig};
 use crate::rara_proto::rara_service_server::RaraService;
 use crate::rara_proto::{Empty, EventFilter, EventMessage, SystemStatus};
 
@@ -19,6 +20,8 @@ pub struct RaraServiceImpl {
     start_time: Instant,
     /// Event bus for subscribing to real-time events.
     event_bus: Option<Arc<EventBus>>,
+    /// Health probe configuration (None = legacy scaffold mode, all indicators false).
+    health_config: Option<Arc<HealthConfig>>,
 }
 
 impl RaraServiceImpl {
@@ -28,6 +31,17 @@ impl RaraServiceImpl {
         Self {
             start_time: Instant::now(),
             event_bus: None,
+            health_config: None,
+        }
+    }
+
+    /// Create a new service instance with health probes enabled.
+    #[must_use]
+    pub fn with_health(health_config: HealthConfig) -> Self {
+        Self {
+            start_time: Instant::now(),
+            event_bus: None,
+            health_config: Some(Arc::new(health_config)),
         }
     }
 
@@ -37,7 +51,15 @@ impl RaraServiceImpl {
         Self {
             start_time: Instant::now(),
             event_bus: Some(event_bus),
+            health_config: None,
         }
+    }
+
+    /// Attach health probe configuration to an existing instance.
+    #[must_use]
+    pub fn health(mut self, config: HealthConfig) -> Self {
+        self.health_config = Some(Arc::new(config));
+        self
     }
 }
 
@@ -58,10 +80,18 @@ impl RaraService for RaraServiceImpl {
         let minutes = (uptime.as_secs() % 3600) / 60;
         let seconds = uptime.as_secs() % 60;
 
+        let (database_connected, websocket_connected, llm_available) =
+            if let Some(ref config) = self.health_config {
+                let h = health::probe(config).await;
+                (h.database_connected, h.websocket_connected, h.llm_available)
+            } else {
+                (false, false, false)
+            };
+
         let status = SystemStatus {
-            database_connected: false,
-            websocket_connected: false,
-            llm_available: false,
+            database_connected,
+            websocket_connected,
+            llm_available,
             event_count: 0,
             uptime: format!("{hours:02}:{minutes:02}:{seconds:02}"),
             strategy_count: 0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1231,8 +1231,20 @@ fn run_research_promoted(promoted_dir: Option<String>) -> error::Result<()> {
 
 /// Start the gRPC server on the given port.
 async fn run_serve(port: u16) -> error::Result<()> {
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Arc;
+
+    use rara_server::health::HealthConfig;
     use rara_server::rara_proto::rara_service_server::RaraServiceServer;
     use rara_server::service::RaraServiceImpl;
+
+    let cfg = crate::app_config::load();
+
+    let health_config = HealthConfig {
+        database_url: cfg.database.url.clone(),
+        llm_backend: cfg.agent.backend.clone(),
+        ws_connected: Arc::new(AtomicBool::new(false)),
+    };
 
     let addr = format!("0.0.0.0:{port}")
         .parse::<std::net::SocketAddr>()
@@ -1243,7 +1255,9 @@ async fn run_serve(port: u16) -> error::Result<()> {
     eprintln!("gRPC server listening on {addr}");
 
     tonic::transport::Server::builder()
-        .add_service(RaraServiceServer::new(RaraServiceImpl::new()))
+        .add_service(RaraServiceServer::new(
+            RaraServiceImpl::with_health(health_config),
+        ))
         .serve(addr)
         .await
         .context(GrpcServeSnafu)?;


### PR DESCRIPTION
Closes #140

## Summary

- Add `health.rs` module with real service probes (DB TCP connect, LLM PATH lookup, WS shared flag)
- Pass `AppConfig` to `RaraServiceImpl` in `run_serve` so probes have connection details
- WS stays false in standalone TUI mode (accurate — no market data stream running)

## Result

- **DB dot**: green when PostgreSQL is reachable, red otherwise
- **LLM dot**: green when agent backend CLI (e.g. `claude`) is in PATH
- **WS dot**: tracks shared `AtomicBool` (ready for future market data integration)

## Test plan

- [x] `cargo check` passes
- [x] `cargo test -p rara-server` — 6 tests pass (3 new URL parsing + 3 existing)
- [x] `cargo clippy -- -D warnings` clean
- [ ] Manual: `rara tui` → DB/LLM dots reflect real state