### PR TITLE
feat(daemon): wire research loop into daemon task (#150)

### DIFF
--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -76,6 +76,8 @@ pub struct ResearchConfig {
     pub timeframes: Vec<String>,
     /// Maximum compile retries per hypothesis.
     pub max_compile_retries: u32,
+    /// Delay in seconds between research cycles in daemon mode.
+    pub cycle_delay_secs: u64,
 }
 
 impl Default for ResearchConfig {
@@ -84,6 +86,7 @@ impl Default for ResearchConfig {
             iterations: 5,
             timeframes: vec!["1h".to_string(), "4h".to_string(), "1d".to_string()],
             max_compile_retries: 3,
+            cycle_delay_secs: 30,
         }
     }
 }
@@ -242,6 +245,8 @@ iterations = 5
 timeframes = ["1h", "4h", "1d"]
 # Maximum compile retries per hypothesis before giving up
 max_compile_retries = 3
+# Delay in seconds between research cycles in daemon mode
+cycle_delay_secs = 30
 
 # ─── Feedback Evaluation ─────────────────────────────────────────
 [feedback]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,16 +1,32 @@
 //! Unified daemon orchestrator — runs research, paper trading, feedback, and
 //! gRPC server as concurrent tokio tasks in a single process.
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use chrono::NaiveDate;
+use rust_decimal_macros::dec;
 use snafu::ResultExt;
 use tokio::task::JoinSet;
 use tracing::{error, info};
 
 use crate::accounts_config;
-use crate::error::{self, EventBusSnafu};
+use crate::agent::{CliBackend, CliExecutor};
+use crate::app_config;
+use crate::error::{self, AgentBackendSnafu, EventBusSnafu, MarketStoreSnafu, PromptRendererSnafu, TraceSnafu};
 use crate::event_bus::bus::EventBus;
 use crate::paths;
+use crate::research::barter_backtester::BarterBacktester;
+use crate::research::compiler::StrategyCompiler;
+use crate::research::feedback_gen::FeedbackGenerator;
+use crate::research::hypothesis_gen::HypothesisGenerator;
+use crate::research::prompt_renderer::PromptRenderer;
+use crate::research::research_loop::ResearchLoop;
+use crate::research::strategy_coder::StrategyCoder;
+use crate::research::strategy_store::StrategyStore;
+use crate::research::trace::Trace;
+use crate::research::wasm_executor::WasmExecutor;
+use crate::research::wasm_strategy_manager::WasmStrategyManager;
 
 /// Run the unified daemon: spawn all trading-loop components as concurrent
 /// tokio tasks and wait for shutdown (Ctrl+C) or a fatal task error.
