### PR TITLE
feat(sentinel): wire sentinel engine into daemon event bus (#161)

### DIFF
--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -128,8 +128,23 @@ impl Default for FeedbackConfig {
 pub struct SentinelConfig {
     /// Whether sentinel monitoring is enabled.
     pub enabled: bool,
-    /// Interval in seconds between health checks.
+    /// Interval in seconds between sentinel poll cycles.
     pub check_interval_secs: u64,
+    /// RSS/Atom feed URLs to monitor for market-moving news.
+    pub rss_feeds: Vec<RssFeedEntry>,
+    /// Whether the trump-code political signal source is enabled.
+    pub trump_code_enabled: bool,
+    /// Base URL of the trump-code API service.
+    pub trump_code_url: String,
+}
+
+/// A single RSS/Atom feed entry for sentinel monitoring.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RssFeedEntry {
+    /// Human-readable name for this feed.
+    pub name: String,
+    /// URL of the RSS/Atom feed.
+    pub url: String,
 }
 
 impl Default for SentinelConfig {
@@ -137,6 +152,9 @@ impl Default for SentinelConfig {
         Self {
             enabled: false,
             check_interval_secs: 30,
+            rss_feeds: Vec::new(),
+            trump_code_enabled: false,
+            trump_code_url: "https://trumpcode.washinmura.jp".to_string(),
         }
     }
 }
@@ -271,10 +289,18 @@ min_trades_between_evals = 100
 
 # ─── Sentinel Monitoring ─────────────────────────────────────────
 [sentinel]
-# Enable or disable sentinel health monitoring
+# Enable or disable sentinel monitoring
 enabled = false
-# Interval in seconds between health checks
+# Interval in seconds between sentinel poll cycles
 check_interval_secs = 30
+# RSS/Atom feeds to monitor (array of {name, url} tables)
+# [[sentinel.rss_feeds]]
+# name = "coindesk"
+# url = "https://www.coindesk.com/arc/outboundfeeds/rss/"
+# Enable trump-code political signal source
+trump_code_enabled = false
+# Base URL of the trump-code API
+trump_code_url = "https://trumpcode.washinmura.jp"
 
 # ─── gRPC Server ─────────────────────────────────────────────────
 [server]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -29,6 +29,13 @@ use crate::research::wasm_executor::WasmExecutor;
 use crate::research::wasm_strategy_manager::WasmStrategyManager;
 
 use rara_domain::event::EventType;
+use rara_sentinel::analyzer::SignalAnalyzer;
+use rara_sentinel::engine::SentinelEngine;
+use rara_sentinel::source::DataSource;
+use rara_sentinel::sources::rss::RssDataSource;
+use rara_sentinel::sources::trump_code::TrumpCodeDataSource;
+
+use crate::app_config::SentinelConfig;
 
 /// Run the unified daemon: spawn all trading-loop components as concurrent
 /// tokio tasks and wait for shutdown (Ctrl+C) or a fatal task error.
@@ -119,6 +126,9 @@ pub async fn run(iterations: u32, grpc_addr: String) -> error::Result<()> {
             Ok::<(), error::AppError>(())
         });
     }
+
+    // --- Sentinel monitoring task ---
+    spawn_sentinel_task(&mut tasks, &event_bus);
 
     info!("daemon running — press Ctrl+C to shut down");
 
@@ -367,6 +377,105 @@ fn has_pending_retrain_events(event_bus: &EventBus) -> bool {
         .any(|e| e.event_type == EventType::FeedbackResearchRetrainRequested)
 }
 
