### PR TITLE
feat(engine): publish realized_pnl in TradingOrderFilled events (#151)

### DIFF
--- a/crates/rara-trading-engine/src/broker.rs
+++ b/crates/rara-trading-engine/src/broker.rs
@@ -10,14 +10,25 @@ use rara_domain::contract::Contract;
 use rara_domain::trading::{OrderType, Side, StagedAction};
 
 /// Result of submitting an order to a broker.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Builder)]
 pub struct OrderResult {
     /// Broker-assigned order identifier.
+    #[builder(into)]
     pub order_id: String,
     /// Contract the order targets.
+    #[builder(into)]
     pub contract_id: String,
     /// Current status of the order.
     pub status: OrderStatus,
+    /// Trade direction.
+    pub side: Side,
+    /// Filled quantity.
+    pub quantity: Decimal,
+    /// Execution price.
+    pub price: Decimal,
+    /// Realized `PnL` from closing/reducing a position (zero for new positions).
+    #[builder(default)]
+    pub realized_pnl: Decimal,
 }
 
 /// Lifecycle status of an order.

--- a/crates/rara-trading-engine/src/brokers/ccxt.rs
+++ b/crates/rara-trading-engine/src/brokers/ccxt.rs
@@ -444,11 +444,14 @@ impl Broker for CcxtBroker {
                         .await
                         .map_err(|e| map_ccxt_error(&e))?;
 
-                    OrderResult {
-                        order_id: order.id,
-                        contract_id: action.contract_id.clone(),
-                        status: from_ccxt_order_status(order.status),
-                    }
+                    OrderResult::builder()
+                        .order_id(order.id)
+                        .contract_id(&action.contract_id)
+                        .status(from_ccxt_order_status(order.status))
+                        .side(action.side)
+                        .quantity(order.filled.unwrap_or(action.quantity))
+                        .price(order.average.or(order.price).unwrap_or(Decimal::ZERO))
+                        .build()
                 }
                 ActionType::CancelOrder => {
                     debug!(contract = action.contract_id, "cancelling order");
@@ -458,11 +461,14 @@ impl Broker for CcxtBroker {
                         .await
                         .map_err(|e| map_ccxt_error(&e))?;
 
-                    OrderResult {
-                        order_id: order.id,
-                        contract_id: action.contract_id.clone(),
-                        status: from_ccxt_order_status(order.status),
-                    }
+                    OrderResult::builder()
+                        .order_id(order.id)
+                        .contract_id(&action.contract_id)
+                        .status(from_ccxt_order_status(order.status))
+                        .side(action.side)
+                        .quantity(Decimal::ZERO)
+                        .price(Decimal::ZERO)
+                        .build()
                 }
                 ActionType::ClosePosition => {
                     // Close position by placing an opposite-side market order
@@ -490,11 +496,14 @@ impl Broker for CcxtBroker {
                         .await
                         .map_err(|e| map_ccxt_error(&e))?;
 
-                    OrderResult {
-                        order_id: order.id,
-                        contract_id: action.contract_id.clone(),
-                        status: from_ccxt_order_status(order.status),
-                    }
+                    OrderResult::builder()
+                        .order_id(order.id)
+                        .contract_id(&action.contract_id)
+                        .status(from_ccxt_order_status(order.status))
+                        .side(action.side)
+                        .quantity(order.filled.unwrap_or(action.quantity))
+                        .price(order.average.or(order.price).unwrap_or(Decimal::ZERO))
+                        .build()
                 }
                 ActionType::ModifyOrder => {
                     // ccxt-rust Exchange trait has no edit_order, so cancel + re-place
@@ -518,11 +527,14 @@ impl Broker for CcxtBroker {
                         .await
                         .map_err(|e| map_ccxt_error(&e))?;
 
-                    OrderResult {
-                        order_id: order.id,
-                        contract_id: action.contract_id.clone(),
-                        status: from_ccxt_order_status(order.status),
-                    }
+                    OrderResult::builder()
+                        .order_id(order.id)
+                        .contract_id(&action.contract_id)
+                        .status(from_ccxt_order_status(order.status))
+                        .side(action.side)
+                        .quantity(order.filled.unwrap_or(action.quantity))
+                        .price(order.average.or(order.price).unwrap_or(Decimal::ZERO))
+                        .build()
                 }
             };
 

--- a/crates/rara-trading-engine/src/brokers/paper.rs
+++ b/crates/rara-trading-engine/src/brokers/paper.rs
@@ -20,8 +20,9 @@ use crate::broker_registry::{
 
 /// A paper trading broker that fills every order immediately at a fixed price.
 pub struct PaperBroker {
-    /// Price at which all orders are filled.
-    fill_price: Decimal,
+    /// Price at which all orders are filled; wrapped in a `Mutex` so it can
+    /// be updated between trades (e.g. to simulate changing market prices).
+    fill_price: Mutex<Decimal>,
     /// Internal position state.
     positions: Mutex<Vec<Position>>,
     /// Record of all executions.
@@ -81,16 +82,24 @@ impl PaperBroker {
     /// Create a new paper trading broker that fills at the given price.
     pub fn new(fill_price: Decimal) -> Self {
         Self {
-            fill_price,
+            fill_price: Mutex::new(fill_price),
             positions: Mutex::new(Vec::new()),
             executions: Mutex::new(Vec::new()),
         }
+    }
+
+    /// Update the fill price for subsequent orders.
+    ///
+    /// Useful for simulating price movement between trades in tests.
+    pub async fn set_fill_price(&self, price: Decimal) {
+        *self.fill_price.lock().await = price;
     }
 }
 
 #[async_trait]
 impl Broker for PaperBroker {
     async fn push(&self, actions: &[StagedAction]) -> Result<Vec<OrderResult>, BrokerError> {
+        let fill_price = *self.fill_price.lock().await;
         let mut positions = self.positions.lock().await;
         let mut executions = self.executions.lock().await;
 
@@ -104,29 +113,53 @@ impl Broker for PaperBroker {
                     .contract_id(&action.contract_id)
                     .side(action.side)
                     .quantity(action.quantity)
-                    .price(self.fill_price)
+                    .price(fill_price)
                     .status(OrderStatus::Filled)
                     .filled_at(jiff::Timestamp::now())
                     .build();
                 executions.push(report);
 
-                // Update or create position
+                // Compute realized PnL when reducing or closing a position
+                let mut realized_pnl = Decimal::ZERO;
+
                 let existing = positions
                     .iter_mut()
                     .find(|p| p.contract_id == action.contract_id.as_str());
 
                 if let Some(pos) = existing {
                     match (pos.side, action.side) {
-                        // Same side: increase quantity
+                        // Same side: increase position with weighted average entry price
                         (Side::Buy, Side::Buy) | (Side::Sell, Side::Sell) => {
-                            pos.quantity += action.quantity;
+                            let new_total = pos.quantity + action.quantity;
+                            // Weighted average: (old_qty * old_price + new_qty * new_price) / total
+                            let old_cost = pos.avg_entry_price * pos.quantity;
+                            let new_cost = fill_price * action.quantity;
+                            pos.avg_entry_price = (old_cost + new_cost) / new_total;
+                            pos.quantity = new_total;
                         }
-                        // Opposite side: reduce or flip
+                        // Opposite side: reduce or flip — realize PnL on the closed portion
                         _ => {
+                            let close_qty = action.quantity.min(pos.quantity);
+                            // Long closing: profit when exit > entry
+                            // Short closing: profit when entry > exit (flip sign)
+                            let side_multiplier = match pos.side {
+                                Side::Buy => Decimal::ONE,
+                                Side::Sell => -Decimal::ONE,
+                            };
+                            realized_pnl = (fill_price - pos.avg_entry_price)
+                                * close_qty
+                                * side_multiplier;
+
                             if action.quantity >= pos.quantity {
-                                pos.quantity = action.quantity - pos.quantity;
+                                // Full close or flip: remainder opens a new position
+                                let remainder = action.quantity - pos.quantity;
                                 pos.side = action.side;
+                                pos.quantity = remainder;
+                                if remainder > Decimal::ZERO {
+                                    pos.avg_entry_price = fill_price;
+                                }
                             } else {
+                                // Partial close — entry price stays the same
                                 pos.quantity -= action.quantity;
                             }
                         }
@@ -137,17 +170,21 @@ impl Broker for PaperBroker {
                             .contract_id(&action.contract_id)
                             .side(action.side)
                             .quantity(action.quantity)
-                            .avg_entry_price(self.fill_price)
+                            .avg_entry_price(fill_price)
                             .unrealized_pnl(Decimal::ZERO)
                             .build(),
                     );
                 }
 
-                OrderResult {
-                    order_id,
-                    contract_id: action.contract_id.clone(),
-                    status: OrderStatus::Filled,
-                }
+                OrderResult::builder()
+                    .order_id(&order_id)
+                    .contract_id(&action.contract_id)
+                    .status(OrderStatus::Filled)
+                    .side(action.side)
+                    .quantity(action.quantity)
+                    .price(fill_price)
+                    .realized_pnl(realized_pnl)
+                    .build()
             })
             .collect();
 
@@ -170,5 +207,110 @@ impl Broker for PaperBroker {
             .positions(positions)
             .realized_pnl(Decimal::ZERO)
             .build())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rust_decimal_macros::dec;
+
+    use rara_domain::trading::{ActionType, OrderType, Side, StagedAction};
+
+    use super::*;
+
+    fn buy(contract: &str, qty: Decimal) -> StagedAction {
+        StagedAction::builder()
+            .action_type(ActionType::PlaceOrder)
+            .contract_id(contract)
+            .side(Side::Buy)
+            .quantity(qty)
+            .order_type(OrderType::Market)
+            .build()
+    }
+
+    fn sell(contract: &str, qty: Decimal) -> StagedAction {
+        StagedAction::builder()
+            .action_type(ActionType::PlaceOrder)
+            .contract_id(contract)
+            .side(Side::Sell)
+            .quantity(qty)
+            .order_type(OrderType::Market)
+            .build()
+    }
+
+    #[tokio::test]
+    async fn realized_pnl_zero_for_new_position() {
+        let broker = PaperBroker::new(dec!(100));
+        let results = broker.push(&[buy("BTC", dec!(1))]).await.unwrap();
+        assert_eq!(results[0].realized_pnl, dec!(0));
+    }
+
+    #[tokio::test]
+    async fn realized_pnl_long_profit() {
+        // Buy at 100, sell at 150 => PnL = (150 - 100) * 2 = 100
+        let broker = PaperBroker::new(dec!(100));
+        broker.push(&[buy("BTC", dec!(2))]).await.unwrap();
+
+        broker.set_fill_price(dec!(150)).await;
+        let results = broker.push(&[sell("BTC", dec!(2))]).await.unwrap();
+        assert_eq!(results[0].realized_pnl, dec!(100));
+    }
+
+    #[tokio::test]
+    async fn realized_pnl_long_loss() {
+        // Buy at 100, sell at 80 => PnL = (80 - 100) * 3 = -60
+        let broker = PaperBroker::new(dec!(100));
+        broker.push(&[buy("BTC", dec!(3))]).await.unwrap();
+
+        broker.set_fill_price(dec!(80)).await;
+        let results = broker.push(&[sell("BTC", dec!(3))]).await.unwrap();
+        assert_eq!(results[0].realized_pnl, dec!(-60));
+    }
+
+    #[tokio::test]
+    async fn realized_pnl_short_profit() {
+        // Sell (open short) at 200, buy (close short) at 150
+        // PnL = (150 - 200) * 1 * (-1) = 50
+        let broker = PaperBroker::new(dec!(200));
+        broker.push(&[sell("BTC", dec!(1))]).await.unwrap();
+
+        broker.set_fill_price(dec!(150)).await;
+        let results = broker.push(&[buy("BTC", dec!(1))]).await.unwrap();
+        assert_eq!(results[0].realized_pnl, dec!(50));
+    }
+
+    #[tokio::test]
+    async fn realized_pnl_partial_close() {
+        // Buy 4 at 100, sell 1 at 120 => PnL = (120 - 100) * 1 = 20
+        // Remaining position: 3 at avg_entry 100
+        let broker = PaperBroker::new(dec!(100));
+        broker.push(&[buy("BTC", dec!(4))]).await.unwrap();
+
+        broker.set_fill_price(dec!(120)).await;
+        let results = broker.push(&[sell("BTC", dec!(1))]).await.unwrap();
+        assert_eq!(results[0].realized_pnl, dec!(20));
+
+        let pos = broker.positions().await.unwrap();
+        assert_eq!(pos[0].quantity, dec!(3));
+        assert_eq!(pos[0].avg_entry_price, dec!(100));
+    }
+
+    #[tokio::test]
+    async fn weighted_avg_entry_on_same_side_add() {
+        // Buy 2 at 100, buy 1 at 130 => avg = (200 + 130) / 3 = 110
+        let broker = PaperBroker::new(dec!(100));
+        broker.push(&[buy("BTC", dec!(2))]).await.unwrap();
+
+        broker.set_fill_price(dec!(130)).await;
+        broker.push(&[buy("BTC", dec!(1))]).await.unwrap();
+
+        let pos = broker.positions().await.unwrap();
+        assert_eq!(pos[0].avg_entry_price, dec!(110));
+        assert_eq!(pos[0].quantity, dec!(3));
+
+        // Now sell all at 120 => PnL = (120 - 110) * 3 = 30
+        broker.set_fill_price(dec!(120)).await;
+        let results = broker.push(&[sell("BTC", dec!(3))]).await.unwrap();
+        assert_eq!(results[0].realized_pnl, dec!(30));
     }
 }

--- a/crates/rara-trading-engine/src/engine.rs
+++ b/crates/rara-trading-engine/src/engine.rs
@@ -29,6 +29,14 @@ struct OrderOutcomePayload<'a> {
     contract_id: &'a str,
     /// Order status.
     status: &'a OrderStatus,
+    /// Trade direction.
+    side: &'a Side,
+    /// Filled quantity as decimal string.
+    quantity: String,
+    /// Execution price as decimal string.
+    price: String,
+    /// Realized `PnL` as decimal string (zero for new positions).
+    realized_pnl: String,
 }
 use rara_event_bus::bus::EventBus;
 use crate::binding::StrategyBinding;
@@ -159,6 +167,10 @@ impl TradingEngine {
                         order_id: &result.order_id,
                         contract_id: &result.contract_id,
                         status: &result.status,
+                        side: &result.side,
+                        quantity: result.quantity.to_string(),
+                        price: result.price.to_string(),
+                        realized_pnl: result.realized_pnl.to_string(),
                     })
                     .expect("OrderOutcomePayload must serialize"),
                 )


### PR DESCRIPTION
## Summary
- **PaperBroker** now computes `realized_pnl` when reducing/closing positions using weighted average entry price tracking
- **OrderResult** extended with `side`, `quantity`, `price`, `realized_pnl` fields (with `bon::Builder`)
- **OrderOutcomePayload** (engine event publisher) includes all new fields in `TradingOrderFilled` events
- **CcxtBroker** updated to populate new OrderResult fields from exchange order responses
- **FeedbackConsumer** already parses `realized_pnl` from event payload — no changes needed

## PnL Logic
- Same-side additions: weighted average entry price update
- Opposite-side (close/reduce): `realized_pnl = (exit_price - avg_entry_price) * close_qty * side_multiplier`
- Position flip: realizes PnL on closed portion, opens remainder at new price

## Test plan
- [x] 6 new unit tests for PnL computation: new position (zero PnL), long profit, long loss, short profit, partial close, weighted average entry
- [x] All 11 existing tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)