@@ -63,12 +79,12 @@ pub async fn run(iterations: u32, grpc_addr: String) -> error::Result<()> {
     if iterations > 0 {
         let bus = Arc::clone(&event_bus);
         let contract = contract_list.first().cloned().unwrap_or_default();
+        let cfg = app_config::load();
+        let cycle_delay = std::time::Duration::from_secs(cfg.research.cycle_delay_secs);
         tasks.spawn(async move {
-            info!(iterations, contract = %contract, "research loop placeholder — wire up ResearchLoop here");
-            // TODO: build and run ResearchLoop using the same pattern as
-            // `run_research_loop` in main.rs, passing `bus` for event publishing.
-            let _ = bus;
-            Ok::<(), error::AppError>(())
+            info!(iterations, contract = %contract, "research loop starting");
+            let research_loop = build_research_loop(&trace_path, bus).await?;
+            run_research_iterations(&research_loop, iterations, &contract, cycle_delay).await
         });
     }
 
@@ -131,5 +147,128 @@ pub async fn run(iterations: u32, grpc_addr: String) -> error::Result<()> {
     while tasks.join_next().await.is_some() {}
 
     info!("daemon stopped");
+    Ok(())
+}
+
+/// Build a `ResearchLoop` from config, using the daemon's shared event bus
+/// instead of creating a new one.
+async fn build_research_loop(
+    trace_path: &Path,
+    event_bus: Arc<EventBus>,
+) -> error::Result<ResearchLoop> {
+    let template_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("strategies/template");
+    let prompts_dir =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("crates/rara-research/src/prompts");
+
+    let trace = Trace::open(trace_path).context(TraceSnafu)?;
+    let compiler = StrategyCompiler::builder()
+        .template_dir(template_dir)
+        .build();
+    let prompt_renderer =
+        PromptRenderer::load_from_dir(&prompts_dir).context(PromptRendererSnafu)?;
+    let prompt_renderer_for_loop =
+        PromptRenderer::load_from_dir(&prompts_dir).context(PromptRendererSnafu)?;
+    let cfg = app_config::load();
+    let market_store = rara_market_data::store::MarketStore::connect(&cfg.database.url)
+        .await
+        .context(MarketStoreSnafu)?;
+
+    let backtester: Arc<dyn crate::research::backtester::Backtester> =
+        Arc::new(BarterBacktester::builder()
+            .store(market_store)
+            .initial_capital(dec!(10000))
+            .fees_percent(dec!(0.1))
+            .backtest_start(NaiveDate::from_ymd_opt(2020, 1, 1).expect("valid date"))
+            .backtest_end(NaiveDate::from_ymd_opt(2030, 12, 31).expect("valid date"))
+            .build());
+
+    let cli_backend =
+        CliBackend::from_agent_config(&cfg.agent).context(AgentBackendSnafu)?;
+    let llm: Arc<dyn crate::infra::llm::LlmClient> =
+        Arc::new(CliExecutor::new(cli_backend));
+
+    let strategy_db_path = trace_path.join("strategy_db");
+    let artifact_dir = paths::data_dir().join("artifacts");
+    let strategy_store = StrategyStore::open_path(&strategy_db_path, &artifact_dir)
+        .expect("failed to open strategy store");
+
+    let strategy_manager: Arc<dyn crate::research::strategy_manager::StrategyManager> =
+        Arc::new(WasmStrategyManager::builder()
+            .store(strategy_store)
+            .coder(StrategyCoder::new(Arc::clone(&llm)))
+            .compiler(compiler)
+            .executor(WasmExecutor::builder().build())
+            .build());
+
+    let feedback_gen = FeedbackGenerator::new(Arc::clone(&llm), prompt_renderer);
+    let hypothesis_gen = HypothesisGenerator::new(llm);
+
+    Ok(ResearchLoop::builder()
+        .hypothesis_gen(hypothesis_gen)
+        .strategy_manager(strategy_manager)
+        .backtester(backtester)
+        .feedback_gen(feedback_gen)
+        .prompt_renderer(prompt_renderer_for_loop)
+        .trace(trace)
+        .event_bus(event_bus)
+        .generated_dir(paths::strategies_generated_dir())
+        .build())
+}
+
+/// Run N research iterations with a configurable delay between cycles.
+/// Errors from individual iterations are logged but do not abort the loop;
+/// only the final summary is reported.
+async fn run_research_iterations(
+    research_loop: &ResearchLoop,
+    iterations: u32,
+    contract: &str,
+    cycle_delay: std::time::Duration,
+) -> error::Result<()> {
+    let mut accepted_count: u32 = 0;
+    let mut rejected_count: u32 = 0;
+    let mut error_count: u32 = 0;
+
+    for i in 1..=iterations {
+        info!(iteration = i, total = iterations, "research iteration starting");
+        match research_loop.run_iteration(contract).await {
+            Ok(ir) => {
+                if ir.accepted {
+                    accepted_count += 1;
+                } else {
+                    rejected_count += 1;
+                }
+                info!(
+                    iteration = i,
+                    total = iterations,
+                    accepted = ir.accepted,
+                    hypothesis = %ir.hypothesis.text,
+                    "research iteration completed"
+                );
+            }
+            Err(e) => {
+                error_count += 1;
+                error!(
+                    iteration = i,
+                    total = iterations,
+                    error = %e,
+                    "research iteration failed"
+                );
+            }
+        }
+
+        // Delay between cycles to avoid overwhelming external services
+        if i < iterations {
+            tokio::time::sleep(cycle_delay).await;
+        }
+    }
+
+    info!(
+        iterations,
+        accepted = accepted_count,
+        rejected = rejected_count,
+        errors = error_count,
+        "research loop finished"
+    );
+
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Replace the research task placeholder in the daemon with a real `ResearchLoop` instantiation and iteration runner
- Share the daemon's `EventBus` with the research loop so research events flow through the same bus used by other daemon components
- Add `cycle_delay_secs` config field (`ResearchConfig`, default 30s) to control the pause between daemon research cycles

## Changes
- `src/daemon.rs`: Add `build_research_loop()` (mirrors `main.rs` pattern but accepts external `EventBus`) and `run_research_iterations()` (runs N iterations with configurable delay, logs results)
- `src/app_config.rs`: Add `cycle_delay_secs: u64` to `ResearchConfig` struct, default impl, and TOML template

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)