+
+/// Spawn the sentinel monitoring task if enabled in config.
+///
+/// When enabled, creates a polling loop that periodically checks all
+/// configured data sources (RSS feeds, trump-code) for market-moving
+/// signals using LLM analysis, publishing detected signals to the event bus.
+fn spawn_sentinel_task(tasks: &mut JoinSet<error::Result<()>>, event_bus: &Arc<EventBus>) {
+    let sentinel_cfg = app_config::load().sentinel.clone();
+    if !sentinel_cfg.enabled {
+        info!("sentinel monitoring disabled — skipping");
+        return;
+    }
+
+    let bus = Arc::clone(event_bus);
+    let cfg = app_config::load();
+    tasks.spawn(async move {
+        info!("sentinel monitoring starting");
+        let cli_backend =
+            CliBackend::from_agent_config(&cfg.agent).context(AgentBackendSnafu)?;
+        let llm = CliExecutor::new(cli_backend);
+        let sources = build_sentinel_sources(&sentinel_cfg);
+        let analyzer = SignalAnalyzer::new(llm);
+        let engine = SentinelEngine::new(sources, analyzer, Arc::clone(&bus));
+        let interval = std::time::Duration::from_secs(sentinel_cfg.check_interval_secs);
+        run_sentinel_loop(&engine, interval).await;
+        Ok::<(), error::AppError>(())
+    });
+}
+
+/// Build data sources from sentinel configuration.
+///
+/// Creates RSS feed sources and optionally the trump-code source based on
+/// the config. Returns an empty vec if no sources are configured.
+fn build_sentinel_sources(cfg: &SentinelConfig) -> Vec<Box<dyn DataSource>> {
+    let client = reqwest::Client::new();
+    let mut sources: Vec<Box<dyn DataSource>> = cfg
+        .rss_feeds
+        .iter()
+        .map(|feed| -> Box<dyn DataSource> {
+            Box::new(
+                RssDataSource::builder()
+                    .name(feed.name.clone())
+                    .url(feed.url.clone())
+                    .client(client.clone())
+                    .build(),
+            )
+        })
+        .collect();
+
+    if cfg.trump_code_enabled {
+        sources.push(Box::new(
+            TrumpCodeDataSource::builder()
+                .base_url(cfg.trump_code_url.clone())
+                .client(client)
+                .build(),
+        ));
+    }
+
+    sources
+}
+
+/// Run the sentinel engine in a polling loop.
+///
+/// Each cycle polls all data sources and analyzes signals via LLM.
+/// Errors are logged but never crash the daemon — sentinel is a monitoring
+/// component that must not take down the trading system.
+async fn run_sentinel_loop<L: rara_infra::llm::LlmClient>(
+    engine: &SentinelEngine<L>,
+    interval: std::time::Duration,
+) {
+    loop {
+        match engine.poll_and_analyze().await {
+            Ok(signals) => {
+                if signals.is_empty() {
+                    info!("sentinel poll complete — no actionable signals");
+                } else {
+                    info!(
+                        count = signals.len(),
+                        "sentinel poll complete — published signals to event bus"
+                    );
+                    for signal in &signals {
+                        info!(
+                            signal_type = %signal.signal_type,
+                            severity = %signal.severity,
+                            contracts = ?signal.affected_contracts,
+                            "sentinel signal detected"
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                // Log and continue — sentinel errors must never crash the daemon
+                error!(error = %e, "sentinel poll failed — will retry next cycle");
+            }
+        }
+
+        tokio::time::sleep(interval).await;
+    }
+}
 
 /// Build a [`StrategyEvaluator`](rara_feedback::evaluator::StrategyEvaluator)
 /// from the application's feedback configuration.

--- a/src/error.rs
+++ b/src/error.rs
@@ -77,6 +77,11 @@ pub enum AppError {
     BrokerRegistry {
         source: rara_trading_engine::broker_registry::BrokerRegistryError,
     },
+
+    #[snafu(display("sentinel error: {source}"))]
+    Sentinel {
+        source: rara_sentinel::engine::SentinelError,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, AppError>;


### PR DESCRIPTION
## Summary
- Wire `SentinelEngine` as a concurrent task in the daemon, polling configured data sources (RSS feeds, trump-code API) on a timer and publishing `SentinelSignalDetected` events to the shared event bus
- Extend `SentinelConfig` with `rss_feeds`, `trump_code_enabled`, and `trump_code_url` fields (backward-compatible defaults)
- Sentinel errors are logged but never crash the daemon — monitoring must not take down the trading system

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` — all 7 e2e + unit tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] CI green

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)