### PR TITLE
feat(daemon): wire candle aggregator into paper trading task (#159)

### DIFF
--- a/crates/rara-agent/src/backend.rs
+++ b/crates/rara-agent/src/backend.rs
@@ -27,7 +27,8 @@ pub enum OutputFormat {
     /// Plain text output (default for most adapters).
     #[default]
     Text,
-    /// Newline-delimited JSON stream (Claude with `--output-format stream-json`).
+    /// Newline-delimited JSON stream (Claude with `--output-format
+    /// stream-json`).
     StreamJson,
     /// Newline-delimited JSON stream (Pi with `--mode json`).
     PiStreamJson,
@@ -67,13 +68,13 @@ pub enum PromptMode {
 /// the underlying file.
 pub struct CommandSpec {
     /// The command binary to execute.
-    pub command: String,
+    pub command:     String,
     /// Fully resolved argument list (includes prompt).
-    pub args: Vec<String>,
+    pub args:        Vec<String>,
     /// If set, this string should be written to the child's stdin.
     pub stdin_input: Option<String>,
     /// Temp file handle — kept alive so the agent can read from it.
-    _temp_file: Option<NamedTempFile>,
+    _temp_file:      Option<NamedTempFile>,
 }
 
 /// A CLI backend configuration for executing prompts.
@@ -86,17 +87,17 @@ pub struct CommandSpec {
 #[derive(Debug, Clone)]
 pub struct CliBackend {
     /// The command to execute.
-    pub command: String,
+    pub command:       String,
     /// Additional arguments before the prompt.
-    pub args: Vec<String>,
+    pub args:          Vec<String>,
     /// How to pass the prompt.
-    pub prompt_mode: PromptMode,
+    pub prompt_mode:   PromptMode,
     /// Argument flag for prompt (if `prompt_mode` is `Arg`).
-    pub prompt_flag: Option<String>,
+    pub prompt_flag:   Option<String>,
     /// Output format emitted by this backend.
     pub output_format: OutputFormat,
     /// Environment variables to set when spawning the process.
-    pub env_vars: Vec<(String, String)>,
+    pub env_vars:      Vec<(String, String)>,
 }
 
 impl CliBackend {
@@ -135,20 +136,21 @@ impl CliBackend {
     /// in non-interactive mode where it executes the prompt and exits.
     ///
     /// Emits `--output-format stream-json` for NDJSON streaming output.
-    /// Note: `--verbose` is required when using `--output-format stream-json` with `-p`.
+    /// Note: `--verbose` is required when using `--output-format stream-json`
+    /// with `-p`.
     pub fn claude() -> Self {
         Self {
-            command: "claude".to_string(),
-            args: vec![
+            command:       "claude".to_string(),
+            args:          vec![
                 "--dangerously-skip-permissions".to_string(),
                 "--verbose".to_string(),
                 "--output-format".to_string(),
                 "stream-json".to_string(),
             ],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: Some("-p".to_string()),
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   Some("-p".to_string()),
             output_format: OutputFormat::StreamJson,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -157,12 +159,12 @@ impl CliBackend {
     /// Runs Claude without `-p` flag, passing prompt as a positional argument.
     pub fn claude_interactive() -> Self {
         Self {
-            command: "claude".to_string(),
-            args: vec!["--dangerously-skip-permissions".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "claude".to_string(),
+            args:          vec!["--dangerously-skip-permissions".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -172,12 +174,12 @@ impl CliBackend {
     /// `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` env var.
     pub fn claude_interactive_teams() -> Self {
         Self {
-            command: "claude".to_string(),
-            args: vec!["--dangerously-skip-permissions".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "claude".to_string(),
+            args:          vec!["--dangerously-skip-permissions".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![(
+            env_vars:      vec![(
                 "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS".to_string(),
                 "1".to_string(),
             )],
@@ -189,16 +191,16 @@ impl CliBackend {
     /// Uses `kiro-cli` in headless mode with all tools trusted.
     pub fn kiro() -> Self {
         Self {
-            command: "kiro-cli".to_string(),
-            args: vec![
+            command:       "kiro-cli".to_string(),
+            args:          vec![
                 "chat".to_string(),
                 "--no-interactive".to_string(),
                 "--trust-all-tools".to_string(),
             ],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -207,18 +209,18 @@ impl CliBackend {
     /// Uses `kiro-cli` with `--agent` flag to select a specific agent.
     pub fn kiro_with_agent(agent: String, extra_args: &[String]) -> Self {
         let mut backend = Self {
-            command: "kiro-cli".to_string(),
-            args: vec![
+            command:       "kiro-cli".to_string(),
+            args:          vec![
                 "chat".to_string(),
                 "--no-interactive".to_string(),
                 "--trust-all-tools".to_string(),
                 "--agent".to_string(),
                 agent,
             ],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         };
         backend.args.extend(extra_args.iter().cloned());
         backend
@@ -228,9 +230,7 @@ impl CliBackend {
     ///
     /// Uses `kiro-cli` with the ACP subcommand for structured JSON-RPC
     /// communication over stdio instead of PTY text scraping.
-    pub fn kiro_acp() -> Self {
-        Self::kiro_acp_with_options(None, None)
-    }
+    pub fn kiro_acp() -> Self { Self::kiro_acp_with_options(None, None) }
 
     /// Creates the Kiro ACP backend with an optional agent and/or model.
     pub fn kiro_acp_with_options(agent: Option<&str>, model: Option<&str>) -> Self {
@@ -256,39 +256,40 @@ impl CliBackend {
     /// Creates the Gemini backend.
     pub fn gemini() -> Self {
         Self {
-            command: "gemini".to_string(),
-            args: vec!["--yolo".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: Some("-p".to_string()),
+            command:       "gemini".to_string(),
+            args:          vec!["--yolo".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   Some("-p".to_string()),
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
     /// Gemini in interactive mode with initial prompt (uses `-i`, not `-p`).
     ///
-    /// **Critical quirk**: Gemini requires `-i` flag for interactive+prompt mode.
-    /// Using `-p` would make it run headless and exit after one response.
+    /// **Critical quirk**: Gemini requires `-i` flag for interactive+prompt
+    /// mode. Using `-p` would make it run headless and exit after one
+    /// response.
     pub fn gemini_interactive() -> Self {
         Self {
-            command: "gemini".to_string(),
-            args: vec!["--yolo".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: Some("-i".to_string()),
+            command:       "gemini".to_string(),
+            args:          vec!["--yolo".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   Some("-i".to_string()),
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
     /// Creates the Codex backend.
     pub fn codex() -> Self {
         Self {
-            command: "codex".to_string(),
-            args: vec!["exec".to_string(), "--yolo".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "codex".to_string(),
+            args:          vec!["exec".to_string(), "--yolo".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -298,24 +299,24 @@ impl CliBackend {
     /// flags, allowing interactive TUI mode.
     pub fn codex_interactive() -> Self {
         Self {
-            command: "codex".to_string(),
-            args: vec![],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "codex".to_string(),
+            args:          vec![],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
     /// Creates the Amp backend.
     pub fn amp() -> Self {
         Self {
-            command: "amp".to_string(),
-            args: vec!["--dangerously-allow-all".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: Some("-x".to_string()),
+            command:       "amp".to_string(),
+            args:          vec!["--dangerously-allow-all".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   Some("-x".to_string()),
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -325,26 +326,27 @@ impl CliBackend {
     /// requiring user confirmation for tool usage.
     pub fn amp_interactive() -> Self {
         Self {
-            command: "amp".to_string(),
-            args: vec![],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: Some("-x".to_string()),
+            command:       "amp".to_string(),
+            args:          vec![],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   Some("-x".to_string()),
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
     /// Creates the Copilot backend for autonomous mode.
     ///
-    /// Uses GitHub Copilot CLI with `--allow-all-tools` for automated tool approval.
+    /// Uses GitHub Copilot CLI with `--allow-all-tools` for automated tool
+    /// approval.
     pub fn copilot() -> Self {
         Self {
-            command: "copilot".to_string(),
-            args: vec!["--allow-all-tools".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: Some("-p".to_string()),
+            command:       "copilot".to_string(),
+            args:          vec!["--allow-all-tools".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   Some("-p".to_string()),
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -354,12 +356,12 @@ impl CliBackend {
     /// requiring user confirmation for tool usage.
     pub fn copilot_interactive() -> Self {
         Self {
-            command: "copilot".to_string(),
-            args: vec![],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: Some("-p".to_string()),
+            command:       "copilot".to_string(),
+            args:          vec![],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   Some("-p".to_string()),
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -369,12 +371,12 @@ impl CliBackend {
     /// Copilot's native TUI to render.
     pub fn copilot_tui() -> Self {
         Self {
-            command: "copilot".to_string(),
-            args: vec![],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "copilot".to_string(),
+            args:          vec![],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -384,12 +386,12 @@ impl CliBackend {
     /// positional argument after the subcommand.
     pub fn opencode() -> Self {
         Self {
-            command: "opencode".to_string(),
-            args: vec!["run".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "opencode".to_string(),
+            args:          vec!["run".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -400,12 +402,12 @@ impl CliBackend {
     /// this launches the interactive TUI and injects the prompt.
     pub fn opencode_interactive() -> Self {
         Self {
-            command: "opencode".to_string(),
-            args: vec![],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: Some("--prompt".to_string()),
+            command:       "opencode".to_string(),
+            args:          vec![],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   Some("--prompt".to_string()),
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -415,17 +417,17 @@ impl CliBackend {
     /// Emits `PiStreamJson` output format for structured event parsing.
     pub fn pi() -> Self {
         Self {
-            command: "pi".to_string(),
-            args: vec![
+            command:       "pi".to_string(),
+            args:          vec![
                 "-p".to_string(),
                 "--mode".to_string(),
                 "json".to_string(),
                 "--no-session".to_string(),
             ],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::PiStreamJson,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -435,12 +437,12 @@ impl CliBackend {
     /// positional argument.
     pub fn pi_interactive() -> Self {
         Self {
-            command: "pi".to_string(),
-            args: vec!["--no-session".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "pi".to_string(),
+            args:          vec!["--no-session".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -451,12 +453,12 @@ impl CliBackend {
     /// `build_command()`).
     pub fn roo() -> Self {
         Self {
-            command: "roo".to_string(),
-            args: vec!["--print".to_string(), "--ephemeral".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "roo".to_string(),
+            args:          vec!["--print".to_string(), "--ephemeral".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -466,19 +468,20 @@ impl CliBackend {
     /// as a positional argument.
     pub fn roo_interactive() -> Self {
         Self {
-            command: "roo".to_string(),
-            args: vec![],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "roo".to_string(),
+            args:          vec![],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
     /// Creates a custom backend from configuration.
     ///
     /// # Errors
-    /// Returns [`BackendError::CustomBackendRequiresCommand`] if no command is specified.
+    /// Returns [`BackendError::CustomBackendRequiresCommand`] if no command is
+    /// specified.
     pub fn custom(config: &AgentConfig) -> Result<Self> {
         let command = config
             .command
@@ -526,10 +529,7 @@ impl CliBackend {
     ///
     /// # Errors
     /// Returns error if the backend name is invalid.
-    pub fn from_name_with_args(
-        name: &str,
-        extra_args: &[String],
-    ) -> Result<Self> {
+    pub fn from_name_with_args(name: &str, extra_args: &[String]) -> Result<Self> {
         let mut backend = Self::from_name(name)?;
         backend.args.extend(extra_args.iter().cloned());
         if backend.command == "codex" {
@@ -544,7 +544,8 @@ impl CliBackend {
     /// session with an initial prompt.
     ///
     /// # Errors
-    /// Returns [`BackendError::UnknownBackend`] if the backend name is not recognized.
+    /// Returns [`BackendError::UnknownBackend`] if the backend name is not
+    /// recognized.
     pub fn for_interactive_prompt(backend_name: &str) -> Result<Self> {
         match backend_name {
             "claude" => Ok(Self::claude_interactive()),
@@ -569,12 +570,12 @@ impl CliBackend {
     /// Kiro's TUI while still passing an initial prompt.
     pub fn kiro_interactive() -> Self {
         Self {
-            command: "kiro-cli".to_string(),
-            args: vec!["chat".to_string(), "--trust-all-tools".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "kiro-cli".to_string(),
+            args:          vec!["chat".to_string(), "--trust-all-tools".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         }
     }
 
@@ -622,7 +623,8 @@ impl CliBackend {
             args = self.filter_args_for_interactive(args);
         }
 
-        // Handle prompt passing: Roo uses --prompt-file, all others use temp file for large prompts
+        // Handle prompt passing: Roo uses --prompt-file, all others use temp file for
+        // large prompts
         let (stdin_input, temp_file) = match self.prompt_mode {
             PromptMode::Arg => {
                 // Roo headless: always use --prompt-file for all prompts
@@ -633,16 +635,12 @@ impl CliBackend {
                         match NamedTempFile::new() {
                             Ok(mut file) => {
                                 if let Err(e) = file.write_all(prompt.as_bytes()) {
-                                    tracing::warn!(
-                                        "Failed to write prompt to temp file: {e}"
-                                    );
+                                    tracing::warn!("Failed to write prompt to temp file: {e}");
                                     (prompt.to_string(), None)
                                 } else {
                                     let path = file.path().display().to_string();
                                     (
-                                        format!(
-                                            "Please read and execute the task in {path}"
-                                        ),
+                                        format!("Please read and execute the task in {path}"),
                                         Some(file),
                                     )
                                 }

--- a/crates/rara-agent/src/config.rs
+++ b/crates/rara-agent/src/config.rs
@@ -53,7 +53,5 @@ pub struct AgentConfig {
 }
 
 impl Default for AgentConfig {
-    fn default() -> Self {
-        Self::builder().build()
-    }
+    fn default() -> Self { Self::builder().build() }
 }

--- a/crates/rara-agent/src/executor.rs
+++ b/crates/rara-agent/src/executor.rs
@@ -4,16 +4,16 @@
 //! Supports optional execution timeout with graceful SIGTERM termination.
 //! Ported from ralph-orchestrator.
 
-use std::io::Write;
-use std::process::Stdio;
-use std::time::Duration;
+use std::{io::Write, process::Stdio, time::Duration};
 
 #[cfg(unix)]
 use nix::sys::signal::{Signal, kill};
 #[cfg(unix)]
 use nix::unistd::Pid;
-use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWriteExt, BufReader};
-use tokio::process::Command;
+use tokio::{
+    io::{AsyncBufReadExt, AsyncRead, AsyncWriteExt, BufReader},
+    process::Command,
+};
 use tracing::{debug, warn};
 
 use crate::backend::{CliBackend, CommandSpec};
@@ -22,11 +22,11 @@ use crate::backend::{CliBackend, CommandSpec};
 #[derive(Debug)]
 pub struct ExecutionResult {
     /// The full stdout output from the CLI.
-    pub output: String,
+    pub output:    String,
     /// Captured stderr output (separate from stdout).
-    pub stderr: String,
+    pub stderr:    String,
     /// Whether the execution succeeded (exit code 0).
-    pub success: bool,
+    pub success:   bool,
     /// The exit code.
     pub exit_code: Option<i32>,
     /// Whether the execution was terminated due to timeout.
@@ -61,19 +61,18 @@ enum StreamKind {
 
 impl CliExecutor {
     /// Creates a new executor with the given backend.
-    pub const fn new(backend: CliBackend) -> Self {
-        Self { backend }
-    }
+    pub const fn new(backend: CliBackend) -> Self { Self { backend } }
 
     /// Executes a prompt and streams output to the provided writer.
     ///
     /// Output is streamed line-by-line to the writer while being accumulated
-    /// for the return value. If `timeout` is provided and the execution produces
-    /// no stdout/stderr activity for longer than that duration, the process
-    /// is terminated and the result indicates timeout.
+    /// for the return value. If `timeout` is provided and the execution
+    /// produces no stdout/stderr activity for longer than that duration,
+    /// the process is terminated and the result indicates timeout.
     ///
-    /// When `verbose` is true, stderr output is also written to the output writer
-    /// with a `[stderr]` prefix. When false, stderr is captured but not displayed.
+    /// When `verbose` is true, stderr output is also written to the output
+    /// writer with a `[stderr]` prefix. When false, stderr is captured but
+    /// not displayed.
     pub async fn execute<W: Write + Send>(
         &self,
         prompt: &str,
@@ -92,8 +91,9 @@ impl CliExecutor {
             drop(stdin);
         }
 
-        let (accumulated_output, accumulated_stderr, timed_out) =
-            self.read_output(&mut child, &mut output_writer, timeout, verbose).await?;
+        let (accumulated_output, accumulated_stderr, timed_out) = self
+            .read_output(&mut child, &mut output_writer, timeout, verbose)
+            .await?;
 
         let status = child.wait().await?;
 
@@ -235,9 +235,7 @@ impl CliExecutor {
 
     /// Terminates the child process via `start_kill()` (non-Unix).
     #[cfg(not(unix))]
-    fn terminate_child(child: &mut tokio::process::Child) {
-        let _ = child.start_kill();
-    }
+    fn terminate_child(child: &mut tokio::process::Child) { let _ = child.start_kill(); }
 
     /// Executes a prompt without streaming (captures all output).
     ///
@@ -299,12 +297,12 @@ mod tests {
     #[tokio::test]
     async fn test_execute_echo() {
         let backend = CliBackend {
-            command: "echo".to_string(),
-            args: vec![],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "echo".to_string(),
+            args:          vec![],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         };
 
         let executor = CliExecutor::new(backend);
@@ -323,12 +321,12 @@ mod tests {
     #[tokio::test]
     async fn test_execute_stdin() {
         let backend = CliBackend {
-            command: "cat".to_string(),
-            args: vec![],
-            prompt_mode: PromptMode::Stdin,
-            prompt_flag: None,
+            command:       "cat".to_string(),
+            args:          vec![],
+            prompt_mode:   PromptMode::Stdin,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         };
 
         let executor = CliExecutor::new(backend);
@@ -341,12 +339,12 @@ mod tests {
     #[tokio::test]
     async fn test_execute_failure() {
         let backend = CliBackend {
-            command: "false".to_string(),
-            args: vec![],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "false".to_string(),
+            args:          vec![],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         };
 
         let executor = CliExecutor::new(backend);
@@ -360,12 +358,12 @@ mod tests {
     #[tokio::test]
     async fn test_execute_timeout() {
         let backend = CliBackend {
-            command: "sleep".to_string(),
-            args: vec!["10".to_string()],
-            prompt_mode: PromptMode::Stdin,
-            prompt_flag: None,
+            command:       "sleep".to_string(),
+            args:          vec!["10".to_string()],
+            prompt_mode:   PromptMode::Stdin,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         };
 
         let executor = CliExecutor::new(backend);
@@ -385,12 +383,12 @@ mod tests {
     #[tokio::test]
     async fn test_execute_timeout_resets_on_output_activity() {
         let backend = CliBackend {
-            command: "sh".to_string(),
-            args: vec!["-c".to_string()],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "sh".to_string(),
+            args:          vec!["-c".to_string()],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         };
 
         let executor = CliExecutor::new(backend);
@@ -416,12 +414,12 @@ mod tests {
     #[tokio::test]
     async fn test_execute_streams_output_before_inactivity_timeout() {
         let backend = CliBackend {
-            command: "sh".to_string(),
-            args: vec!["-c".to_string(), "printf 'hello\\n'; sleep 10".to_string()],
-            prompt_mode: PromptMode::Stdin,
-            prompt_flag: None,
+            command:       "sh".to_string(),
+            args:          vec!["-c".to_string(), "printf 'hello\\n'; sleep 10".to_string()],
+            prompt_mode:   PromptMode::Stdin,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         };
 
         let executor = CliExecutor::new(backend);
@@ -442,12 +440,12 @@ mod tests {
     #[tokio::test]
     async fn test_execute_no_timeout_when_fast() {
         let backend = CliBackend {
-            command: "echo".to_string(),
-            args: vec![],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "echo".to_string(),
+            args:          vec![],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         };
 
         let executor = CliExecutor::new(backend);
@@ -465,15 +463,15 @@ mod tests {
     #[tokio::test]
     async fn test_stderr_not_mixed_into_output() {
         let backend = CliBackend {
-            command: "sh".to_string(),
-            args: vec![
+            command:       "sh".to_string(),
+            args:          vec![
                 "-c".to_string(),
                 "echo stdout_line; echo stderr_line >&2".to_string(),
             ],
-            prompt_mode: PromptMode::Stdin,
-            prompt_flag: None,
+            prompt_mode:   PromptMode::Stdin,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         };
 
         let executor = CliExecutor::new(backend);

--- a/crates/rara-agent/src/llm_impl.rs
+++ b/crates/rara-agent/src/llm_impl.rs
@@ -1,7 +1,6 @@
 //! `LlmClient` implementation for `CliExecutor`.
 
 use async_trait::async_trait;
-
 use rara_infra::llm::{LlmClient, LlmError};
 
 use crate::executor::CliExecutor;
@@ -9,11 +8,12 @@ use crate::executor::CliExecutor;
 #[async_trait]
 impl LlmClient for CliExecutor {
     async fn complete(&self, prompt: &str) -> Result<String, LlmError> {
-        let result = self.execute_capture(prompt).await.map_err(|e| {
-            LlmError::RequestFailed {
+        let result = self
+            .execute_capture(prompt)
+            .await
+            .map_err(|e| LlmError::RequestFailed {
                 message: e.to_string(),
-            }
-        })?;
+            })?;
         if result.success {
             Ok(result.output.trim().to_owned())
         } else {

--- a/crates/rara-domain/src/contract.rs
+++ b/crates/rara-domain/src/contract.rs
@@ -31,7 +31,7 @@ pub struct Contract {
     pub exchange: String,
     /// Exchange-native symbol, e.g. `"BTCUSDT"`.
     #[builder(into)]
-    pub symbol: String,
+    pub symbol:   String,
     /// Security type classification.
     pub sec_type: SecType,
     /// Quote currency code, e.g. `"USDT"`.
@@ -41,7 +41,5 @@ pub struct Contract {
 
 impl Contract {
     /// Returns a unique identifier in the format `"{exchange}-{symbol}"`.
-    pub fn id(&self) -> String {
-        format!("{}-{}", self.exchange, self.symbol)
-    }
+    pub fn id(&self) -> String { format!("{}-{}", self.exchange, self.symbol) }
 }

--- a/crates/rara-domain/src/event.rs
+++ b/crates/rara-domain/src/event.rs
@@ -6,7 +6,16 @@ use uuid::Uuid;
 
 /// All known domain event types flowing through the event bus.
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, strum::Display, strum::EnumString,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    strum::Display,
+    strum::EnumString,
 )]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
@@ -65,29 +74,27 @@ impl EventType {
 pub struct Event {
     /// Unique event identifier.
     #[builder(default = Uuid::new_v4())]
-    pub event_id: Uuid,
+    pub event_id:         Uuid,
     /// The type of this event.
-    pub event_type: EventType,
+    pub event_type:       EventType,
     /// When the event occurred.
     #[builder(default = jiff::Timestamp::now())]
-    pub timestamp: jiff::Timestamp,
+    pub timestamp:        jiff::Timestamp,
     /// System or component that produced the event.
     #[builder(into)]
-    pub source: String,
+    pub source:           String,
     /// Correlation ID for tracing related events.
     #[builder(into)]
-    pub correlation_id: String,
+    pub correlation_id:   String,
     /// Optional strategy that originated this event.
-    pub strategy_id: Option<String>,
+    pub strategy_id:      Option<String>,
     /// Optional strategy version.
     pub strategy_version: Option<u32>,
     /// Arbitrary JSON payload.
-    pub payload: serde_json::Value,
+    pub payload:          serde_json::Value,
 }
 
 impl Event {
     /// Returns the top-level topic for event bus routing.
-    pub const fn topic(&self) -> &'static str {
-        self.event_type.topic()
-    }
+    pub const fn topic(&self) -> &'static str { self.event_type.topic() }
 }

--- a/crates/rara-domain/src/feedback.rs
+++ b/crates/rara-domain/src/feedback.rs
@@ -23,15 +23,15 @@ pub enum FeedbackDecision {
 #[derive(Debug, Clone, Serialize, Deserialize, Builder)]
 pub struct StrategyMetrics {
     /// Profit and loss.
-    pub pnl: Decimal,
+    pub pnl:          Decimal,
     /// Sharpe ratio.
     pub sharpe_ratio: f64,
     /// Maximum drawdown.
     pub max_drawdown: Decimal,
     /// Win rate as a fraction.
-    pub win_rate: f64,
+    pub win_rate:     f64,
     /// Total number of trades.
-    pub trade_count: u32,
+    pub trade_count:  u32,
 }
 
 /// A periodic evaluation report for a strategy.
@@ -39,30 +39,28 @@ pub struct StrategyMetrics {
 pub struct StrategyReport {
     /// Strategy identifier being evaluated.
     #[builder(into)]
-    pub strategy_id: String,
+    pub strategy_id:      String,
     /// Strategy version under evaluation.
     pub strategy_version: u32,
     /// Evaluation window start timestamp.
-    pub window_start: jiff::Timestamp,
+    pub window_start:     jiff::Timestamp,
     /// Evaluation window end timestamp.
-    pub window_end: jiff::Timestamp,
+    pub window_end:       jiff::Timestamp,
     /// Aggregated performance metrics in the window.
-    pub metrics: StrategyMetrics,
+    pub metrics:          StrategyMetrics,
     /// Related sentinel event identifiers.
-    pub sentinel_events: Vec<Uuid>,
+    pub sentinel_events:  Vec<Uuid>,
     /// Lifecycle decision from evaluator.
-    pub decision: FeedbackDecision,
+    pub decision:         FeedbackDecision,
     /// Human-readable decision rationale.
     #[builder(into)]
-    pub reason: String,
+    pub reason:           String,
     /// Report generation timestamp.
     #[builder(default = jiff::Timestamp::now())]
-    pub generated_at: jiff::Timestamp,
+    pub generated_at:     jiff::Timestamp,
 }
 
 impl StrategyReport {
     /// Returns `true` if the strategy should be retrained (i.e. retired).
-    pub fn should_trigger_retrain(&self) -> bool {
-        self.decision == FeedbackDecision::Retire
-    }
+    pub fn should_trigger_retrain(&self) -> bool { self.decision == FeedbackDecision::Retire }
 }

--- a/crates/rara-domain/src/research.rs
+++ b/crates/rara-domain/src/research.rs
@@ -13,28 +13,30 @@ use crate::timeframe::Timeframe;
 pub struct Hypothesis {
     /// Hypothesis identifier.
     #[builder(default = Uuid::new_v4())]
-    pub id: Uuid,
+    pub id:          Uuid,
     /// Hypothesis statement to validate.
     #[builder(into)]
-    pub text: String,
+    pub text:        String,
     /// Rationale for proposing the hypothesis.
     #[builder(into)]
-    pub reason: String,
+    pub reason:      String,
     /// What was observed in prior experiment results.
     #[builder(default, into)]
     pub observation: String,
     /// Domain knowledge applied when forming this hypothesis.
     #[builder(default, into)]
-    pub knowledge: String,
+    pub knowledge:   String,
     /// Optional parent hypothesis for lineage tracking.
-    pub parent: Option<Uuid>,
+    pub parent:      Option<Uuid>,
     /// Creation timestamp.
     #[builder(default = jiff::Timestamp::now())]
-    pub created_at: jiff::Timestamp,
+    pub created_at:  jiff::Timestamp,
 }
 
 /// Lifecycle status of an experiment.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize, Display, EnumString)]
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize, Display, EnumString,
+)]
 pub enum ExperimentStatus {
     /// Awaiting execution.
     #[default]
@@ -56,63 +58,63 @@ pub enum ExperimentStatus {
 pub struct Experiment {
     /// Experiment identifier.
     #[builder(default = Uuid::new_v4())]
-    pub id: Uuid,
+    pub id:              Uuid,
     /// Referenced hypothesis under test.
-    pub hypothesis_id: Uuid,
+    pub hypothesis_id:   Uuid,
     /// Generated strategy source code for this run.
     #[builder(into)]
-    pub strategy_code: String,
+    pub strategy_code:   String,
     /// Current experiment lifecycle state.
     #[builder(default)]
-    pub status: ExperimentStatus,
+    pub status:          ExperimentStatus,
     /// Backtest output, populated when execution completes.
     pub backtest_result: Option<BacktestResult>,
     /// Creation timestamp.
     #[builder(default = jiff::Timestamp::now())]
-    pub created_at: jiff::Timestamp,
+    pub created_at:      jiff::Timestamp,
 }
 
 /// Results from a backtest run.
 #[derive(Debug, Clone, Serialize, Deserialize, Builder)]
 pub struct BacktestResult {
     /// Profit and loss.
-    pub pnl: Decimal,
+    pub pnl:          Decimal,
     /// Sharpe ratio.
     pub sharpe_ratio: f64,
     /// Maximum drawdown.
     pub max_drawdown: Decimal,
     /// Win rate as a fraction.
-    pub win_rate: f64,
+    pub win_rate:     f64,
     /// Total number of trades.
-    pub trade_count: u32,
+    pub trade_count:  u32,
     /// Timeframe this result was evaluated on, if applicable.
-    pub timeframe: Option<Timeframe>,
+    pub timeframe:    Option<Timeframe>,
 }
 
 /// Feedback on an experiment guiding the next research iteration.
 #[derive(Debug, Clone, Serialize, Deserialize, Builder)]
 pub struct HypothesisFeedback {
     /// Experiment this feedback belongs to.
-    pub experiment_id: Uuid,
+    pub experiment_id:         Uuid,
     /// Whether the experiment outcome supports continuation.
-    pub decision: bool,
+    pub decision:              bool,
     /// Decision rationale.
     #[builder(into)]
-    pub reason: String,
+    pub reason:                String,
     /// Key observations from the run.
     #[builder(into)]
-    pub observations: String,
+    pub observations:          String,
     /// Whether the hypothesis was validated, refuted, or inconclusive.
     #[builder(default, into)]
     pub hypothesis_evaluation: String,
     /// LLM suggestion for the next research round.
-    pub new_hypothesis: Option<String>,
+    pub new_hypothesis:        Option<String>,
     /// Summary of code changes from the previous experiment.
     #[builder(default, into)]
-    pub code_change_summary: String,
+    pub code_change_summary:   String,
     /// Feedback creation timestamp.
     #[builder(default = jiff::Timestamp::now())]
-    pub created_at: jiff::Timestamp,
+    pub created_at:            jiff::Timestamp,
 }
 
 /// Lifecycle status of a research-generated strategy.
@@ -136,16 +138,16 @@ pub enum ResearchStrategyStatus {
 pub struct ResearchStrategy {
     /// Strategy identifier.
     #[builder(default = Uuid::new_v4())]
-    pub id: Uuid,
+    pub id:            Uuid,
     /// Hypothesis that generated this strategy.
     pub hypothesis_id: Uuid,
     /// Generated source code.
     #[builder(into)]
-    pub source_code: String,
+    pub source_code:   String,
     /// Current lifecycle status.
     #[builder(default)]
-    pub status: ResearchStrategyStatus,
+    pub status:        ResearchStrategyStatus,
     /// Creation timestamp.
     #[builder(default = jiff::Timestamp::now())]
-    pub created_at: jiff::Timestamp,
+    pub created_at:    jiff::Timestamp,
 }

--- a/crates/rara-domain/src/sentinel.rs
+++ b/crates/rara-domain/src/sentinel.rs
@@ -54,28 +54,26 @@ pub enum Severity {
 pub struct SentinelSignal {
     /// Unique signal identifier.
     #[builder(default = Uuid::new_v4())]
-    pub id: Uuid,
+    pub id:                 Uuid,
     /// Classified signal type.
-    pub signal_type: SignalType,
+    pub signal_type:        SignalType,
     /// Signal severity level.
-    pub severity: Severity,
+    pub severity:           Severity,
     /// Source channel where the signal was observed.
-    pub source: SignalSource,
+    pub source:             SignalSource,
     /// Contract IDs potentially impacted by this signal.
     pub affected_contracts: Vec<String>,
     /// One-line analyst/LLM summary.
     #[builder(into)]
-    pub summary: String,
+    pub summary:            String,
     /// Raw source payload and analyzer metadata.
-    pub raw_data: serde_json::Value,
+    pub raw_data:           serde_json::Value,
     /// Detection timestamp.
     #[builder(default = jiff::Timestamp::now())]
-    pub detected_at: jiff::Timestamp,
+    pub detected_at:        jiff::Timestamp,
 }
 
 impl SentinelSignal {
     /// Returns `true` if this signal is critical and should block trading.
-    pub fn should_block_trading(&self) -> bool {
-        self.severity == Severity::Critical
-    }
+    pub fn should_block_trading(&self) -> bool { self.severity == Severity::Critical }
 }

--- a/crates/rara-domain/src/strategy.rs
+++ b/crates/rara-domain/src/strategy.rs
@@ -56,41 +56,41 @@ pub enum ContractFilter {
 pub struct Strategy {
     /// Stable strategy identifier.
     #[builder(into)]
-    pub id: String,
+    pub id:                   String,
     /// Monotonic strategy version.
-    pub version: u32,
+    pub version:              u32,
     /// Human-readable strategy name.
     #[builder(into)]
-    pub name: String,
+    pub name:                 String,
     /// Strategy description and intent.
     #[builder(into)]
-    pub description: String,
+    pub description:          String,
     /// Executable strategy source code.
     #[builder(into)]
-    pub code: String,
+    pub code:                 String,
     /// Strategy classification.
-    pub strategy_type: StrategyType,
+    pub strategy_type:        StrategyType,
     /// Contract matching rules this strategy applies to.
     pub applicable_contracts: Vec<ContractFilter>,
     /// JSON parameters consumed by strategy runtime.
-    pub parameters: serde_json::Value,
+    pub parameters:           serde_json::Value,
     /// Lifecycle status of the strategy.
-    pub status: StrategyStatus,
+    pub status:               StrategyStatus,
 }
 
 /// Risk limits and constraints for a specific security type.
 #[derive(Debug, Clone, Serialize, Deserialize, Builder)]
 pub struct RiskProfile {
     /// Security type this risk profile targets.
-    pub sec_type: SecType,
+    pub sec_type:           SecType,
     /// Maximum leverage allowed.
-    pub max_leverage: Decimal,
+    pub max_leverage:       Decimal,
     /// Maximum position size as portfolio fraction.
-    pub max_position_pct: Decimal,
+    pub max_position_pct:   Decimal,
     /// Maximum tolerated drawdown.
-    pub max_drawdown: Decimal,
+    pub max_drawdown:       Decimal,
     /// Whether stop-loss orders are mandatory.
-    pub require_stop_loss: bool,
+    pub require_stop_loss:  bool,
     /// Minimum liquidation safety buffer.
     pub liquidation_buffer: Decimal,
     /// Whether funding-rate checks are required.
@@ -101,11 +101,11 @@ impl RiskProfile {
     /// Default risk profile for crypto spot trading.
     pub fn crypto_spot_default() -> Self {
         Self {
-            sec_type: SecType::CryptoSpot,
-            max_leverage: Decimal::from(1),
-            max_position_pct: Decimal::new(10, 2), // 0.10
-            max_drawdown: Decimal::new(5, 2),       // 0.05
-            require_stop_loss: false,
+            sec_type:           SecType::CryptoSpot,
+            max_leverage:       Decimal::from(1),
+            max_position_pct:   Decimal::new(10, 2), // 0.10
+            max_drawdown:       Decimal::new(5, 2),  // 0.05
+            require_stop_loss:  false,
             liquidation_buffer: Decimal::ZERO,
             funding_rate_check: false,
         }
@@ -114,12 +114,12 @@ impl RiskProfile {
     /// Default risk profile for crypto perpetual swaps.
     pub fn crypto_perp_default() -> Self {
         Self {
-            sec_type: SecType::CryptoPerp,
-            max_leverage: Decimal::from(5),
-            max_position_pct: Decimal::new(5, 2),   // 0.05
-            max_drawdown: Decimal::new(10, 2),       // 0.10
-            require_stop_loss: true,
-            liquidation_buffer: Decimal::new(2, 2),  // 0.02
+            sec_type:           SecType::CryptoPerp,
+            max_leverage:       Decimal::from(5),
+            max_position_pct:   Decimal::new(5, 2),  // 0.05
+            max_drawdown:       Decimal::new(10, 2), // 0.10
+            require_stop_loss:  true,
+            liquidation_buffer: Decimal::new(2, 2), // 0.02
             funding_rate_check: true,
         }
     }

--- a/crates/rara-domain/src/timeframe.rs
+++ b/crates/rara-domain/src/timeframe.rs
@@ -40,7 +40,5 @@ impl Timeframe {
     }
 
     /// Duration of this timeframe in seconds.
-    pub const fn seconds(&self) -> i64 {
-        self.minutes() as i64 * 60
-    }
+    pub const fn seconds(&self) -> i64 { self.minutes() as i64 * 60 }
 }

--- a/crates/rara-domain/src/trading/git.rs
+++ b/crates/rara-domain/src/trading/git.rs
@@ -4,8 +4,10 @@ use bon::Builder;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
-use super::Side;
-use super::operation::{Operation, OperationResult, OperationStatus};
+use super::{
+    Side,
+    operation::{Operation, OperationResult, OperationStatus},
+};
 
 /// 8-character hex commit hash.
 pub type CommitHash = String;
@@ -14,15 +16,15 @@ pub type CommitHash = String;
 #[derive(Debug, Clone, Serialize, Deserialize, Builder)]
 pub struct GitState {
     /// Total portfolio equity.
-    pub net_liquidation: Decimal,
+    pub net_liquidation:  Decimal,
     /// Available cash.
     pub total_cash_value: Decimal,
     /// Unrealized P&L across all positions.
-    pub unrealized_pnl: Decimal,
+    pub unrealized_pnl:   Decimal,
     /// Realized P&L.
-    pub realized_pnl: Decimal,
+    pub realized_pnl:     Decimal,
     /// Open positions at snapshot time.
-    pub positions: Vec<GitPosition>,
+    pub positions:        Vec<GitPosition>,
 }
 
 /// Position representation within a [`GitState`] snapshot.
@@ -30,15 +32,16 @@ pub struct GitState {
 pub struct GitPosition {
     /// Contract identifier.
     #[builder(into)]
-    pub contract_id: String,
+    pub contract_id:    String,
     /// Long or short.
-    pub side: Side,
+    pub side:           Side,
     /// Position size.
-    pub quantity: Decimal,
+    pub quantity:       Decimal,
     /// Average entry price.
-    pub avg_cost: Decimal,
-    /// Current market price. May be approximate if the broker does not provide real-time quotes.
-    pub market_price: Decimal,
+    pub avg_cost:       Decimal,
+    /// Current market price. May be approximate if the broker does not provide
+    /// real-time quotes.
+    pub market_price:   Decimal,
     /// Unrealized P&L for this position.
     pub unrealized_pnl: Decimal,
 }
@@ -48,32 +51,32 @@ pub struct GitPosition {
 pub struct GitCommit {
     /// Commit hash (8 hex chars).
     #[builder(into)]
-    pub hash: CommitHash,
+    pub hash:        CommitHash,
     /// Parent commit hash (`None` for the first commit).
     pub parent_hash: Option<CommitHash>,
     /// Human-readable commit message.
     #[builder(into)]
-    pub message: String,
+    pub message:     String,
     /// Operations that were staged.
-    pub operations: Vec<Operation>,
+    pub operations:  Vec<Operation>,
     /// Per-operation execution results.
-    pub results: Vec<OperationResult>,
+    pub results:     Vec<OperationResult>,
     /// Account state snapshot taken after execution.
     pub state_after: GitState,
     /// ISO 8601 timestamp.
     #[builder(into)]
-    pub timestamp: String,
+    pub timestamp:   String,
     /// Optional trading round number.
-    pub round: Option<u32>,
+    pub round:       Option<u32>,
 }
 
 /// Result of staging an operation via `TradingGit::add`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AddResult {
     /// Always `true` on success.
-    pub staged: bool,
+    pub staged:    bool,
     /// Index in the staging area.
-    pub index: usize,
+    pub index:     usize,
     /// The staged operation.
     pub operation: Operation,
 }
@@ -82,11 +85,11 @@ pub struct AddResult {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommitPrepareResult {
     /// Always `true` on success.
-    pub prepared: bool,
+    pub prepared:        bool,
     /// Generated commit hash.
-    pub hash: CommitHash,
+    pub hash:            CommitHash,
     /// Commit message.
-    pub message: String,
+    pub message:         String,
     /// Number of staged operations.
     pub operation_count: usize,
 }
@@ -95,24 +98,24 @@ pub struct CommitPrepareResult {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PushResult {
     /// Commit hash.
-    pub hash: CommitHash,
+    pub hash:            CommitHash,
     /// Commit message.
-    pub message: String,
+    pub message:         String,
     /// Number of operations.
     pub operation_count: usize,
     /// Operations that were successfully dispatched.
-    pub submitted: Vec<OperationResult>,
+    pub submitted:       Vec<OperationResult>,
     /// Operations rejected by guards or broker.
-    pub rejected: Vec<OperationResult>,
+    pub rejected:        Vec<OperationResult>,
 }
 
 /// Result of rejecting a pending commit.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RejectResult {
     /// Commit hash of the rejected commit.
-    pub hash: CommitHash,
+    pub hash:            CommitHash,
     /// Commit message.
-    pub message: String,
+    pub message:         String,
     /// Number of operations that were discarded.
     pub operation_count: usize,
 }
@@ -121,15 +124,15 @@ pub struct RejectResult {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GitStatus {
     /// Currently staged operations.
-    pub staged: Vec<Operation>,
+    pub staged:          Vec<Operation>,
     /// Message of the pending (committed but not pushed) commit.
     pub pending_message: Option<String>,
     /// Hash of the pending commit.
-    pub pending_hash: Option<CommitHash>,
+    pub pending_hash:    Option<CommitHash>,
     /// HEAD commit hash.
-    pub head: Option<CommitHash>,
+    pub head:            Option<CommitHash>,
     /// Total number of commits in history.
-    pub commit_count: usize,
+    pub commit_count:    usize,
 }
 
 /// Summary of a single operation within a commit log entry.
@@ -149,17 +152,17 @@ pub struct OperationSummary {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommitLogEntry {
     /// Commit hash.
-    pub hash: CommitHash,
+    pub hash:        CommitHash,
     /// Parent commit hash.
     pub parent_hash: Option<CommitHash>,
     /// Commit message.
-    pub message: String,
+    pub message:     String,
     /// ISO 8601 timestamp.
-    pub timestamp: String,
+    pub timestamp:   String,
     /// Trading round number.
-    pub round: Option<u32>,
+    pub round:       Option<u32>,
     /// Operation summaries.
-    pub operations: Vec<OperationSummary>,
+    pub operations:  Vec<OperationSummary>,
 }
 
 /// Serializable export of the full `TradingGit` state.
@@ -168,33 +171,33 @@ pub struct GitExportState {
     /// All commits in chronological order.
     pub commits: Vec<GitCommit>,
     /// Current HEAD hash.
-    pub head: Option<CommitHash>,
+    pub head:    Option<CommitHash>,
 }
 
 /// A single order status update from a sync operation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OrderStatusUpdate {
     /// Broker-assigned order ID.
-    pub order_id: String,
+    pub order_id:        String,
     /// Trading symbol.
-    pub symbol: String,
+    pub symbol:          String,
     /// Status before the update.
     pub previous_status: OperationStatus,
     /// Status after the update.
-    pub current_status: OperationStatus,
+    pub current_status:  OperationStatus,
     /// Fill price if newly filled.
-    pub filled_price: Option<Decimal>,
+    pub filled_price:    Option<Decimal>,
     /// Fill quantity if newly filled.
-    pub filled_qty: Option<Decimal>,
+    pub filled_qty:      Option<Decimal>,
 }
 
 /// Result of a sync operation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SyncResult {
     /// Commit hash of the sync commit.
-    pub hash: CommitHash,
+    pub hash:          CommitHash,
     /// Number of orders whose status changed.
     pub updated_count: usize,
     /// Individual status changes.
-    pub updates: Vec<OrderStatusUpdate>,
+    pub updates:       Vec<OrderStatusUpdate>,
 }

--- a/crates/rara-domain/src/trading/mod.rs
+++ b/crates/rara-domain/src/trading/mod.rs
@@ -54,39 +54,37 @@ pub struct StagedAction {
     #[builder(into)]
     pub contract_id: String,
     /// Order side.
-    pub side: Side,
+    pub side:        Side,
     /// Order quantity in contract units.
-    pub quantity: Decimal,
+    pub quantity:    Decimal,
     /// Order type semantics.
-    pub order_type: OrderType,
+    pub order_type:  OrderType,
     /// Optional limit/trigger price depending on order type.
     pub limit_price: Option<Decimal>,
 }
 
 /// Generates an 8-character hex hash from a UUID.
-fn generate_hash() -> String {
-    Uuid::new_v4().to_string()[..8].to_string()
-}
+fn generate_hash() -> String { Uuid::new_v4().to_string()[..8].to_string() }
 
 /// A git-style commit of trading actions, bundling multiple staged actions.
 #[derive(Debug, Clone, Serialize, Deserialize, Builder)]
 pub struct TradingCommit {
     /// Short commit hash used as correlation key.
     #[builder(default = generate_hash())]
-    pub hash: String,
+    pub hash:             String,
     /// Commit message describing intent.
     #[builder(into)]
-    pub message: String,
+    pub message:          String,
     /// Batched staged actions.
-    pub actions: Vec<StagedAction>,
+    pub actions:          Vec<StagedAction>,
     /// Strategy that produced this commit.
     #[builder(into)]
-    pub strategy_id: String,
+    pub strategy_id:      String,
     /// Strategy version used for generation.
     pub strategy_version: u32,
     /// Commit creation timestamp.
     #[builder(default = jiff::Timestamp::now())]
-    pub created_at: jiff::Timestamp,
+    pub created_at:       jiff::Timestamp,
 }
 
 /// One leg of an arbitrage opportunity.
@@ -96,12 +94,12 @@ pub struct ArbLeg {
     #[builder(into)]
     pub contract_id: String,
     /// Execution side for this leg.
-    pub side: Side,
+    pub side:        Side,
     /// Leg quantity.
-    pub quantity: Decimal,
+    pub quantity:    Decimal,
     /// Broker/exchange route for this leg.
     #[builder(into)]
-    pub broker: String,
+    pub broker:      String,
 }
 
 /// A detected arbitrage opportunity across legs.
@@ -109,13 +107,13 @@ pub struct ArbLeg {
 pub struct ArbOpportunity {
     /// Strategy that discovered the opportunity.
     #[builder(into)]
-    pub strategy_id: String,
+    pub strategy_id:     String,
     /// Arbitrage legs to execute atomically.
-    pub legs: Vec<ArbLeg>,
+    pub legs:            Vec<ArbLeg>,
     /// Expected gross spread across legs.
     pub expected_spread: Decimal,
     /// Maximum tolerated execution slippage.
-    pub max_slippage: Decimal,
+    pub max_slippage:    Decimal,
     /// Opportunity expiry timestamp.
-    pub expiry: jiff::Timestamp,
+    pub expiry:          jiff::Timestamp,
 }

--- a/crates/rara-domain/src/trading/operation.rs
+++ b/crates/rara-domain/src/trading/operation.rs
@@ -18,13 +18,13 @@ pub enum Operation {
     /// Place a new order on the exchange.
     PlaceOrder {
         /// Target contract.
-        contract: Contract,
+        contract:    Contract,
         /// Buy or sell.
-        side: Side,
+        side:        Side,
         /// Order type (market, limit, etc.).
-        order_type: OperationOrderType,
+        order_type:  OperationOrderType,
         /// Order quantity.
-        quantity: Decimal,
+        quantity:    Decimal,
         /// Limit/trigger price (required for limit/stop orders).
         limit_price: Option<Decimal>,
     },
@@ -35,7 +35,7 @@ pub enum Operation {
         /// New quantity (if changing).
         quantity: Option<Decimal>,
         /// New price (if changing).
-        price: Option<Decimal>,
+        price:    Option<Decimal>,
     },
     /// Close an existing position.
     ClosePosition {
@@ -102,17 +102,17 @@ pub enum OperationStatus {
 #[derive(Debug, Clone, Serialize, Deserialize, Builder)]
 pub struct OperationResult {
     /// Which action was attempted.
-    pub action: Operation,
+    pub action:       Operation,
     /// Whether the broker accepted the operation.
-    pub success: bool,
+    pub success:      bool,
     /// Broker-assigned order ID (if any).
-    pub order_id: Option<String>,
+    pub order_id:     Option<String>,
     /// Lifecycle status after dispatch.
-    pub status: OperationStatus,
+    pub status:       OperationStatus,
     /// Filled quantity (if partially/fully filled).
-    pub filled_qty: Option<Decimal>,
+    pub filled_qty:   Option<Decimal>,
     /// Average fill price.
     pub filled_price: Option<Decimal>,
     /// Error message on failure.
-    pub error: Option<String>,
+    pub error:        Option<String>,
 }

--- a/crates/rara-event-bus/src/bus.rs
+++ b/crates/rara-event-bus/src/bus.rs
@@ -3,9 +3,8 @@
 
 use std::path::Path;
 
-use tokio::sync::broadcast;
-
 use rara_domain::event::Event;
+use tokio::sync::broadcast;
 
 use crate::store::{EventStore, Result};
 
@@ -18,11 +17,12 @@ pub struct EventBus {
     /// Persistent backing store.
     store: EventStore,
     /// Broadcast sender for real-time sequence number notifications.
-    tx: broadcast::Sender<u64>,
+    tx:    broadcast::Sender<u64>,
 }
 
 impl EventBus {
-    /// Open (or create) an event bus backed by a sled database at the given path.
+    /// Open (or create) an event bus backed by a sled database at the given
+    /// path.
     pub fn open(path: &Path) -> Result<Self> {
         let store = EventStore::open(path)?;
         let (tx, _) = broadcast::channel(1024);
@@ -40,21 +40,16 @@ impl EventBus {
     }
 
     /// Subscribe to real-time sequence number notifications.
-    pub fn subscribe(&self) -> broadcast::Receiver<u64> {
-        self.tx.subscribe()
-    }
+    pub fn subscribe(&self) -> broadcast::Receiver<u64> { self.tx.subscribe() }
 
     /// Access the underlying store for catch-up reads and offset management.
-    pub const fn store(&self) -> &EventStore {
-        &self.store
-    }
+    pub const fn store(&self) -> &EventStore { &self.store }
 }
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
-
     use rara_domain::event::EventType;
+    use serde_json::json;
 
     use super::*;
 

--- a/crates/rara-event-bus/src/store.rs
+++ b/crates/rara-event-bus/src/store.rs
@@ -2,9 +2,8 @@
 
 use std::path::Path;
 
-use snafu::{ResultExt, Snafu};
-
 use rara_domain::event::Event;
+use snafu::{ResultExt, Snafu};
 
 /// Errors that can occur in the event store.
 #[derive(Debug, Snafu)]
@@ -31,13 +30,13 @@ pub type Result<T> = std::result::Result<T, StoreError>;
 /// consumer offset tracking.
 pub struct EventStore {
     /// Primary store: seq (u64 BE bytes) -> Event JSON bytes.
-    events: sled::Tree,
+    events:  sled::Tree,
     /// Topic index: "{topic}/{seq:020}" -> seq bytes.
-    topics: sled::Tree,
+    topics:  sled::Tree,
     /// Consumer offsets: `"{consumer_id}/{topic}"` -> u64 BE bytes.
     offsets: sled::Tree,
     /// The underlying sled database, used for monotonic ID generation.
-    db: sled::Db,
+    db:      sled::Db,
 }
 
 impl EventStore {
@@ -147,9 +146,8 @@ impl EventStore {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
-
     use rara_domain::event::EventType;
+    use serde_json::json;
 
     use super::*;
 

--- a/crates/rara-feedback/src/aggregator.rs
+++ b/crates/rara-feedback/src/aggregator.rs
@@ -3,13 +3,10 @@
 
 use std::sync::Arc;
 
+use rara_domain::{event::EventType, feedback::StrategyMetrics};
+use rara_event_bus::{bus::EventBus, store::StoreError};
 use rust_decimal::Decimal;
 use snafu::{ResultExt, Snafu};
-
-use rara_domain::event::EventType;
-use rara_domain::feedback::StrategyMetrics;
-use rara_event_bus::bus::EventBus;
-use rara_event_bus::store::StoreError;
 
 /// Errors from metrics aggregation.
 #[derive(Debug, Snafu)]
@@ -34,9 +31,7 @@ pub struct MetricsAggregator {
 
 impl MetricsAggregator {
     /// Create a new aggregator backed by the given event bus.
-    pub const fn new(event_bus: Arc<EventBus>) -> Self {
-        Self { event_bus }
-    }
+    pub const fn new(event_bus: Arc<EventBus>) -> Self { Self { event_bus } }
 
     /// Aggregate trading events for `strategy_id` within the time window
     /// into [`StrategyMetrics`].

--- a/crates/rara-feedback/src/consumer.rs
+++ b/crates/rara-feedback/src/consumer.rs
@@ -4,16 +4,15 @@
 //! events, and maintains per-strategy running metric accumulators with
 //! consumer-offset persistence so restarts don't reprocess old events.
 
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
+use rara_domain::{
+    event::{Event, EventType},
+    feedback::StrategyMetrics,
+};
+use rara_event_bus::{bus::EventBus, store::StoreError};
 use rust_decimal::Decimal;
 use snafu::{ResultExt, Snafu};
-
-use rara_domain::event::{Event, EventType};
-use rara_domain::feedback::StrategyMetrics;
-use rara_event_bus::bus::EventBus;
-use rara_event_bus::store::StoreError;
 
 /// Errors from the feedback consumer.
 #[derive(Debug, Snafu)]
@@ -45,21 +44,21 @@ const BATCH_SIZE: usize = 100;
 #[derive(Debug, Clone)]
 pub struct StrategyAccumulator {
     /// Strategy identifier.
-    pub strategy_id: String,
+    pub strategy_id:    String,
     /// Total number of filled trades.
-    pub trade_count: u32,
+    pub trade_count:    u32,
     /// Number of winning trades (realized `PnL` > 0).
     pub winning_trades: u32,
     /// Number of losing trades (realized `PnL` <= 0).
-    pub losing_trades: u32,
+    pub losing_trades:  u32,
     /// Running total realized `PnL`.
-    pub total_pnl: Decimal,
+    pub total_pnl:      Decimal,
     /// Peak cumulative equity for drawdown calculation.
-    pub peak_equity: Decimal,
+    pub peak_equity:    Decimal,
     /// Maximum drawdown observed so far.
-    pub max_drawdown: Decimal,
+    pub max_drawdown:   Decimal,
     /// Individual trade returns for Sharpe calculation.
-    pub returns: Vec<f64>,
+    pub returns:        Vec<f64>,
 }
 
 impl StrategyAccumulator {
@@ -108,7 +107,8 @@ impl StrategyAccumulator {
     /// Compute the Sharpe ratio from accumulated returns.
     ///
     /// Uses sample standard deviation (n-1 denominator). Returns 0.0 when
-    /// fewer than 2 trades have been recorded or when all returns are identical.
+    /// fewer than 2 trades have been recorded or when all returns are
+    /// identical.
     pub fn sharpe_ratio(&self) -> f64 {
         if self.returns.len() < 2 {
             return 0.0;
@@ -151,7 +151,7 @@ impl StrategyAccumulator {
 /// only processes new events on each poll.
 pub struct FeedbackConsumer {
     /// Event bus to consume from.
-    event_bus: Arc<EventBus>,
+    event_bus:    Arc<EventBus>,
     /// Per-strategy running accumulators.
     accumulators: HashMap<String, StrategyAccumulator>,
 }
@@ -167,7 +167,10 @@ impl FeedbackConsumer {
 
     /// Get current metrics for all tracked strategies.
     pub fn all_metrics(&self) -> Vec<StrategyMetrics> {
-        self.accumulators.values().map(StrategyAccumulator::to_metrics).collect()
+        self.accumulators
+            .values()
+            .map(StrategyAccumulator::to_metrics)
+            .collect()
     }
 
     /// Get current metrics for all tracked strategies, paired with their IDs.
@@ -180,7 +183,9 @@ impl FeedbackConsumer {
 
     /// Get metrics for a specific strategy, if any fills have been recorded.
     pub fn strategy_metrics(&self, strategy_id: &str) -> Option<StrategyMetrics> {
-        self.accumulators.get(strategy_id).map(StrategyAccumulator::to_metrics)
+        self.accumulators
+            .get(strategy_id)
+            .map(StrategyAccumulator::to_metrics)
     }
 
     /// Poll for new trading events and update accumulators.
@@ -233,7 +238,8 @@ impl FeedbackConsumer {
             .clone()
             .unwrap_or_else(|| "unknown".to_string());
 
-        // Extract realized_pnl from payload — try string first (Decimal-safe), then number
+        // Extract realized_pnl from payload — try string first (Decimal-safe), then
+        // number
         let pnl = event
             .payload
             .get("realized_pnl")
@@ -283,11 +289,10 @@ impl FeedbackConsumer {
 mod tests {
     use std::sync::Arc;
 
-    use rust_decimal_macros::dec;
-    use serde_json::json;
-
     use rara_domain::event::{Event, EventType};
     use rara_event_bus::bus::EventBus;
+    use rust_decimal_macros::dec;
+    use serde_json::json;
 
     use super::*;
 

--- a/crates/rara-feedback/src/engine.rs
+++ b/crates/rara-feedback/src/engine.rs
@@ -1,29 +1,32 @@
-//! `FeedbackBridge` engine — orchestrates the strategy evaluation feedback loop.
+//! `FeedbackBridge` engine — orchestrates the strategy evaluation feedback
+//! loop.
 
 use std::sync::Arc;
 
+use rara_domain::{
+    event::{Event, EventType},
+    feedback::{FeedbackDecision, StrategyReport},
+};
 use serde::Serialize;
 use snafu::{ResultExt, Snafu};
 use uuid::Uuid;
-
-use rara_domain::event::{Event, EventType};
-use rara_domain::feedback::{FeedbackDecision, StrategyReport};
 
 /// Event payload published when a feedback decision is made.
 #[derive(Debug, Serialize)]
 struct FeedbackEventPayload<'a> {
     /// The lifecycle decision.
-    decision: &'a FeedbackDecision,
+    decision:         &'a FeedbackDecision,
     /// Strategy identifier.
-    strategy_id: &'a str,
+    strategy_id:      &'a str,
     /// Strategy version number.
     strategy_version: u32,
 }
-use rara_event_bus::bus::EventBus;
-use rara_event_bus::store::StoreError;
+use rara_event_bus::{bus::EventBus, store::StoreError};
 
-use crate::aggregator::{AggregatorError, MetricsAggregator};
-use crate::evaluator::StrategyEvaluator;
+use crate::{
+    aggregator::{AggregatorError, MetricsAggregator},
+    evaluator::StrategyEvaluator,
+};
 
 /// Errors from feedback bridge operations.
 #[derive(Debug, Snafu)]
@@ -50,8 +53,8 @@ pub type Result<T> = std::result::Result<T, FeedbackBridgeError>;
 /// and publish lifecycle events.
 pub struct FeedbackBridge {
     aggregator: MetricsAggregator,
-    evaluator: StrategyEvaluator,
-    event_bus: Arc<EventBus>,
+    evaluator:  StrategyEvaluator,
+    event_bus:  Arc<EventBus>,
 }
 
 impl FeedbackBridge {
@@ -139,7 +142,8 @@ impl FeedbackBridge {
         Ok(report)
     }
 
-    /// Check whether any of the given sentinel event IDs have Critical severity.
+    /// Check whether any of the given sentinel event IDs have Critical
+    /// severity.
     fn has_critical_sentinel(&self, event_ids: &[Uuid]) -> Result<bool> {
         let sentinel_events = self
             .event_bus
@@ -149,10 +153,7 @@ impl FeedbackBridge {
 
         let has_critical = sentinel_events.iter().any(|e| {
             event_ids.contains(&e.event_id)
-                && e.payload
-                    .get("severity")
-                    .and_then(|v| v.as_str())
-                    == Some("Critical")
+                && e.payload.get("severity").and_then(|v| v.as_str()) == Some("Critical")
         });
 
         Ok(has_critical)
@@ -214,7 +215,9 @@ mod tests {
         let (bus, _dir) = setup();
 
         // Publish winning trades with slight variance so Sharpe > 0
-        let pnls = ["120", "80", "110", "90", "130", "95", "105", "115", "100", "85"];
+        let pnls = [
+            "120", "80", "110", "90", "130", "95", "105", "115", "100", "85",
+        ];
         for pnl in &pnls {
             publish_fill(&bus, "strat-1", pnl);
         }
@@ -240,7 +243,9 @@ mod tests {
     fn demote_on_critical_sentinel() {
         let (bus, _dir) = setup();
 
-        let pnls = ["120", "80", "110", "90", "130", "95", "105", "115", "100", "85"];
+        let pnls = [
+            "120", "80", "110", "90", "130", "95", "105", "115", "100", "85",
+        ];
         for pnl in &pnls {
             publish_fill(&bus, "strat-1", pnl);
         }

--- a/crates/rara-feedback/src/evaluator.rs
+++ b/crates/rara-feedback/src/evaluator.rs
@@ -1,9 +1,8 @@
 //! Strategy evaluation logic — maps metrics + sentinel context to a lifecycle
 //! decision.
 
-use rust_decimal::Decimal;
-
 use rara_domain::feedback::{FeedbackDecision, StrategyMetrics};
+use rust_decimal::Decimal;
 
 /// Evaluates a strategy's performance metrics and sentinel context to produce
 /// a [`FeedbackDecision`] controlling the strategy's lifecycle.
@@ -11,9 +10,9 @@ pub struct StrategyEvaluator {
     /// Minimum Sharpe ratio required to promote a strategy.
     promote_threshold: f64,
     /// Maximum drawdown that triggers demotion/retirement.
-    demote_drawdown: Decimal,
+    demote_drawdown:   Decimal,
     /// Minimum number of trades before a decision can be made.
-    min_trades: u32,
+    min_trades:        u32,
 }
 
 impl StrategyEvaluator {
@@ -51,8 +50,7 @@ impl StrategyEvaluator {
                 FeedbackDecision::Hold,
                 format!(
                     "insufficient trades: {} < {} minimum",
-                    metrics.trade_count,
-                    self.min_trades
+                    metrics.trade_count, self.min_trades
                 ),
             );
         }
@@ -62,8 +60,7 @@ impl StrategyEvaluator {
                 FeedbackDecision::Retire,
                 format!(
                     "excessive drawdown: {} > {} threshold — requesting retrain",
-                    metrics.max_drawdown,
-                    self.demote_drawdown
+                    metrics.max_drawdown, self.demote_drawdown
                 ),
             );
         }
@@ -73,8 +70,7 @@ impl StrategyEvaluator {
                 FeedbackDecision::Promote,
                 format!(
                     "strong performance: sharpe={:.2}, win_rate={:.2}",
-                    metrics.sharpe_ratio,
-                    metrics.win_rate
+                    metrics.sharpe_ratio, metrics.win_rate
                 ),
             );
         }
@@ -83,9 +79,7 @@ impl StrategyEvaluator {
             FeedbackDecision::Hold,
             format!(
                 "metrics within tolerance: sharpe={:.2}, win_rate={:.2}, drawdown={}",
-                metrics.sharpe_ratio,
-                metrics.win_rate,
-                metrics.max_drawdown
+                metrics.sharpe_ratio, metrics.win_rate, metrics.max_drawdown
             ),
         )
     }
@@ -97,9 +91,7 @@ mod tests {
 
     use super::*;
 
-    fn evaluator() -> StrategyEvaluator {
-        StrategyEvaluator::new(1.5, dec!(0.20), 10)
-    }
+    fn evaluator() -> StrategyEvaluator { StrategyEvaluator::new(1.5, dec!(0.20), 10) }
 
     #[test]
     fn critical_sentinel_forces_demote() {

--- a/crates/rara-feedback/src/feedback_loop.rs
+++ b/crates/rara-feedback/src/feedback_loop.rs
@@ -1,20 +1,20 @@
 //! Feedback loop — periodic evaluation of strategies via the consumer,
 //! with lifecycle event publishing on promote/demote/retire decisions.
 
-use std::collections::HashMap;
-use std::sync::Arc;
-use std::time::Duration;
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use bon::Builder;
+use rara_domain::{
+    event::{Event, EventType},
+    feedback::FeedbackDecision,
+};
+use rara_event_bus::{bus::EventBus, store::StoreError};
 use snafu::{ResultExt, Snafu};
 
-use rara_domain::event::{Event, EventType};
-use rara_domain::feedback::FeedbackDecision;
-use rara_event_bus::bus::EventBus;
-use rara_event_bus::store::StoreError;
-
-use crate::consumer::{ConsumerError, FeedbackConsumer};
-use crate::evaluator::StrategyEvaluator;
+use crate::{
+    consumer::{ConsumerError, FeedbackConsumer},
+    evaluator::StrategyEvaluator,
+};
 
 /// Errors from the feedback loop.
 #[derive(Debug, Snafu)]
@@ -42,8 +42,9 @@ pub type Result<T> = std::result::Result<T, FeedbackLoopError>;
 pub struct FeedbackLoopConfig {
     /// Interval between evaluation ticks.
     #[builder(default = Duration::from_secs(3600))]
-    pub eval_interval: Duration,
-    /// Minimum new trades since last evaluation before re-evaluating a strategy.
+    pub eval_interval:            Duration,
+    /// Minimum new trades since last evaluation before re-evaluating a
+    /// strategy.
     #[builder(default = 100)]
     pub min_trades_between_evals: u32,
 }
@@ -51,7 +52,7 @@ pub struct FeedbackLoopConfig {
 impl Default for FeedbackLoopConfig {
     fn default() -> Self {
         Self {
-            eval_interval: Duration::from_secs(3600),
+            eval_interval:            Duration::from_secs(3600),
             min_trades_between_evals: 100,
         }
     }
@@ -174,19 +175,18 @@ pub async fn run_feedback_loop(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-    use std::sync::Arc;
+    use std::{collections::HashMap, sync::Arc};
 
+    use rara_domain::{
+        event::{Event, EventType},
+        feedback::FeedbackDecision,
+    };
+    use rara_event_bus::bus::EventBus;
     use rust_decimal_macros::dec;
     use serde_json::json;
 
-    use rara_domain::event::{Event, EventType};
-    use rara_domain::feedback::FeedbackDecision;
-    use rara_event_bus::bus::EventBus;
-
-    use crate::evaluator::StrategyEvaluator;
-
     use super::*;
+    use crate::evaluator::StrategyEvaluator;
 
     fn setup() -> (Arc<EventBus>, tempfile::TempDir) {
         let dir = tempfile::tempdir().unwrap();
@@ -205,16 +205,16 @@ mod tests {
         bus.publish(&event).unwrap();
     }
 
-    fn default_evaluator() -> StrategyEvaluator {
-        StrategyEvaluator::new(1.5, dec!(0.20), 5)
-    }
+    fn default_evaluator() -> StrategyEvaluator { StrategyEvaluator::new(1.5, dec!(0.20), 5) }
 
     #[test]
     fn evaluate_tick_publishes_promote_on_strong_performance() {
         let (bus, _dir) = setup();
 
         // Publish enough winning trades to exceed min_trades and get promotion
-        let pnls = ["120", "80", "110", "90", "130", "95", "105", "115", "100", "85"];
+        let pnls = [
+            "120", "80", "110", "90", "130", "95", "105", "115", "100", "85",
+        ];
         for pnl in &pnls {
             publish_fill(&bus, "strat-1", pnl);
         }
@@ -233,10 +233,7 @@ mod tests {
             feedback_events[0].event_type,
             EventType::FeedbackStrategyPromote
         );
-        assert_eq!(
-            feedback_events[0].strategy_id.as_deref(),
-            Some("strat-1")
-        );
+        assert_eq!(feedback_events[0].strategy_id.as_deref(), Some("strat-1"));
     }
 
     #[test]
@@ -295,8 +292,7 @@ mod tests {
         let mut last_eval = HashMap::new();
 
         // First tick evaluates (10 new trades >= min 5)
-        let evaluated =
-            evaluate_tick(&mut consumer, &evaluator, &bus, &mut last_eval, 5).unwrap();
+        let evaluated = evaluate_tick(&mut consumer, &evaluator, &bus, &mut last_eval, 5).unwrap();
         assert_eq!(evaluated, 1);
 
         // Add 3 more trades (below min_trades_between_evals of 5)
@@ -305,8 +301,7 @@ mod tests {
         }
 
         // Second tick should skip (only 3 new trades < min 5)
-        let evaluated =
-            evaluate_tick(&mut consumer, &evaluator, &bus, &mut last_eval, 5).unwrap();
+        let evaluated = evaluate_tick(&mut consumer, &evaluator, &bus, &mut last_eval, 5).unwrap();
         assert_eq!(evaluated, 0);
 
         // Only 1 feedback event from the first evaluation
@@ -356,8 +351,7 @@ mod tests {
         }
 
         // Second evaluation should trigger
-        let evaluated =
-            evaluate_tick(&mut consumer, &evaluator, &bus, &mut last_eval, 5).unwrap();
+        let evaluated = evaluate_tick(&mut consumer, &evaluator, &bus, &mut last_eval, 5).unwrap();
         assert_eq!(evaluated, 1);
 
         let feedback_events = bus.store().read_topic("feedback", 0, 10).unwrap();
@@ -400,8 +394,14 @@ mod tests {
             .trade_count(30)
             .build();
 
-        publish_decision_event(&bus, "strat-1", FeedbackDecision::Demote, "bad sharpe", &metrics)
-            .unwrap();
+        publish_decision_event(
+            &bus,
+            "strat-1",
+            FeedbackDecision::Demote,
+            "bad sharpe",
+            &metrics,
+        )
+        .unwrap();
 
         let events = bus.store().read_topic("feedback", 0, 10).unwrap();
         assert_eq!(events[0].event_type, EventType::FeedbackStrategyDemote);

--- a/crates/rara-feedback/src/retrain.rs
+++ b/crates/rara-feedback/src/retrain.rs
@@ -4,14 +4,12 @@
 use std::sync::Arc;
 
 use bon::Builder;
+use rara_domain::event::{Event, EventType};
+use rara_event_bus::{bus::EventBus, store::StoreError};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use uuid::Uuid;
-
-use rara_domain::event::{Event, EventType};
-use rara_event_bus::bus::EventBus;
-use rara_event_bus::store::StoreError;
 
 /// Event payload for a confirmed strategy.
 #[derive(Debug, Serialize)]
@@ -19,9 +17,9 @@ struct ConfirmedPayload {
     /// Experiment identifier.
     experiment_id: String,
     /// Paper trading Sharpe ratio.
-    sharpe_ratio: f64,
+    sharpe_ratio:  f64,
     /// Paper trading maximum drawdown (decimal string).
-    max_drawdown: String,
+    max_drawdown:  String,
 }
 
 /// Event payload for a retrain request.
@@ -30,11 +28,11 @@ struct RetrainRequestedPayload {
     /// Experiment identifier.
     experiment_id: String,
     /// Reason(s) for requesting retraining.
-    reason: String,
+    reason:        String,
     /// Paper trading Sharpe ratio.
-    sharpe_ratio: f64,
+    sharpe_ratio:  f64,
     /// Paper trading maximum drawdown (decimal string).
-    max_drawdown: String,
+    max_drawdown:  String,
 }
 
 /// Errors from retrain evaluation.
@@ -73,38 +71,28 @@ pub struct PaperMetrics {
     /// Maximum drawdown observed during paper trading.
     max_drawdown: Decimal,
     /// Total profit and loss (`PnL`).
-    pnl: Decimal,
+    pnl:          Decimal,
     /// Win rate as a fraction (0.0 – 1.0).
-    win_rate: f64,
+    win_rate:     f64,
     /// Total number of trades executed.
-    trade_count: u32,
+    trade_count:  u32,
 }
 
 impl PaperMetrics {
     /// Returns the Sharpe ratio.
-    pub const fn sharpe_ratio(&self) -> f64 {
-        self.sharpe_ratio
-    }
+    pub const fn sharpe_ratio(&self) -> f64 { self.sharpe_ratio }
 
     /// Returns the maximum drawdown.
-    pub const fn max_drawdown(&self) -> Decimal {
-        self.max_drawdown
-    }
+    pub const fn max_drawdown(&self) -> Decimal { self.max_drawdown }
 
     /// Returns the total `PnL`.
-    pub const fn pnl(&self) -> Decimal {
-        self.pnl
-    }
+    pub const fn pnl(&self) -> Decimal { self.pnl }
 
     /// Returns the win rate.
-    pub const fn win_rate(&self) -> f64 {
-        self.win_rate
-    }
+    pub const fn win_rate(&self) -> f64 { self.win_rate }
 
     /// Returns the trade count.
-    pub const fn trade_count(&self) -> u32 {
-        self.trade_count
-    }
+    pub const fn trade_count(&self) -> u32 { self.trade_count }
 }
 
 /// Metrics from the original backtest that serve as the baseline for
@@ -116,24 +104,18 @@ pub struct BacktestBaseline {
     /// Maximum drawdown from the original backtest.
     max_drawdown: Decimal,
     /// Total `PnL` from the original backtest.
-    pnl: Decimal,
+    pnl:          Decimal,
 }
 
 impl BacktestBaseline {
     /// Returns the baseline Sharpe ratio.
-    pub const fn sharpe_ratio(&self) -> f64 {
-        self.sharpe_ratio
-    }
+    pub const fn sharpe_ratio(&self) -> f64 { self.sharpe_ratio }
 
     /// Returns the baseline maximum drawdown.
-    pub const fn max_drawdown(&self) -> Decimal {
-        self.max_drawdown
-    }
+    pub const fn max_drawdown(&self) -> Decimal { self.max_drawdown }
 
     /// Returns the baseline `PnL`.
-    pub const fn pnl(&self) -> Decimal {
-        self.pnl
-    }
+    pub const fn pnl(&self) -> Decimal { self.pnl }
 }
 
 /// Evaluates paper trading results against thresholds and the original
@@ -144,17 +126,17 @@ impl BacktestBaseline {
 #[derive(Builder)]
 pub struct RetrainChecker {
     /// The event bus used to publish retrain/confirmed events.
-    event_bus: Arc<EventBus>,
+    event_bus:              Arc<EventBus>,
     /// Absolute Sharpe floor — retrain if paper Sharpe drops below this.
     #[builder(default = 0.5)]
-    sharpe_threshold: f64,
+    sharpe_threshold:       f64,
     /// Absolute drawdown ceiling — retrain if paper drawdown exceeds this.
     #[builder(default = Decimal::new(20, 2))]
     max_drawdown_threshold: Decimal,
     /// Fraction of original backtest Sharpe — retrain if paper Sharpe falls
     /// below this fraction of the baseline (e.g. 0.5 = 50% degradation).
     #[builder(default = 0.5)]
-    degradation_factor: f64,
+    degradation_factor:     f64,
 }
 
 impl RetrainChecker {
@@ -180,8 +162,8 @@ impl RetrainChecker {
                 .payload(
                     serde_json::to_value(ConfirmedPayload {
                         experiment_id: experiment_id.to_string(),
-                        sharpe_ratio: paper_metrics.sharpe_ratio(),
-                        max_drawdown: paper_metrics.max_drawdown().to_string(),
+                        sharpe_ratio:  paper_metrics.sharpe_ratio(),
+                        max_drawdown:  paper_metrics.max_drawdown().to_string(),
                     })
                     .expect("ConfirmedPayload must serialize"),
                 )
@@ -200,9 +182,9 @@ impl RetrainChecker {
                 .payload(
                     serde_json::to_value(RetrainRequestedPayload {
                         experiment_id: experiment_id.to_string(),
-                        reason: combined_reason.clone(),
-                        sharpe_ratio: paper_metrics.sharpe_ratio(),
-                        max_drawdown: paper_metrics.max_drawdown().to_string(),
+                        reason:        combined_reason.clone(),
+                        sharpe_ratio:  paper_metrics.sharpe_ratio(),
+                        max_drawdown:  paper_metrics.max_drawdown().to_string(),
                     })
                     .expect("RetrainRequestedPayload must serialize"),
                 )
@@ -220,11 +202,7 @@ impl RetrainChecker {
 
     /// Check all degradation conditions and return a list of reasons (empty
     /// if the strategy is healthy).
-    fn check_degradation(
-        &self,
-        paper: &PaperMetrics,
-        baseline: &BacktestBaseline,
-    ) -> Vec<String> {
+    fn check_degradation(&self, paper: &PaperMetrics, baseline: &BacktestBaseline) -> Vec<String> {
         let mut reasons = Vec::new();
 
         if paper.sharpe_ratio() < self.sharpe_threshold {

--- a/crates/rara-market-data/src/fetcher/binance.rs
+++ b/crates/rara-market-data/src/fetcher/binance.rs
@@ -10,8 +10,7 @@ use snafu::ResultExt;
 use tracing::info;
 
 use super::{HistoryFetcher, HttpSnafu, ParseSnafu, Result, StoreSnafu};
-use crate::store::candle::CandleRow;
-use crate::store::MarketStore;
+use crate::store::{MarketStore, candle::CandleRow};
 
 /// Maximum candles per Binance klines request.
 const PAGE_LIMIT: u64 = 1000;
@@ -22,12 +21,12 @@ const BASE_URL: &str = "https://api.binance.com";
 /// Raw candle parsed from Binance JSON before DB insertion.
 struct RawKline {
     open_time_ms: i64,
-    open: f64,
-    high: f64,
-    low: f64,
-    close: f64,
-    volume: f64,
-    trade_count: u32,
+    open:         f64,
+    high:         f64,
+    low:          f64,
+    close:        f64,
+    volume:       f64,
+    trade_count:  u32,
 }
 
 /// Fetches historical 1m klines from Binance public API.
@@ -50,7 +49,8 @@ impl BinanceFetcher {
     /// Fetch one page of klines.
     async fn fetch_page(&self, start_ms: i64, end_ms: i64) -> Result<Vec<RawKline>> {
         let url = format!(
-            "{BASE_URL}/api/v3/klines?symbol={}&interval=1m&startTime={start_ms}&endTime={end_ms}&limit={PAGE_LIMIT}",
+            "{BASE_URL}/api/v3/klines?symbol={}&interval=1m&startTime={start_ms}&endTime={end_ms}&\
+             limit={PAGE_LIMIT}",
             self.symbol
         );
         let resp = self
@@ -79,10 +79,7 @@ impl HistoryFetcher for BinanceFetcher {
         start: NaiveDate,
         end: NaiveDate,
     ) -> Result<usize> {
-        let range_start_ms = start
-            .and_time(NaiveTime::MIN)
-            .and_utc()
-            .timestamp_millis();
+        let range_start_ms = start.and_time(NaiveTime::MIN).and_utc().timestamp_millis();
         let range_end_ms = end
             .checked_add_days(Days::new(1))
             .expect("date overflow")
@@ -118,20 +115,23 @@ impl HistoryFetcher for BinanceFetcher {
             let candle_rows: Vec<CandleRow> = page
                 .iter()
                 .map(|k| CandleRow {
-                    ts: DateTime::from_timestamp_millis(k.open_time_ms)
+                    ts:            DateTime::from_timestamp_millis(k.open_time_ms)
                         .unwrap_or(DateTime::<Utc>::MIN_UTC),
                     instrument_id: instrument_id.to_string(),
-                    interval: "1m".to_string(),
-                    open: k.open,
-                    high: k.high,
-                    low: k.low,
-                    close: k.close,
-                    volume: k.volume,
-                    trade_count: k.trade_count.cast_signed(),
+                    interval:      "1m".to_string(),
+                    open:          k.open,
+                    high:          k.high,
+                    low:           k.low,
+                    close:         k.close,
+                    volume:        k.volume,
+                    trade_count:   k.trade_count.cast_signed(),
                 })
                 .collect();
 
-            let count = store.insert_candles(&candle_rows).await.context(StoreSnafu)?;
+            let count = store
+                .insert_candles(&candle_rows)
+                .await
+                .context(StoreSnafu)?;
             total += usize::try_from(count).expect("candle count fits in usize");
         }
 

--- a/crates/rara-market-data/src/fetcher/yahoo.rs
+++ b/crates/rara-market-data/src/fetcher/yahoo.rs
@@ -12,8 +12,7 @@ use snafu::ResultExt;
 use tracing::info;
 
 use super::{HistoryFetcher, HttpSnafu, ParseSnafu, Result, StoreSnafu};
-use crate::store::candle::CandleRow;
-use crate::store::MarketStore;
+use crate::store::{MarketStore, candle::CandleRow};
 
 /// Yahoo Finance chart API base URL.
 const BASE_URL: &str = "https://query1.finance.yahoo.com/v8/finance/chart";
@@ -174,7 +173,7 @@ struct YahooChart {
 
 #[derive(Deserialize)]
 struct YahooResult {
-    timestamp: Vec<i64>,
+    timestamp:  Vec<i64>,
     indicators: YahooIndicators,
 }
 
@@ -185,9 +184,9 @@ struct YahooIndicators {
 
 #[derive(Deserialize)]
 struct YahooQuote {
-    open: Vec<Option<f64>>,
-    high: Vec<Option<f64>>,
-    low: Vec<Option<f64>>,
-    close: Vec<Option<f64>>,
+    open:   Vec<Option<f64>>,
+    high:   Vec<Option<f64>>,
+    low:    Vec<Option<f64>>,
+    close:  Vec<Option<f64>>,
     volume: Vec<Option<f64>>,
 }

--- a/crates/rara-market-data/src/store/candle.rs
+++ b/crates/rara-market-data/src/store/candle.rs
@@ -13,36 +13,36 @@ pub struct CandleCoverage {
     /// Instrument identifier.
     pub instrument_id: String,
     /// Candle interval.
-    pub interval: String,
+    pub interval:      String,
     /// Total candle count.
-    pub count: i64,
+    pub count:         i64,
     /// Earliest candle timestamp.
-    pub min_ts: Option<DateTime<Utc>>,
+    pub min_ts:        Option<DateTime<Utc>>,
     /// Latest candle timestamp.
-    pub max_ts: Option<DateTime<Utc>>,
+    pub max_ts:        Option<DateTime<Utc>>,
 }
 
 /// A single OHLCV candle row, used for both insert and query.
 #[derive(Debug, Clone)]
 pub struct CandleRow {
     /// Candle open timestamp (UTC).
-    pub ts: DateTime<Utc>,
+    pub ts:            DateTime<Utc>,
     /// Instrument identifier, e.g. `"binance-BTCUSDT"`.
     pub instrument_id: String,
     /// Candle interval, e.g. `"1m"`, `"1d"`.
-    pub interval: String,
+    pub interval:      String,
     /// Open price.
-    pub open: f64,
+    pub open:          f64,
     /// High price.
-    pub high: f64,
+    pub high:          f64,
     /// Low price.
-    pub low: f64,
+    pub low:           f64,
     /// Close price.
-    pub close: f64,
+    pub close:         f64,
     /// Volume.
-    pub volume: f64,
+    pub volume:        f64,
     /// Number of trades.
-    pub trade_count: i32,
+    pub trade_count:   i32,
 }
 
 impl MarketStore {
@@ -66,8 +66,10 @@ impl MarketStore {
         let trade_counts: Vec<i32> = candles.iter().map(|c| c.trade_count).collect();
 
         let result = sqlx::query(
-            "INSERT INTO candles (ts, instrument_id, interval, open, high, low, close, volume, trade_count)
-             SELECT * FROM UNNEST($1::timestamptz[], $2::text[], $3::text[], $4::float8[], $5::float8[], $6::float8[], $7::float8[], $8::float8[], $9::int4[])
+            "INSERT INTO candles (ts, instrument_id, interval, open, high, low, close, volume, \
+             trade_count)
+             SELECT * FROM UNNEST($1::timestamptz[], $2::text[], $3::text[], $4::float8[], \
+             $5::float8[], $6::float8[], $7::float8[], $8::float8[], $9::int4[])
              ON CONFLICT (ts, instrument_id, interval) DO NOTHING",
         )
         .bind(&ts)
@@ -87,7 +89,8 @@ impl MarketStore {
         Ok(result.rows_affected())
     }
 
-    /// Query candles for a given instrument and time range, ordered by time ascending.
+    /// Query candles for a given instrument and time range, ordered by time
+    /// ascending.
     #[tracing::instrument(skip(self))]
     pub async fn query_candles(
         &self,
@@ -126,7 +129,8 @@ impl MarketStore {
     /// Get coverage summary for all instrument+interval pairs in the store.
     pub async fn get_coverage(&self) -> Result<Vec<CandleCoverage>> {
         let rows = sqlx::query_as::<_, CoverageRow>(
-            "SELECT instrument_id, interval, count(*) as count, min(ts) as min_ts, max(ts) as max_ts
+            "SELECT instrument_id, interval, count(*) as count, min(ts) as min_ts, max(ts) as \
+             max_ts
              FROM candles
              GROUP BY instrument_id, interval
              ORDER BY instrument_id, interval",
@@ -139,10 +143,10 @@ impl MarketStore {
             .into_iter()
             .map(|r| CandleCoverage {
                 instrument_id: r.instrument_id,
-                interval: r.interval,
-                count: r.count.unwrap_or(0),
-                min_ts: r.min_ts,
-                max_ts: r.max_ts,
+                interval:      r.interval,
+                count:         r.count.unwrap_or(0),
+                min_ts:        r.min_ts,
+                max_ts:        r.max_ts,
             })
             .collect())
     }
@@ -174,38 +178,38 @@ impl MarketStore {
 #[derive(sqlx::FromRow)]
 struct CoverageRow {
     instrument_id: String,
-    interval: String,
-    count: Option<i64>,
-    min_ts: Option<DateTime<Utc>>,
-    max_ts: Option<DateTime<Utc>>,
+    interval:      String,
+    count:         Option<i64>,
+    min_ts:        Option<DateTime<Utc>>,
+    max_ts:        Option<DateTime<Utc>>,
 }
 
 /// Internal query result type that implements `sqlx::FromRow`.
 #[derive(sqlx::FromRow)]
 struct CandleQueryRow {
-    ts: DateTime<Utc>,
+    ts:            DateTime<Utc>,
     instrument_id: String,
-    interval: String,
-    open: f64,
-    high: f64,
-    low: f64,
-    close: f64,
-    volume: f64,
-    trade_count: i32,
+    interval:      String,
+    open:          f64,
+    high:          f64,
+    low:           f64,
+    close:         f64,
+    volume:        f64,
+    trade_count:   i32,
 }
 
 impl From<CandleQueryRow> for CandleRow {
     fn from(row: CandleQueryRow) -> Self {
         Self {
-            ts: row.ts,
+            ts:            row.ts,
             instrument_id: row.instrument_id,
-            interval: row.interval,
-            open: row.open,
-            high: row.high,
-            low: row.low,
-            close: row.close,
-            volume: row.volume,
-            trade_count: row.trade_count,
+            interval:      row.interval,
+            open:          row.open,
+            high:          row.high,
+            low:           row.low,
+            close:         row.close,
+            volume:        row.volume,
+            trade_count:   row.trade_count,
         }
     }
 }

--- a/crates/rara-market-data/src/store/mod.rs
+++ b/crates/rara-market-data/src/store/mod.rs
@@ -4,8 +4,7 @@ pub mod candle;
 pub mod tick;
 
 use snafu::{ResultExt, Snafu};
-use sqlx::postgres::PgPoolOptions;
-use sqlx::PgPool;
+use sqlx::{PgPool, postgres::PgPoolOptions};
 
 /// Errors from market data store operations.
 #[derive(Debug, Snafu)]

--- a/crates/rara-market-data/src/store/tick.rs
+++ b/crates/rara-market-data/src/store/tick.rs
@@ -10,15 +10,15 @@ use super::{DatabaseSnafu, MarketStore, Result};
 #[derive(Debug, Clone)]
 pub struct TickRow {
     /// Trade timestamp (UTC).
-    pub ts: DateTime<Utc>,
+    pub ts:            DateTime<Utc>,
     /// Instrument identifier.
     pub instrument_id: String,
     /// Trade price.
-    pub price: f64,
+    pub price:         f64,
     /// Trade amount.
-    pub amount: f64,
+    pub amount:        f64,
     /// Trade side: 0 = buy, 1 = sell.
-    pub side: i16,
+    pub side:          i16,
 }
 
 impl MarketStore {
@@ -36,7 +36,8 @@ impl MarketStore {
 
         let result = sqlx::query(
             "INSERT INTO ticks (ts, instrument_id, price, amount, side)
-             SELECT * FROM UNNEST($1::timestamptz[], $2::text[], $3::float8[], $4::float8[], $5::int2[])",
+             SELECT * FROM UNNEST($1::timestamptz[], $2::text[], $3::float8[], $4::float8[], \
+             $5::int2[])",
         )
         .bind(&ts)
         .bind(&instrument_ids)

--- a/crates/rara-market-data/src/stream/aggregator.rs
+++ b/crates/rara-market-data/src/stream/aggregator.rs
@@ -15,21 +15,21 @@ use super::binance_ws::RawKline;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AggregatedCandle {
     /// Symbol (e.g., "BTCUSDT").
-    pub symbol: String,
+    pub symbol:      String,
     /// Candle open timestamp (aligned to interval boundary).
-    pub ts: DateTime<Utc>,
+    pub ts:          DateTime<Utc>,
     /// Timeframe interval string (e.g., "5m", "1h").
-    pub interval: String,
+    pub interval:    String,
     /// Open price (first candle's open).
-    pub open: f64,
+    pub open:        f64,
     /// Highest price across all constituent candles.
-    pub high: f64,
+    pub high:        f64,
     /// Lowest price across all constituent candles.
-    pub low: f64,
+    pub low:         f64,
     /// Close price (last candle's close).
-    pub close: f64,
+    pub close:       f64,
     /// Total volume summed across all constituent candles.
-    pub volume: f64,
+    pub volume:      f64,
     /// Total trade count summed across all constituent candles.
     pub trade_count: i32,
 }
@@ -37,15 +37,15 @@ pub struct AggregatedCandle {
 /// Tracks partial candle state during aggregation.
 struct PartialCandle {
     /// Aligned open timestamp for this bucket.
-    open_ts: DateTime<Utc>,
-    open: f64,
-    high: f64,
-    low: f64,
-    close: f64,
-    volume: f64,
+    open_ts:     DateTime<Utc>,
+    open:        f64,
+    high:        f64,
+    low:         f64,
+    close:       f64,
+    volume:      f64,
     trade_count: i32,
     /// Number of 1m candles absorbed so far.
-    count: u32,
+    count:       u32,
 }
 
 impl PartialCandle {
@@ -73,14 +73,14 @@ impl PartialCandle {
 
     fn into_candle(self, symbol: &str, interval: &str) -> AggregatedCandle {
         AggregatedCandle {
-            symbol: symbol.to_string(),
-            ts: self.open_ts,
-            interval: interval.to_string(),
-            open: self.open,
-            high: self.high,
-            low: self.low,
-            close: self.close,
-            volume: self.volume,
+            symbol:      symbol.to_string(),
+            ts:          self.open_ts,
+            interval:    interval.to_string(),
+            open:        self.open,
+            high:        self.high,
+            low:         self.low,
+            close:       self.close,
+            volume:      self.volume,
             trade_count: self.trade_count,
         }
     }
@@ -99,9 +99,9 @@ pub struct CandleAggregator {
     /// Target intervals to aggregate into: (`interval_name`, minutes).
     intervals: Vec<(String, u32)>,
     /// Partial candle buffers keyed by (symbol, interval).
-    buffers: HashMap<AggKey, PartialCandle>,
+    buffers:   HashMap<AggKey, PartialCandle>,
     /// Broadcast sender for completed candles.
-    sender: broadcast::Sender<AggregatedCandle>,
+    sender:    broadcast::Sender<AggregatedCandle>,
 }
 
 impl CandleAggregator {
@@ -129,9 +129,7 @@ impl CandleAggregator {
     }
 
     /// Subscribe to receive completed candles.
-    pub fn subscribe(&self) -> broadcast::Receiver<AggregatedCandle> {
-        self.sender.subscribe()
-    }
+    pub fn subscribe(&self) -> broadcast::Receiver<AggregatedCandle> { self.sender.subscribe() }
 
     /// Process a closed 1m kline, potentially emitting aggregated candles.
     ///
@@ -214,20 +212,25 @@ mod tests {
     use super::*;
 
     /// Helper to create a closed 1m `RawKline` at a given minute offset.
-    fn make_kline(symbol: &str, hour: u32, minute: u32, ohlcv: (f64, f64, f64, f64, f64, i32)) -> RawKline {
+    fn make_kline(
+        symbol: &str,
+        hour: u32,
+        minute: u32,
+        ohlcv: (f64, f64, f64, f64, f64, i32),
+    ) -> RawKline {
         let ts = Utc.with_ymd_and_hms(2025, 1, 15, hour, minute, 0).unwrap();
         RawKline {
-            symbol: symbol.to_string(),
-            open_time: ts.timestamp_millis(),
-            close_time: ts.timestamp_millis() + 59_999,
-            interval: "1m".to_string(),
-            open: ohlcv.0,
-            high: ohlcv.1,
-            low: ohlcv.2,
-            close: ohlcv.3,
-            volume: ohlcv.4,
+            symbol:      symbol.to_string(),
+            open_time:   ts.timestamp_millis(),
+            close_time:  ts.timestamp_millis() + 59_999,
+            interval:    "1m".to_string(),
+            open:        ohlcv.0,
+            high:        ohlcv.1,
+            low:         ohlcv.2,
+            close:       ohlcv.3,
+            volume:      ohlcv.4,
             trade_count: ohlcv.5,
-            is_closed: true,
+            is_closed:   true,
         }
     }
 
@@ -260,19 +263,44 @@ mod tests {
         let (mut agg, mut rx) = CandleAggregator::new(&intervals);
 
         // Minute 0: open=100, high=105, low=99, close=102, vol=10, trades=5
-        agg.process_kline(&make_kline("BTCUSDT", 10, 0, (100.0, 105.0, 99.0, 102.0, 10.0, 5)));
+        agg.process_kline(&make_kline(
+            "BTCUSDT",
+            10,
+            0,
+            (100.0, 105.0, 99.0, 102.0, 10.0, 5),
+        ));
         // Minute 1: high spike
-        agg.process_kline(&make_kline("BTCUSDT", 10, 1, (102.0, 110.0, 101.0, 108.0, 20.0, 8)));
+        agg.process_kline(&make_kline(
+            "BTCUSDT",
+            10,
+            1,
+            (102.0, 110.0, 101.0, 108.0, 20.0, 8),
+        ));
         // Minute 2: low dip
-        agg.process_kline(&make_kline("BTCUSDT", 10, 2, (108.0, 109.0, 95.0, 97.0, 15.0, 3)));
+        agg.process_kline(&make_kline(
+            "BTCUSDT",
+            10,
+            2,
+            (108.0, 109.0, 95.0, 97.0, 15.0, 3),
+        ));
         // Minute 3
-        agg.process_kline(&make_kline("BTCUSDT", 10, 3, (97.0, 100.0, 96.0, 99.0, 12.0, 6)));
+        agg.process_kline(&make_kline(
+            "BTCUSDT",
+            10,
+            3,
+            (97.0, 100.0, 96.0, 99.0, 12.0, 6),
+        ));
 
         // After 4 candles, nothing should be emitted yet
         assert!(rx.try_recv().is_err());
 
         // Minute 4: completes the 5m bucket
-        agg.process_kline(&make_kline("BTCUSDT", 10, 4, (99.0, 103.0, 98.0, 101.0, 18.0, 7)));
+        agg.process_kline(&make_kline(
+            "BTCUSDT",
+            10,
+            4,
+            (99.0, 103.0, 98.0, 101.0, 18.0, 7),
+        ));
 
         let candle = rx.try_recv().expect("should emit 5m candle");
         assert_eq!(candle.symbol, "BTCUSDT");
@@ -297,17 +325,39 @@ mod tests {
         let (mut agg, mut rx) = CandleAggregator::new(&intervals);
 
         // Feed 3 of 5 candles in the 10:00-10:04 bucket
-        agg.process_kline(&make_kline("BTCUSDT", 10, 0, (100.0, 105.0, 99.0, 102.0, 10.0, 5)));
-        agg.process_kline(&make_kline("BTCUSDT", 10, 1, (102.0, 106.0, 101.0, 104.0, 8.0, 3)));
-        agg.process_kline(&make_kline("BTCUSDT", 10, 2, (104.0, 107.0, 103.0, 105.0, 12.0, 4)));
+        agg.process_kline(&make_kline(
+            "BTCUSDT",
+            10,
+            0,
+            (100.0, 105.0, 99.0, 102.0, 10.0, 5),
+        ));
+        agg.process_kline(&make_kline(
+            "BTCUSDT",
+            10,
+            1,
+            (102.0, 106.0, 101.0, 104.0, 8.0, 3),
+        ));
+        agg.process_kline(&make_kline(
+            "BTCUSDT",
+            10,
+            2,
+            (104.0, 107.0, 103.0, 105.0, 12.0, 4),
+        ));
 
         // No emission yet
         assert!(rx.try_recv().is_err());
 
         // Jump to next bucket (10:05) -- should flush the partial
-        agg.process_kline(&make_kline("BTCUSDT", 10, 5, (105.0, 108.0, 104.0, 107.0, 15.0, 6)));
+        agg.process_kline(&make_kline(
+            "BTCUSDT",
+            10,
+            5,
+            (105.0, 108.0, 104.0, 107.0, 15.0, 6),
+        ));
 
-        let candle = rx.try_recv().expect("partial bucket should be emitted on new bucket");
+        let candle = rx
+            .try_recv()
+            .expect("partial bucket should be emitted on new bucket");
         assert_eq!(candle.interval, "5m");
         // Partial had 3 candles: open from first, close from third
         assert!((candle.open - 100.0).abs() < f64::EPSILON);
@@ -323,10 +373,20 @@ mod tests {
 
         // Feed 5 candles for BTC and only 3 for ETH
         for m in 0..5 {
-            agg.process_kline(&make_kline("BTCUSDT", 10, m, (100.0, 105.0, 99.0, 102.0, 10.0, 1)));
+            agg.process_kline(&make_kline(
+                "BTCUSDT",
+                10,
+                m,
+                (100.0, 105.0, 99.0, 102.0, 10.0, 1),
+            ));
         }
         for m in 0..3 {
-            agg.process_kline(&make_kline("ETHUSDT", 10, m, (3000.0, 3100.0, 2900.0, 3050.0, 5.0, 2)));
+            agg.process_kline(&make_kline(
+                "ETHUSDT",
+                10,
+                m,
+                (3000.0, 3100.0, 2900.0, 3050.0, 5.0, 2),
+            ));
         }
 
         // BTC should have emitted, ETH should not
@@ -371,7 +431,12 @@ mod tests {
 
         // Feed 5 candles (minute 0-4) -- should complete 5m but not 15m
         for m in 0..5 {
-            agg.process_kline(&make_kline("BTCUSDT", 10, m, (100.0, 105.0, 99.0, 102.0, 10.0, 1)));
+            agg.process_kline(&make_kline(
+                "BTCUSDT",
+                10,
+                m,
+                (100.0, 105.0, 99.0, 102.0, 10.0, 1),
+            ));
         }
 
         let candle = rx.try_recv().expect("5m candle should emit");
@@ -382,10 +447,16 @@ mod tests {
 
         // Feed remaining 10 candles to complete the 15m bucket
         for m in 5..15 {
-            agg.process_kline(&make_kline("BTCUSDT", 10, m, (102.0, 106.0, 98.0, 103.0, 8.0, 2)));
+            agg.process_kline(&make_kline(
+                "BTCUSDT",
+                10,
+                m,
+                (102.0, 106.0, 98.0, 103.0, 8.0, 2),
+            ));
         }
 
-        // Should have emitted two more 5m candles (10:05-10:09, 10:10-10:14) and one 15m
+        // Should have emitted two more 5m candles (10:05-10:09, 10:10-10:14) and one
+        // 15m
         let mut intervals_seen = Vec::new();
         while let Ok(c) = rx.try_recv() {
             intervals_seen.push(c.interval.clone());
@@ -401,7 +472,12 @@ mod tests {
         let mut rx2 = agg.subscribe();
 
         for m in 0..5 {
-            agg.process_kline(&make_kline("BTCUSDT", 10, m, (100.0, 105.0, 99.0, 102.0, 10.0, 1)));
+            agg.process_kline(&make_kline(
+                "BTCUSDT",
+                10,
+                m,
+                (100.0, 105.0, 99.0, 102.0, 10.0, 1),
+            ));
         }
 
         // Both receivers should get the candle

--- a/crates/rara-market-data/src/stream/binance_ws.rs
+++ b/crates/rara-market-data/src/stream/binance_ws.rs
@@ -37,27 +37,27 @@ pub type Result<T> = std::result::Result<T, WsError>;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RawKline {
     /// Symbol (e.g., "BTCUSDT").
-    pub symbol: String,
+    pub symbol:      String,
     /// Kline open time in milliseconds since epoch.
-    pub open_time: i64,
+    pub open_time:   i64,
     /// Kline close time in milliseconds since epoch.
-    pub close_time: i64,
+    pub close_time:  i64,
     /// Interval string (e.g., "1m", "1h").
-    pub interval: String,
+    pub interval:    String,
     /// Open price.
-    pub open: f64,
+    pub open:        f64,
     /// High price.
-    pub high: f64,
+    pub high:        f64,
     /// Low price.
-    pub low: f64,
+    pub low:         f64,
     /// Close price.
-    pub close: f64,
+    pub close:       f64,
     /// Base asset volume.
-    pub volume: f64,
+    pub volume:      f64,
     /// Number of trades in this kline.
     pub trade_count: i32,
     /// Whether this kline is closed (final).
-    pub is_closed: bool,
+    pub is_closed:   bool,
 }
 
 /// Binance kline event wrapper matching the raw JSON structure.
@@ -66,32 +66,32 @@ struct BinanceKlineEvent {
     #[serde(rename = "s")]
     symbol: String,
     #[serde(rename = "k")]
-    kline: BinanceKlineData,
+    kline:  BinanceKlineData,
 }
 
 /// Inner kline data fields from the Binance stream.
 #[derive(Debug, Deserialize)]
 struct BinanceKlineData {
     #[serde(rename = "t")]
-    open_time: i64,
+    open_time:   i64,
     #[serde(rename = "T")]
-    close_time: i64,
+    close_time:  i64,
     #[serde(rename = "i")]
-    interval: String,
+    interval:    String,
     #[serde(rename = "o")]
-    open: String,
+    open:        String,
     #[serde(rename = "h")]
-    high: String,
+    high:        String,
     #[serde(rename = "l")]
-    low: String,
+    low:         String,
     #[serde(rename = "c")]
-    close: String,
+    close:       String,
     #[serde(rename = "v")]
-    volume: String,
+    volume:      String,
     #[serde(rename = "n")]
     trade_count: i32,
     #[serde(rename = "x")]
-    is_closed: bool,
+    is_closed:   bool,
 }
 
 /// Combined stream wrapper used by Binance multi-symbol endpoints.
@@ -116,11 +116,10 @@ impl Default for BinanceWsClient {
 
 impl BinanceWsClient {
     /// Create a new client with the default Binance WebSocket URL.
-    pub fn new() -> Self {
-        Self::default()
-    }
+    pub fn new() -> Self { Self::default() }
 
-    /// Create a client with a custom WebSocket URL (useful for testing or proxies).
+    /// Create a client with a custom WebSocket URL (useful for testing or
+    /// proxies).
     pub fn with_url(base_url: impl Into<String>) -> Self {
         Self {
             base_url: base_url.into(),
@@ -140,9 +139,12 @@ impl BinanceWsClient {
 
         tracing::info!(%symbol, %interval, %url, "connecting to Binance kline stream");
 
-        let (ws_stream, _) = tokio_tungstenite::connect_async(&url)
-            .await
-            .map_err(|e| WsError::Connection { source: Box::new(e) })?;
+        let (ws_stream, _) =
+            tokio_tungstenite::connect_async(&url)
+                .await
+                .map_err(|e| WsError::Connection {
+                    source: Box::new(e),
+                })?;
 
         tracing::info!(%symbol, %interval, "WebSocket connected");
 
@@ -159,7 +161,9 @@ impl BinanceWsClient {
                     tracing::warn!("WebSocket closed by server");
                     Some(Err(WsError::StreamEnded))
                 }
-                Err(e) => Some(Err(WsError::Connection { source: Box::new(e) })),
+                Err(e) => Some(Err(WsError::Connection {
+                    source: Box::new(e),
+                })),
                 _ => None,
             };
             std::future::ready(result)
@@ -186,9 +190,12 @@ impl BinanceWsClient {
 
         tracing::info!(?subscriptions, %url, "connecting to combined kline stream");
 
-        let (ws_stream, _) = tokio_tungstenite::connect_async(&url)
-            .await
-            .map_err(|e| WsError::Connection { source: Box::new(e) })?;
+        let (ws_stream, _) =
+            tokio_tungstenite::connect_async(&url)
+                .await
+                .map_err(|e| WsError::Connection {
+                    source: Box::new(e),
+                })?;
 
         tracing::info!("combined WebSocket connected");
 
@@ -202,7 +209,9 @@ impl BinanceWsClient {
                     tracing::warn!("WebSocket closed by server");
                     Some(Err(WsError::StreamEnded))
                 }
-                Err(e) => Some(Err(WsError::Connection { source: Box::new(e) })),
+                Err(e) => Some(Err(WsError::Connection {
+                    source: Box::new(e),
+                })),
                 _ => None,
             };
             std::future::ready(result)
@@ -231,17 +240,17 @@ fn parse_combined_message(text: &str) -> Result<RawKline> {
 fn kline_event_to_raw(event: BinanceKlineEvent) -> RawKline {
     let k = event.kline;
     RawKline {
-        symbol: event.symbol,
-        open_time: k.open_time,
-        close_time: k.close_time,
-        interval: k.interval,
-        open: k.open.parse().unwrap_or(0.0),
-        high: k.high.parse().unwrap_or(0.0),
-        low: k.low.parse().unwrap_or(0.0),
-        close: k.close.parse().unwrap_or(0.0),
-        volume: k.volume.parse().unwrap_or(0.0),
+        symbol:      event.symbol,
+        open_time:   k.open_time,
+        close_time:  k.close_time,
+        interval:    k.interval,
+        open:        k.open.parse().unwrap_or(0.0),
+        high:        k.high.parse().unwrap_or(0.0),
+        low:         k.low.parse().unwrap_or(0.0),
+        close:       k.close.parse().unwrap_or(0.0),
+        volume:      k.volume.parse().unwrap_or(0.0),
         trade_count: k.trade_count,
-        is_closed: k.is_closed,
+        is_closed:   k.is_closed,
     }
 }
 

--- a/crates/rara-market-data/src/stream/persister.rs
+++ b/crates/rara-market-data/src/stream/persister.rs
@@ -6,8 +6,7 @@
 use tokio::sync::broadcast;
 
 use super::aggregator::AggregatedCandle;
-use crate::store::candle::CandleRow;
-use crate::store::MarketStore;
+use crate::store::{MarketStore, candle::CandleRow};
 
 /// Run the candle persister loop, consuming candles and writing to the store.
 ///
@@ -25,15 +24,15 @@ pub async fn run_candle_persister(
             Ok(candle) => {
                 let instrument_id = format!("{}-{}", instrument_prefix, candle.symbol);
                 let row = CandleRow {
-                    ts: candle.ts,
+                    ts:            candle.ts,
                     instrument_id: instrument_id.clone(),
-                    interval: candle.interval.clone(),
-                    open: candle.open,
-                    high: candle.high,
-                    low: candle.low,
-                    close: candle.close,
-                    volume: candle.volume,
-                    trade_count: candle.trade_count,
+                    interval:      candle.interval.clone(),
+                    open:          candle.open,
+                    high:          candle.high,
+                    low:           candle.low,
+                    close:         candle.close,
+                    volume:        candle.volume,
+                    trade_count:   candle.trade_count,
                 };
 
                 match store.insert_candles(&[row]).await {

--- a/crates/rara-market-data/src/stream/reconnect.rs
+++ b/crates/rara-market-data/src/stream/reconnect.rs
@@ -11,11 +11,11 @@ use super::binance_ws::{BinanceWsClient, RawKline, WsError};
 #[derive(Debug, Clone)]
 pub struct ReconnectConfig {
     /// Initial backoff delay after first failure.
-    pub initial_delay: Duration,
+    pub initial_delay:             Duration,
     /// Maximum backoff delay cap.
-    pub max_delay: Duration,
+    pub max_delay:                 Duration,
     /// Backoff multiplier applied after each consecutive failure.
-    pub multiplier: f64,
+    pub multiplier:                f64,
     /// Number of consecutive failures before logging an alert.
     pub max_failures_before_alert: u32,
 }
@@ -23,9 +23,9 @@ pub struct ReconnectConfig {
 impl Default for ReconnectConfig {
     fn default() -> Self {
         Self {
-            initial_delay: Duration::from_secs(1),
-            max_delay: Duration::from_secs(60),
-            multiplier: 2.0,
+            initial_delay:             Duration::from_secs(1),
+            max_delay:                 Duration::from_secs(60),
+            multiplier:                2.0,
             max_failures_before_alert: 10,
         }
     }
@@ -50,7 +50,7 @@ pub struct ReconnectingWsClient {
     /// Reconnection configuration.
     pub config: ReconnectConfig,
     /// Broadcast sender for klines -- survives reconnects.
-    sender: broadcast::Sender<RawKline>,
+    sender:     broadcast::Sender<RawKline>,
 }
 
 impl ReconnectingWsClient {
@@ -65,9 +65,7 @@ impl ReconnectingWsClient {
     }
 
     /// Subscribe to receive klines. The returned receiver survives reconnects.
-    pub fn subscribe(&self) -> broadcast::Receiver<RawKline> {
-        self.sender.subscribe()
-    }
+    pub fn subscribe(&self) -> broadcast::Receiver<RawKline> { self.sender.subscribe() }
 
     /// Run the reconnecting stream loop for the given subscriptions.
     ///

--- a/crates/rara-research/src/backtest_pool.rs
+++ b/crates/rara-research/src/backtest_pool.rs
@@ -2,13 +2,14 @@
 
 use std::sync::Arc;
 
+use rara_domain::{research::BacktestResult, timeframe::Timeframe};
 use snafu::Snafu;
 use tokio::sync::Semaphore;
 
-use crate::backtester::{BacktestError, Backtester};
-use crate::strategy_executor::StrategyExecutor;
-use rara_domain::research::BacktestResult;
-use rara_domain::timeframe::Timeframe;
+use crate::{
+    backtester::{BacktestError, Backtester},
+    strategy_executor::StrategyExecutor,
+};
 
 /// Errors from pool operations.
 #[derive(Debug, Snafu)]
@@ -20,7 +21,7 @@ pub enum PoolError {
         /// Identifier of the failed task.
         task_id: String,
         /// Underlying backtest error.
-        source: BacktestError,
+        source:  BacktestError,
     },
 }
 
@@ -28,13 +29,13 @@ pub enum PoolError {
 #[derive(Debug, Clone)]
 pub struct BacktestTask {
     /// Unique identifier for this task.
-    pub id: String,
+    pub id:                String,
     /// Compiled WASM strategy bytes.
     pub strategy_artifact: Arc<Vec<u8>>,
     /// Contract to run the backtest against.
-    pub contract_id: String,
+    pub contract_id:       String,
     /// Target timeframe for candle aggregation.
-    pub timeframe: Timeframe,
+    pub timeframe:         Timeframe,
 }
 
 /// Parallel backtest scheduler that limits concurrency via a semaphore.
@@ -42,14 +43,14 @@ pub struct BacktestPool<B: Backtester> {
     /// Maximum number of concurrent backtests.
     concurrency: usize,
     /// Shared backtester implementation.
-    backtester: Arc<B>,
+    backtester:  Arc<B>,
     /// Strategy executor for loading artifacts into handles.
-    executor: Arc<dyn StrategyExecutor>,
+    executor:    Arc<dyn StrategyExecutor>,
 }
 
 impl<B: Backtester + 'static> BacktestPool<B> {
-    /// Create a new pool with the given backtester, executor, and default concurrency
-    /// (`num_cpus` - 1, minimum 1).
+    /// Create a new pool with the given backtester, executor, and default
+    /// concurrency (`num_cpus` - 1, minimum 1).
     pub fn new(backtester: Arc<B>, executor: Arc<dyn StrategyExecutor>) -> Self {
         let concurrency = num_cpus::get().saturating_sub(1).max(1);
         Self {
@@ -72,7 +73,8 @@ impl<B: Backtester + 'static> BacktestPool<B> {
         }
     }
 
-    /// Run a batch of backtest tasks in parallel, respecting the concurrency limit.
+    /// Run a batch of backtest tasks in parallel, respecting the concurrency
+    /// limit.
     ///
     /// Returns results in the same order as the input tasks.
     pub async fn run_batch(
@@ -89,14 +91,14 @@ impl<B: Backtester + 'static> BacktestPool<B> {
             let handle = tokio::spawn(async move {
                 let _permit = sem.acquire().await.expect("semaphore not closed");
                 let strategy_handle =
-                    executor.load(&task.strategy_artifact).map_err(|e| {
-                        PoolError::TaskFailed {
+                    executor
+                        .load(&task.strategy_artifact)
+                        .map_err(|e| PoolError::TaskFailed {
                             task_id: task.id.clone(),
-                            source: BacktestError::ExecutionFailed {
+                            source:  BacktestError::ExecutionFailed {
                                 message: format!("failed to load strategy: {e}"),
                             },
-                        }
-                    })?;
+                        })?;
                 backtester
                     .run(strategy_handle, &task.contract_id, task.timeframe)
                     .await
@@ -113,7 +115,7 @@ impl<B: Backtester + 'static> BacktestPool<B> {
             let result = handle.await.unwrap_or_else(|e| {
                 Err(PoolError::TaskFailed {
                     task_id: "unknown".to_string(),
-                    source: BacktestError::ExecutionFailed {
+                    source:  BacktestError::ExecutionFailed {
                         message: format!("task panicked: {e}"),
                     },
                 })
@@ -124,19 +126,16 @@ impl<B: Backtester + 'static> BacktestPool<B> {
     }
 
     /// Run a single backtest task.
-    pub async fn run_single(
-        &self,
-        task: BacktestTask,
-    ) -> Result<BacktestResult, PoolError> {
+    pub async fn run_single(&self, task: BacktestTask) -> Result<BacktestResult, PoolError> {
         let strategy_handle =
-            self.executor.load(&task.strategy_artifact).map_err(|e| {
-                PoolError::TaskFailed {
+            self.executor
+                .load(&task.strategy_artifact)
+                .map_err(|e| PoolError::TaskFailed {
                     task_id: task.id.clone(),
-                    source: BacktestError::ExecutionFailed {
+                    source:  BacktestError::ExecutionFailed {
                         message: format!("failed to load strategy: {e}"),
                     },
-                }
-            })?;
+                })?;
         self.backtester
             .run(strategy_handle, &task.contract_id, task.timeframe)
             .await
@@ -152,13 +151,11 @@ mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
 
     use async_trait::async_trait;
+    use rara_strategy_api::{Candle, RiskLevels, Side, Signal, StrategyMeta};
     use rust_decimal_macros::dec;
 
-    use rara_strategy_api::{Candle, RiskLevels, Side, Signal, StrategyMeta};
-
-    use crate::strategy_executor::{self, StrategyHandle};
-
     use super::*;
+    use crate::strategy_executor::{self, StrategyHandle};
 
     /// Mock strategy handle for tests.
     struct MockHandle;
@@ -166,8 +163,8 @@ mod tests {
     impl StrategyHandle for MockHandle {
         fn meta(&mut self) -> strategy_executor::Result<StrategyMeta> {
             Ok(StrategyMeta {
-                name: "mock".to_string(),
-                version: 1,
+                name:        "mock".to_string(),
+                version:     1,
                 api_version: 1,
                 description: "mock strategy".to_string(),
             })
@@ -183,7 +180,7 @@ mod tests {
             _side: Side,
         ) -> strategy_executor::Result<RiskLevels> {
             Ok(RiskLevels {
-                stop_loss: 0.0,
+                stop_loss:   0.0,
                 take_profit: 0.0,
             })
         }
@@ -193,16 +190,13 @@ mod tests {
     struct MockExecutor;
 
     impl StrategyExecutor for MockExecutor {
-        fn load(
-            &self,
-            _artifact: &[u8],
-        ) -> strategy_executor::Result<Box<dyn StrategyHandle>> {
+        fn load(&self, _artifact: &[u8]) -> strategy_executor::Result<Box<dyn StrategyHandle>> {
             Ok(Box::new(MockHandle))
         }
     }
 
     struct CountingBacktester {
-        current: AtomicU32,
+        current:        AtomicU32,
         max_concurrent: Arc<AtomicU32>,
     }
 
@@ -226,8 +220,7 @@ mod tests {
             let prev = self.current.fetch_add(1, Ordering::SeqCst);
             let running = prev + 1;
             // Update max if this is a new high-water mark
-            self.max_concurrent
-                .fetch_max(running, Ordering::SeqCst);
+            self.max_concurrent.fetch_max(running, Ordering::SeqCst);
 
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
@@ -253,10 +246,10 @@ mod tests {
 
         let tasks: Vec<BacktestTask> = (0..8)
             .map(|i| BacktestTask {
-                id: format!("task-{i}"),
+                id:                format!("task-{i}"),
                 strategy_artifact: Arc::new(vec![]),
-                contract_id: "contract".to_string(),
-                timeframe: Timeframe::Min1,
+                contract_id:       "contract".to_string(),
+                timeframe:         Timeframe::Min1,
             })
             .collect();
 
@@ -281,10 +274,10 @@ mod tests {
         let pool = BacktestPool::with_concurrency(backtester, executor, 2);
 
         let task = BacktestTask {
-            id: "single".to_string(),
+            id:                "single".to_string(),
             strategy_artifact: Arc::new(vec![]),
-            contract_id: "contract".to_string(),
-            timeframe: Timeframe::Min1,
+            contract_id:       "contract".to_string(),
+            timeframe:         Timeframe::Min1,
         };
 
         let result = pool.run_single(task).await;

--- a/crates/rara-research/src/backtester.rs
+++ b/crates/rara-research/src/backtester.rs
@@ -1,10 +1,8 @@
 //! Backtester trait for strategy evaluation.
 
 use async_trait::async_trait;
+use rara_domain::{research::BacktestResult, timeframe::Timeframe};
 use snafu::Snafu;
-
-use rara_domain::research::BacktestResult;
-use rara_domain::timeframe::Timeframe;
 
 use crate::strategy_executor::StrategyHandle;
 

--- a/crates/rara-research/src/barter_backtester.rs
+++ b/crates/rara-research/src/barter_backtester.rs
@@ -4,43 +4,46 @@
 //! engine with a compiled strategy, and extracts performance metrics into
 //! our domain `BacktestResult`.
 
-use std::fmt;
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
 use async_trait::async_trait;
-use barter::backtest::market_data::MarketDataInMemory;
-use barter::backtest::{BacktestArgsConstant, BacktestArgsDynamic, run_backtests};
-use barter::engine::state::EngineState;
-use barter::engine::state::global::DefaultGlobalData;
-use barter::engine::state::trading::TradingState;
-use barter::risk::DefaultRiskManager;
-use barter::statistic::time::Daily;
-use barter::system::config::ExecutionConfig;
-use barter_data::event::{DataKind, MarketEvent};
-use barter_data::streams::reconnect::Event as ReconnectEvent;
-use barter_data::subscription::candle::Candle;
-use barter_execution::balance::Balance;
-use barter_execution::client::mock::MockExecutionConfig;
-use barter_execution::UnindexedAccountSnapshot;
-use barter_instrument::asset::name::AssetNameExchange;
-use barter_instrument::asset::Asset;
-use barter_instrument::exchange::ExchangeId;
-use barter_instrument::index::IndexedInstruments;
-use barter_instrument::instrument::{Instrument, InstrumentIndex};
-use barter_instrument::Underlying;
+use barter::{
+    backtest::{
+        BacktestArgsConstant, BacktestArgsDynamic, market_data::MarketDataInMemory, run_backtests,
+    },
+    engine::state::{EngineState, global::DefaultGlobalData, trading::TradingState},
+    risk::DefaultRiskManager,
+    statistic::time::Daily,
+    system::config::ExecutionConfig,
+};
+use barter_data::{
+    event::{DataKind, MarketEvent},
+    streams::reconnect::Event as ReconnectEvent,
+    subscription::candle::Candle,
+};
+use barter_execution::{
+    UnindexedAccountSnapshot, balance::Balance, client::mock::MockExecutionConfig,
+};
+use barter_instrument::{
+    Underlying,
+    asset::{Asset, name::AssetNameExchange},
+    exchange::ExchangeId,
+    index::IndexedInstruments,
+    instrument::{Instrument, InstrumentIndex},
+};
 use bon::Builder;
 use chrono::NaiveDate;
+use rara_domain::{research::BacktestResult, timeframe::Timeframe};
+use rara_market_data::store::MarketStore;
 use rust_decimal::Decimal;
 use smol_str::SmolStr;
 
-use rara_domain::research::BacktestResult;
-use rara_domain::timeframe::Timeframe;
-use rara_market_data::store::MarketStore;
-
-use crate::backtester::{BacktestError, Backtester};
-use crate::candle_instrument_data::CandleInstrumentData;
-use crate::strategy_executor::StrategyHandle;
-use crate::barter_strategy::{BacktestEngineState, BarterStrategy};
+use crate::{
+    backtester::{BacktestError, Backtester},
+    barter_strategy::{BacktestEngineState, BarterStrategy},
+    candle_instrument_data::CandleInstrumentData,
+    strategy_executor::StrategyHandle,
+};
 
 /// Risk manager type parameterized over our engine state.
 type BtRisk = DefaultRiskManager<BacktestEngineState>;
@@ -53,15 +56,15 @@ type BtRisk = DefaultRiskManager<BacktestEngineState>;
 #[derive(Builder)]
 pub struct BarterBacktester {
     /// `TimescaleDB` market data store.
-    pub store: MarketStore,
+    pub store:           MarketStore,
     /// Initial capital for the simulated account.
     pub initial_capital: Decimal,
     /// Trading fees as a percentage (e.g., 0.1 for 0.1%).
-    pub fees_percent: Decimal,
+    pub fees_percent:    Decimal,
     /// Backtest window start date.
-    pub backtest_start: NaiveDate,
+    pub backtest_start:  NaiveDate,
     /// Backtest window end date.
-    pub backtest_end: NaiveDate,
+    pub backtest_end:    NaiveDate,
 }
 
 impl fmt::Debug for BarterBacktester {
@@ -75,30 +78,27 @@ impl fmt::Debug for BarterBacktester {
     }
 }
 
-/// Extract performance metrics from a barter `TradingSummary` into our domain `BacktestResult`.
+/// Extract performance metrics from a barter `TradingSummary` into our domain
+/// `BacktestResult`.
 ///
-/// Aggregates `PnL`, Sharpe ratio, max drawdown, and win rate across all instruments
-/// in the trading summary, tagging the result with the given timeframe.
+/// Aggregates `PnL`, Sharpe ratio, max drawdown, and win rate across all
+/// instruments in the trading summary, tagging the result with the given
+/// timeframe.
 fn extract_metrics(
     trading_summary: &barter::statistic::summary::TradingSummary<Daily>,
     timeframe: Timeframe,
 ) -> BacktestResult {
-    let (total_pnl, sharpe, max_dd, win_rate_val, trade_count) = trading_summary
-        .instruments
-        .values()
-        .fold(
+    let (total_pnl, sharpe, max_dd, win_rate_val, trade_count) =
+        trading_summary.instruments.values().fold(
             (Decimal::ZERO, Decimal::ZERO, Decimal::ZERO, None, 0u32),
             |(pnl, _sharpe, max_dd, win_rate, trades), tear_sheet| {
                 let sheet_pnl = pnl + tear_sheet.pnl;
                 let sheet_sharpe = tear_sheet.sharpe_ratio.value;
 
-                let sheet_max_dd = tear_sheet
-                    .pnl_drawdown_max
-                    .as_ref()
-                    .map_or(max_dd, |dd| {
-                        let dd_val = dd.0.value.abs();
-                        if dd_val > max_dd { dd_val } else { max_dd }
-                    });
+                let sheet_max_dd = tear_sheet.pnl_drawdown_max.as_ref().map_or(max_dd, |dd| {
+                    let dd_val = dd.0.value.abs();
+                    if dd_val > max_dd { dd_val } else { max_dd }
+                });
 
                 let sheet_win_rate = tear_sheet.win_rate.as_ref().map(|wr| wr.value);
 
@@ -118,9 +118,7 @@ fn extract_metrics(
         );
 
     let sharpe_f64 = sharpe.try_into().unwrap_or(0.0f64);
-    let win_rate_f64: f64 = win_rate_val
-        .and_then(|v| v.try_into().ok())
-        .unwrap_or(0.0);
+    let win_rate_f64: f64 = win_rate_val.and_then(|v| v.try_into().ok()).unwrap_or(0.0);
 
     BacktestResult::builder()
         .pnl(total_pnl)
@@ -134,12 +132,11 @@ fn extract_metrics(
 
 /// Build an `Instrument` for a given contract ID using simulated exchange.
 ///
-/// For MVP, all instruments are treated as spot instruments on a simulated exchange.
+/// For MVP, all instruments are treated as spot instruments on a simulated
+/// exchange.
 fn build_instrument(contract_id: &str) -> Instrument<ExchangeId, Asset> {
     // Parse contract_id as "base_quote" (e.g., "btc_usdt") or use as-is
-    let (base, quote) = contract_id
-        .split_once('_')
-        .unwrap_or((contract_id, "usdt"));
+    let (base, quote) = contract_id.split_once('_').unwrap_or((contract_id, "usdt"));
 
     Instrument::spot(
         ExchangeId::Simulated,
@@ -171,13 +168,11 @@ impl BarterBacktester {
         let instruments = IndexedInstruments::new(vec![instrument]);
 
         // Build the initial account snapshot with configured capital
-        let (_, quote_name) = contract_id
-            .split_once('_')
-            .unwrap_or((contract_id, "usdt"));
+        let (_, quote_name) = contract_id.split_once('_').unwrap_or((contract_id, "usdt"));
 
         let initial_state = UnindexedAccountSnapshot {
-            exchange: ExchangeId::Simulated,
-            balances: vec![barter_execution::balance::AssetBalance::new(
+            exchange:    ExchangeId::Simulated,
+            balances:    vec![barter_execution::balance::AssetBalance::new(
                 AssetNameExchange::from(quote_name),
                 Balance::new(self.initial_capital, self.initial_capital),
                 chrono::Utc::now(),
@@ -192,13 +187,12 @@ impl BarterBacktester {
             self.fees_percent,
         ));
 
-        let engine_state: BacktestEngineState = EngineState::builder(
-            &instruments,
-            DefaultGlobalData,
-            |_| CandleInstrumentData::default(),
-        )
-        .trading_state(TradingState::Enabled)
-        .build();
+        let engine_state: BacktestEngineState =
+            EngineState::builder(&instruments, DefaultGlobalData, |_| {
+                CandleInstrumentData::default()
+            })
+            .trading_state(TradingState::Enabled)
+            .build();
 
         let args_constant = Arc::new(BacktestArgsConstant {
             instruments,
@@ -221,13 +215,11 @@ impl BarterBacktester {
                 message: format!("barter backtest engine error: {e}"),
             })?;
 
-        let summary = multi_summary
-            .summaries
-            .into_iter()
-            .next()
-            .ok_or_else(|| BacktestError::ExecutionFailed {
+        let summary = multi_summary.summaries.into_iter().next().ok_or_else(|| {
+            BacktestError::ExecutionFailed {
                 message: "no backtest summary produced".to_string(),
-            })?;
+            }
+        })?;
 
         Ok(extract_metrics(&summary.trading_summary, timeframe))
     }
@@ -243,12 +235,7 @@ impl Backtester for BarterBacktester {
     ) -> Result<BacktestResult, BacktestError> {
         let candle_rows = self
             .store
-            .query_candles(
-                contract_id,
-                "1m",
-                self.backtest_start,
-                self.backtest_end,
-            )
+            .query_candles(contract_id, "1m", self.backtest_start, self.backtest_end)
             .await
             .map_err(|e| BacktestError::ExecutionFailed {
                 message: format!("failed to query market data: {e}"),
@@ -264,21 +251,21 @@ impl Backtester for BarterBacktester {
             .iter()
             .map(|row| {
                 let candle = Candle {
-                    close_time: row.ts,
-                    open: row.open,
-                    high: row.high,
-                    low: row.low,
-                    close: row.close,
-                    volume: row.volume,
+                    close_time:  row.ts,
+                    open:        row.open,
+                    high:        row.high,
+                    low:         row.low,
+                    close:       row.close,
+                    volume:      row.volume,
                     trade_count: u64::from(row.trade_count.cast_unsigned()),
                 };
 
                 ReconnectEvent::Item(MarketEvent {
                     time_exchange: row.ts,
                     time_received: row.ts,
-                    exchange: ExchangeId::Simulated,
-                    instrument: InstrumentIndex(0),
-                    kind: DataKind::Candle(candle),
+                    exchange:      ExchangeId::Simulated,
+                    instrument:    InstrumentIndex(0),
+                    kind:          DataKind::Candle(candle),
                 })
             })
             .collect();

--- a/crates/rara-research/src/barter_strategy.rs
+++ b/crates/rara-research/src/barter_strategy.rs
@@ -1,34 +1,45 @@
-//! Barter [`AlgoStrategy`] adapter that bridges any [`StrategyHandle`] with the barter engine.
+//! Barter [`AlgoStrategy`] adapter that bridges any [`StrategyHandle`] with the
+//! barter engine.
 //!
-//! Receives 1-minute candle data from [`CandleInstrumentData`], aggregates to the target
-//! [`Timeframe`], and delegates signal generation to a [`StrategyHandle`] (runtime-agnostic).
+//! Receives 1-minute candle data from [`CandleInstrumentData`], aggregates to
+//! the target [`Timeframe`], and delegates signal generation to a
+//! [`StrategyHandle`] (runtime-agnostic).
 
 use std::cell::RefCell;
 
-use barter::engine::Engine;
-use barter::engine::state::EngineState;
-use barter::engine::state::global::DefaultGlobalData;
-use barter::engine::state::instrument::data::InstrumentDataState;
-use barter::engine::state::instrument::filter::InstrumentFilter;
-use barter::strategy::algo::AlgoStrategy;
-use barter::strategy::close_positions::{ClosePositionsStrategy, close_open_positions_with_market_orders};
-use barter::strategy::on_disconnect::OnDisconnectStrategy;
-use barter::strategy::on_trading_disabled::OnTradingDisabled;
-use barter_execution::order::id::{ClientOrderId, StrategyId};
-use barter_execution::order::request::{OrderRequestCancel, OrderRequestOpen, RequestOpen};
-use barter_execution::order::{OrderKey, OrderKind, TimeInForce};
-use barter_instrument::Side;
-use barter_instrument::asset::AssetIndex;
-use barter_instrument::exchange::{ExchangeId, ExchangeIndex};
-use barter_instrument::instrument::InstrumentIndex;
+use barter::{
+    engine::{
+        Engine,
+        state::{
+            EngineState,
+            global::DefaultGlobalData,
+            instrument::{data::InstrumentDataState, filter::InstrumentFilter},
+        },
+    },
+    strategy::{
+        algo::AlgoStrategy,
+        close_positions::{ClosePositionsStrategy, close_open_positions_with_market_orders},
+        on_disconnect::OnDisconnectStrategy,
+        on_trading_disabled::OnTradingDisabled,
+    },
+};
+use barter_execution::order::{
+    OrderKey, OrderKind, TimeInForce,
+    id::{ClientOrderId, StrategyId},
+    request::{OrderRequestCancel, OrderRequestOpen, RequestOpen},
+};
+use barter_instrument::{
+    Side,
+    asset::AssetIndex,
+    exchange::{ExchangeId, ExchangeIndex},
+    instrument::InstrumentIndex,
+};
+use rara_domain::timeframe::Timeframe;
+use rara_strategy_api::{Candle as ApiCandle, Signal};
 use rust_decimal::{Decimal, prelude::FromPrimitive};
 use tracing::warn;
 
-use rara_domain::timeframe::Timeframe;
-use rara_strategy_api::{Candle as ApiCandle, Signal};
-
-use crate::candle_instrument_data::CandleInstrumentData;
-use crate::strategy_executor::StrategyHandle;
+use crate::{candle_instrument_data::CandleInstrumentData, strategy_executor::StrategyHandle};
 
 /// Maximum number of aggregated candles retained in history.
 const MAX_AGGREGATED_HISTORY: usize = 500;
@@ -36,32 +47,35 @@ const MAX_AGGREGATED_HISTORY: usize = 500;
 /// Engine state type alias using our candle-aware instrument data.
 pub type BacktestEngineState = EngineState<DefaultGlobalData, CandleInstrumentData>;
 
-/// Barter strategy adapter that delegates signal generation to any [`StrategyHandle`].
+/// Barter strategy adapter that delegates signal generation to any
+/// [`StrategyHandle`].
 ///
-/// Aggregates 1-minute candles from [`CandleInstrumentData`] into the target [`Timeframe`],
-/// then calls the handle's `on_candles()` when a new aggregated bar completes.
-/// Uses [`RefCell`] for interior mutability because barter's [`AlgoStrategy`] requires `&self`.
+/// Aggregates 1-minute candles from [`CandleInstrumentData`] into the target
+/// [`Timeframe`], then calls the handle's `on_candles()` when a new aggregated
+/// bar completes. Uses [`RefCell`] for interior mutability because barter's
+/// [`AlgoStrategy`] requires `&self`.
 pub struct BarterStrategy {
     /// Strategy identifier for order tagging.
     pub id: StrategyId,
-    /// Mutable inner state behind `RefCell` (barter calls `generate_algo_orders` with `&self`).
-    state: RefCell<StrategyInner>,
+    /// Mutable inner state behind `RefCell` (barter calls
+    /// `generate_algo_orders` with `&self`).
+    state:  RefCell<StrategyInner>,
 }
 
 /// Mutable state for candle aggregation and strategy invocation.
 struct StrategyInner {
     /// Strategy handle for calling `on_candles()`.
-    handle: Box<dyn StrategyHandle>,
+    handle:          Box<dyn StrategyHandle>,
     /// Target timeframe for candle aggregation.
-    timeframe: Timeframe,
+    timeframe:       Timeframe,
     /// Buffer of 1m candles accumulating toward next aggregation boundary.
-    buffer: Vec<ApiCandle>,
+    buffer:          Vec<ApiCandle>,
     /// Aggregated candle history passed to the WASM strategy.
-    history: Vec<ApiCandle>,
+    history:         Vec<ApiCandle>,
     /// Number of candles already consumed from `CandleInstrumentData`.
     processed_count: usize,
     /// Most recent signal from the WASM strategy.
-    current_signal: Option<Signal>,
+    current_signal:  Option<Signal>,
 }
 
 impl BarterStrategy {
@@ -72,7 +86,7 @@ impl BarterStrategy {
     /// * `timeframe` - Target timeframe for candle aggregation (e.g., 4h)
     pub fn new(handle: Box<dyn StrategyHandle>, timeframe: Timeframe) -> Self {
         Self {
-            id: StrategyId::new("strategy"),
+            id:    StrategyId::new("strategy"),
             state: RefCell::new(StrategyInner {
                 handle,
                 timeframe,
@@ -85,10 +99,12 @@ impl BarterStrategy {
     }
 }
 
-/// Check whether the buffer of 1m candles should be aggregated into one target-timeframe bar.
+/// Check whether the buffer of 1m candles should be aggregated into one
+/// target-timeframe bar.
 ///
-/// For 1m timeframe, every candle passes through directly. For larger timeframes,
-/// aggregation triggers when the next minute would cross a natural timeframe boundary.
+/// For 1m timeframe, every candle passes through directly. For larger
+/// timeframes, aggregation triggers when the next minute would cross a natural
+/// timeframe boundary.
 fn should_aggregate(buffer: &[ApiCandle], timeframe: Timeframe) -> bool {
     if timeframe == Timeframe::Min1 {
         return true;
@@ -106,15 +122,22 @@ fn should_aggregate(buffer: &[ApiCandle], timeframe: Timeframe) -> bool {
 ///
 /// Panics if `candles` is empty.
 fn aggregate_candles(candles: &[ApiCandle]) -> ApiCandle {
-    let first = candles.first().expect("aggregate requires non-empty candles");
-    let last = candles.last().expect("aggregate requires non-empty candles");
+    let first = candles
+        .first()
+        .expect("aggregate requires non-empty candles");
+    let last = candles
+        .last()
+        .expect("aggregate requires non-empty candles");
     ApiCandle {
         timestamp: first.timestamp,
-        open: first.open,
-        high: candles.iter().map(|c| c.high).fold(f64::NEG_INFINITY, f64::max),
-        low: candles.iter().map(|c| c.low).fold(f64::INFINITY, f64::min),
-        close: last.close,
-        volume: candles.iter().map(|c| c.volume).sum(),
+        open:      first.open,
+        high:      candles
+            .iter()
+            .map(|c| c.high)
+            .fold(f64::NEG_INFINITY, f64::max),
+        low:       candles.iter().map(|c| c.low).fold(f64::INFINITY, f64::min),
+        close:     last.close,
+        volume:    candles.iter().map(|c| c.volume).sum(),
     }
 }
 
@@ -180,15 +203,14 @@ impl AlgoStrategy for BarterStrategy {
                                 rara_strategy_api::Side::Long => Side::Buy,
                                 rara_strategy_api::Side::Short => Side::Sell,
                             };
-                            let quantity = Decimal::from_f64(*strength)
-                                .unwrap_or(Decimal::ONE);
+                            let quantity = Decimal::from_f64(*strength).unwrap_or(Decimal::ONE);
 
                             open_orders.push(OrderRequestOpen {
-                                key: OrderKey {
-                                    exchange: instrument_state.instrument.exchange,
+                                key:   OrderKey {
+                                    exchange:   instrument_state.instrument.exchange,
                                     instrument: instrument_state.key,
-                                    strategy: self.id.clone(),
-                                    cid: ClientOrderId::random(),
+                                    strategy:   self.id.clone(),
+                                    cid:        ClientOrderId::random(),
                                 },
                                 state: RequestOpen {
                                     side: order_side,
@@ -210,11 +232,11 @@ impl AlgoStrategy for BarterStrategy {
                                 Side::Sell => Side::Buy,
                             };
                             open_orders.push(OrderRequestOpen {
-                                key: OrderKey {
-                                    exchange: instrument_state.instrument.exchange,
+                                key:   OrderKey {
+                                    exchange:   instrument_state.instrument.exchange,
                                     instrument: instrument_state.key,
-                                    strategy: self.id.clone(),
-                                    cid: ClientOrderId::random(),
+                                    strategy:   self.id.clone(),
+                                    cid:        ClientOrderId::random(),
                                 },
                                 state: RequestOpen {
                                     side: exit_side,

--- a/crates/rara-research/src/candle_instrument_data.rs
+++ b/crates/rara-research/src/candle_instrument_data.rs
@@ -4,18 +4,27 @@
 //! which ignores candle events, this implementation stores OHLCV candle history
 //! so strategies can read historical candle data for technical analysis.
 
-use barter::engine::Processor;
-use barter::engine::state::instrument::data::InstrumentDataState;
-use barter::engine::state::order::in_flight_recorder::InFlightRequestRecorder;
-use barter::Timed;
-use barter_data::event::{DataKind, MarketEvent};
-use barter_data::subscription::book::OrderBookL1;
-use barter_execution::AccountEvent;
-use barter_execution::order::request::{OrderRequestCancel, OrderRequestOpen};
+use barter::{
+    Timed,
+    engine::{
+        Processor,
+        state::{
+            instrument::data::InstrumentDataState,
+            order::in_flight_recorder::InFlightRequestRecorder,
+        },
+    },
+};
+use barter_data::{
+    event::{DataKind, MarketEvent},
+    subscription::book::OrderBookL1,
+};
+use barter_execution::{
+    AccountEvent,
+    order::request::{OrderRequestCancel, OrderRequestOpen},
+};
+use rara_strategy_api::Candle as ApiCandle;
 use rust_decimal::{Decimal, prelude::FromPrimitive};
 use serde::{Deserialize, Serialize};
-
-use rara_strategy_api::Candle as ApiCandle;
 
 /// Maximum number of candles to retain in history.
 ///
@@ -25,23 +34,22 @@ const MAX_CANDLE_HISTORY: usize = 10_000;
 /// Instrument data state that tracks candle history in addition to price.
 ///
 /// Mirrors [`DefaultInstrumentMarketData`](barter::engine::state::instrument::data::DefaultInstrumentMarketData)
-/// for L1 order book and last traded price tracking, but additionally accumulates
-/// OHLCV candles from `DataKind::Candle` events for strategy consumption.
+/// for L1 order book and last traded price tracking, but additionally
+/// accumulates OHLCV candles from `DataKind::Candle` events for strategy
+/// consumption.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CandleInstrumentData {
     /// Latest L1 order book snapshot.
-    pub l1: OrderBookL1,
+    pub l1:                OrderBookL1,
     /// Last traded price with timestamp.
     pub last_traded_price: Option<Timed<Decimal>>,
     /// Accumulated candle history, oldest first.
-    pub candles: Vec<ApiCandle>,
+    pub candles:           Vec<ApiCandle>,
 }
 
 impl CandleInstrumentData {
     /// Returns a slice of all accumulated candles, oldest first.
-    pub fn candle_history(&self) -> &[ApiCandle] {
-        &self.candles
-    }
+    pub fn candle_history(&self) -> &[ApiCandle] { &self.candles }
 }
 
 impl InstrumentDataState for CandleInstrumentData {
@@ -78,11 +86,11 @@ impl<InstrumentKey> Processor<&MarketEvent<InstrumentKey, DataKind>> for CandleI
             DataKind::Candle(candle) => {
                 let api_candle = ApiCandle {
                     timestamp: event.time_exchange.timestamp(),
-                    open: candle.open,
-                    high: candle.high,
-                    low: candle.low,
-                    close: candle.close,
-                    volume: candle.volume,
+                    open:      candle.open,
+                    high:      candle.high,
+                    low:       candle.low,
+                    close:     candle.close,
+                    volume:    candle.volume,
                 };
 
                 self.candles.push(api_candle);

--- a/crates/rara-research/src/compiler.rs
+++ b/crates/rara-research/src/compiler.rs
@@ -33,13 +33,13 @@ pub type Result<T> = std::result::Result<T, CompilerError>;
 #[derive(Debug)]
 pub struct CompileResult {
     /// Whether compilation succeeded.
-    pub success: bool,
+    pub success:         bool,
     /// Compiled WASM bytes (if successful).
-    pub wasm_bytes: Option<Vec<u8>>,
+    pub wasm_bytes:      Option<Vec<u8>>,
     /// Compilation errors from stderr.
-    pub errors: Vec<String>,
+    pub errors:          Vec<String>,
     /// Clippy warnings from stderr.
-    pub warnings: Vec<String>,
+    pub warnings:        Vec<String>,
     /// Time taken to compile in milliseconds.
     pub compile_time_ms: u64,
 }
@@ -51,7 +51,7 @@ pub struct StrategyCompiler {
     template_dir: PathBuf,
     /// WASM target triple.
     #[builder(default = "wasm32-wasip1".into())]
-    wasm_target: String,
+    wasm_target:  String,
 }
 
 const IMPL_START_MARKER: &str = "// ===== STRATEGY_IMPL START =====";
@@ -70,15 +70,13 @@ impl StrategyCompiler {
         let tmp = tempfile::tempdir().context(WorkspaceSetupSnafu)?;
         copy_dir_recursive(&self.template_dir, tmp.path()).context(WorkspaceSetupSnafu)?;
 
-        // 2. Patch Cargo.toml to use absolute path for rara-strategy-api
-        //    (the relative path breaks once we copy to a temp location)
+        // 2. Patch Cargo.toml to use absolute path for rara-strategy-api (the relative
+        //    path breaks once we copy to a temp location)
         let cargo_toml_path = tmp.path().join("Cargo.toml");
-        let cargo_toml =
-            std::fs::read_to_string(&cargo_toml_path).context(WorkspaceSetupSnafu)?;
-        let abs_api_path = std::fs::canonicalize(
-            self.template_dir.join("../../crates/rara-strategy-api"),
-        )
-        .context(WorkspaceSetupSnafu)?;
+        let cargo_toml = std::fs::read_to_string(&cargo_toml_path).context(WorkspaceSetupSnafu)?;
+        let abs_api_path =
+            std::fs::canonicalize(self.template_dir.join("../../crates/rara-strategy-api"))
+                .context(WorkspaceSetupSnafu)?;
         let patched = cargo_toml.replace(
             "../../crates/rara-strategy-api",
             &abs_api_path.to_string_lossy(),
@@ -246,8 +244,15 @@ fn risk_levels(entry_price: f64, side: Side) -> RiskLevels {
 }
 "#;
 
-        let result = compiler.compile(code).await.expect("compile should not error");
-        assert!(result.success, "expected success, got errors: {:?}", result.errors);
+        let result = compiler
+            .compile(code)
+            .await
+            .expect("compile should not error");
+        assert!(
+            result.success,
+            "expected success, got errors: {:?}",
+            result.errors
+        );
         assert!(result.wasm_bytes.is_some(), "expected wasm bytes");
         assert!(
             result.wasm_bytes.as_ref().unwrap().len() > 100,
@@ -255,12 +260,13 @@ fn risk_levels(entry_price: f64, side: Side) -> RiskLevels {
         );
     }
 
-    /// End-to-end: compile → load via `WasmExecutor` → call `on_candles()` → verify signal.
+    /// End-to-end: compile → load via `WasmExecutor` → call `on_candles()` →
+    /// verify signal.
     #[tokio::test]
     async fn wasm_strategy_executes_end_to_end() {
-        use crate::strategy_executor::StrategyExecutor;
-        use crate::wasm_executor::WasmExecutor;
         use rara_strategy_api::{Candle, Signal};
+
+        use crate::{strategy_executor::StrategyExecutor, wasm_executor::WasmExecutor};
 
         let compiler = StrategyCompiler::builder()
             .template_dir(template_dir())
@@ -304,7 +310,10 @@ fn risk_levels(entry_price: f64, side: Side) -> RiskLevels {
 "#;
 
         // 1. Compile to WASM
-        let result = compiler.compile(code).await.expect("compile should succeed");
+        let result = compiler
+            .compile(code)
+            .await
+            .expect("compile should succeed");
         assert!(result.success, "compile errors: {:?}", result.errors);
         let wasm_bytes = result.wasm_bytes.expect("should produce wasm bytes");
 
@@ -320,34 +329,83 @@ fn risk_levels(entry_price: f64, side: Side) -> RiskLevels {
         // 4. Call on_candles() with < 2 candles → Hold
         let one_candle = vec![Candle {
             timestamp: 1000,
-            open: 100.0,
-            high: 105.0,
-            low: 95.0,
-            close: 102.0,
-            volume: 50.0,
+            open:      100.0,
+            high:      105.0,
+            low:       95.0,
+            close:     102.0,
+            volume:    50.0,
         }];
-        let signal = handle.on_candles(&one_candle).expect("on_candles should succeed");
-        assert!(matches!(signal, Signal::Hold), "expected Hold with 1 candle, got {signal:?}");
+        let signal = handle
+            .on_candles(&one_candle)
+            .expect("on_candles should succeed");
+        assert!(
+            matches!(signal, Signal::Hold),
+            "expected Hold with 1 candle, got {signal:?}"
+        );
 
         // 5. Call on_candles() with rising price → Long
         let rising = vec![
-            Candle { timestamp: 1000, open: 100.0, high: 105.0, low: 95.0, close: 100.0, volume: 50.0 },
-            Candle { timestamp: 1060, open: 100.0, high: 110.0, low: 99.0, close: 108.0, volume: 60.0 },
+            Candle {
+                timestamp: 1000,
+                open:      100.0,
+                high:      105.0,
+                low:       95.0,
+                close:     100.0,
+                volume:    50.0,
+            },
+            Candle {
+                timestamp: 1060,
+                open:      100.0,
+                high:      110.0,
+                low:       99.0,
+                close:     108.0,
+                volume:    60.0,
+            },
         ];
-        let signal = handle.on_candles(&rising).expect("on_candles should succeed");
+        let signal = handle
+            .on_candles(&rising)
+            .expect("on_candles should succeed");
         assert!(
-            matches!(signal, Signal::Entry { side: rara_strategy_api::Side::Long, .. }),
+            matches!(
+                signal,
+                Signal::Entry {
+                    side: rara_strategy_api::Side::Long,
+                    ..
+                }
+            ),
             "expected Long entry on rising price, got {signal:?}"
         );
 
         // 6. Call on_candles() with falling price → Short
         let falling = vec![
-            Candle { timestamp: 2000, open: 100.0, high: 105.0, low: 95.0, close: 100.0, volume: 50.0 },
-            Candle { timestamp: 2060, open: 100.0, high: 101.0, low: 90.0, close: 92.0, volume: 70.0 },
+            Candle {
+                timestamp: 2000,
+                open:      100.0,
+                high:      105.0,
+                low:       95.0,
+                close:     100.0,
+                volume:    50.0,
+            },
+            Candle {
+                timestamp: 2060,
+                open:      100.0,
+                high:      101.0,
+                low:       90.0,
+                close:     92.0,
+                volume:    70.0,
+            },
         ];
-        let signal = handle.on_candles(&falling).expect("on_candles should succeed");
+        let signal = handle
+            .on_candles(&falling)
+            .expect("on_candles should succeed");
         assert!(
-            matches!(signal, Signal::Entry { side: rara_strategy_api::Side::Short, .. }),
+            matches!(
+                signal,
+                Signal::Entry {
+                    side: rara_strategy_api::Side::Short,
+                    ..
+                }
+            ),
             "expected Short entry on falling price, got {signal:?}"
         );
 
@@ -355,8 +413,14 @@ fn risk_levels(entry_price: f64, side: Side) -> RiskLevels {
         let levels = handle
             .risk_levels(100.0, rara_strategy_api::Side::Long)
             .expect("risk_levels should succeed");
-        assert!((levels.stop_loss - 98.0).abs() < 0.01, "stop_loss should be ~98.0");
-        assert!((levels.take_profit - 104.0).abs() < 0.01, "take_profit should be ~104.0");
+        assert!(
+            (levels.stop_loss - 98.0).abs() < 0.01,
+            "stop_loss should be ~98.0"
+        );
+        assert!(
+            (levels.take_profit - 104.0).abs() < 0.01,
+            "take_profit should be ~104.0"
+        );
     }
 
     #[tokio::test]

--- a/crates/rara-research/src/feedback_gen.rs
+++ b/crates/rara-research/src/feedback_gen.rs
@@ -4,14 +4,12 @@
 //! calls the LLM, and parses the structured JSON response into
 //! [`HypothesisFeedback`].
 
-use std::collections::HashMap;
-use std::sync::Arc;
-
-use snafu::{ResultExt, Snafu};
-use uuid::Uuid;
+use std::{collections::HashMap, sync::Arc};
 
 use rara_domain::research::{BacktestResult, Hypothesis, HypothesisFeedback};
 use rara_infra::llm::LlmClient;
+use snafu::{ResultExt, Snafu};
+use uuid::Uuid;
 
 use crate::prompt_renderer::{PromptError, PromptRenderer};
 
@@ -45,22 +43,23 @@ pub type Result<T> = std::result::Result<T, FeedbackGenError>;
 /// Raw JSON structure matching the LLM response format.
 #[derive(serde::Deserialize)]
 struct RawFeedback {
-    decision: bool,
-    reason: String,
-    observations: String,
+    decision:              bool,
+    reason:                String,
+    observations:          String,
     hypothesis_evaluation: String,
-    new_hypothesis: Option<String>,
-    code_change_summary: String,
+    new_hypothesis:        Option<String>,
+    code_change_summary:   String,
 }
 
 /// Generates structured feedback for experiments by prompting an LLM.
 pub struct FeedbackGenerator {
-    llm: Arc<dyn LlmClient>,
+    llm:             Arc<dyn LlmClient>,
     prompt_renderer: PromptRenderer,
 }
 
 impl FeedbackGenerator {
-    /// Create a new feedback generator with the given LLM client and prompt renderer.
+    /// Create a new feedback generator with the given LLM client and prompt
+    /// renderer.
     pub fn new(llm: Arc<dyn LlmClient>, prompt_renderer: PromptRenderer) -> Self {
         Self {
             llm,
@@ -177,11 +176,11 @@ fn extract_json(response: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use async_trait::async_trait;
     use rara_infra::llm::LlmError;
     use rust_decimal_macros::dec;
+
+    use super::*;
 
     /// Mock LLM client that returns a fixed response.
     struct MockLlm {
@@ -209,8 +208,7 @@ mod tests {
     }
 
     fn make_renderer() -> PromptRenderer {
-        let prompt_dir =
-            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/prompts");
+        let prompt_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/prompts");
         PromptRenderer::load_from_dir(&prompt_dir).expect("prompts dir should exist")
     }
 

--- a/crates/rara-research/src/hypothesis_gen.rs
+++ b/crates/rara-research/src/hypothesis_gen.rs
@@ -2,10 +2,9 @@
 
 use std::sync::Arc;
 
-use snafu::{ResultExt, Snafu};
-
 use rara_domain::research::Hypothesis;
 use rara_infra::llm::LlmClient;
+use snafu::{ResultExt, Snafu};
 
 use crate::trace::Trace;
 
@@ -43,9 +42,7 @@ pub struct HypothesisGenerator {
 
 impl HypothesisGenerator {
     /// Create a new generator backed by the given LLM client.
-    pub fn new(llm: Arc<dyn LlmClient>) -> Self {
-        Self { llm }
-    }
+    pub fn new(llm: Arc<dyn LlmClient>) -> Self { Self { llm } }
 
     /// Generate a new hypothesis informed by the trace history and context.
     ///
@@ -67,8 +64,7 @@ impl HypothesisGenerator {
             let _ = write!(
                 prompt,
                 "Best experiment so far:\n- Code: {}\n- Feedback: {}\n\n",
-                exp.strategy_code,
-                fb.reason
+                exp.strategy_code, fb.reason
             );
         }
 
@@ -82,16 +78,15 @@ impl HypothesisGenerator {
 
     /// Parse the LLM response into a Hypothesis, linking to the best
     /// experiment's hypothesis as parent if one exists.
-    fn parse_response(
-        response: &str,
-        trace: &Trace,
-    ) -> Result<Hypothesis> {
+    fn parse_response(response: &str, trace: &Trace) -> Result<Hypothesis> {
         let lines: Vec<&str> = response.lines().collect();
 
-        let text = lines
-            .first()
-            .filter(|s| !s.is_empty())
-            .ok_or_else(|| ParseSnafu { message: "empty response".to_owned() }.build())?;
+        let text = lines.first().filter(|s| !s.is_empty()).ok_or_else(|| {
+            ParseSnafu {
+                message: "empty response".to_owned(),
+            }
+            .build()
+        })?;
 
         let reason = lines.get(1).unwrap_or(&"no reason provided");
 
@@ -113,19 +108,22 @@ impl HypothesisGenerator {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use rara_agent::backend::{CliBackend, OutputFormat, PromptMode};
-    use rara_agent::executor::CliExecutor;
+    use rara_agent::{
+        backend::{CliBackend, OutputFormat, PromptMode},
+        executor::CliExecutor,
+    };
     use rara_domain::research::Experiment;
+
+    use super::*;
 
     fn echo_executor(response: &str) -> CliExecutor {
         CliExecutor::new(CliBackend {
-            command: "sh".to_string(),
-            args: vec!["-c".to_string(), format!("printf '{response}\\n'")],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "sh".to_string(),
+            args:          vec!["-c".to_string(), format!("printf '{response}\\n'")],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         })
     }
 

--- a/crates/rara-research/src/lib.rs
+++ b/crates/rara-research/src/lib.rs
@@ -1,21 +1,21 @@
 //! Research engine — hypothesis generation, backtesting, and feedback loops.
 
-pub mod backtester;
 pub mod backtest_pool;
-pub mod compiler;
+pub mod backtester;
 pub mod barter_backtester;
+pub mod barter_strategy;
 pub mod candle_instrument_data;
+pub mod compiler;
 pub mod feedback_gen;
 pub mod hypothesis_gen;
 pub mod prompt_renderer;
 pub mod research_loop;
 pub mod strategy_coder;
 pub mod strategy_executor;
-pub mod strategy_promoter;
-pub mod strategy_store;
 pub mod strategy_manager;
-pub mod wasm_strategy_manager;
+pub mod strategy_promoter;
+pub mod strategy_registry;
+pub mod strategy_store;
 pub mod trace;
 pub mod wasm_executor;
-pub mod barter_strategy;
-pub mod strategy_registry;
+pub mod wasm_strategy_manager;

--- a/crates/rara-research/src/prompt_renderer.rs
+++ b/crates/rara-research/src/prompt_renderer.rs
@@ -2,8 +2,7 @@
 //!
 //! Templates use `{variable}` placeholders that are substituted at render time.
 
-use std::collections::HashMap;
-use std::path::Path;
+use std::{collections::HashMap, path::Path};
 
 use snafu::{ResultExt, Snafu};
 
@@ -33,7 +32,7 @@ pub enum PromptError {
     #[snafu(display("missing variable '{name}' in template '{template}'"))]
     MissingVariable {
         /// Name of the missing variable.
-        name: String,
+        name:     String,
         /// Name of the template being rendered.
         template: String,
     },
@@ -51,7 +50,7 @@ struct TemplateFile {
 /// The `[template]` section of a TOML file.
 #[derive(serde::Deserialize)]
 struct TemplateContent {
-    name: String,
+    name:   String,
     prompt: String,
 }
 
@@ -66,7 +65,8 @@ pub struct PromptRenderer {
 impl PromptRenderer {
     /// Load all `.toml` templates from the given directory.
     ///
-    /// Each file must contain a `[template]` section with `name` and `prompt` fields.
+    /// Each file must contain a `[template]` section with `name` and `prompt`
+    /// fields.
     pub fn load_from_dir(dir: &Path) -> Result<Self> {
         let mut templates = HashMap::new();
 
@@ -92,28 +92,19 @@ impl PromptRenderer {
     /// Create a renderer from an in-memory map of templates.
     ///
     /// Useful for testing without filesystem access.
-    pub const fn from_map(templates: HashMap<String, String>) -> Self {
-        Self { templates }
-    }
+    pub const fn from_map(templates: HashMap<String, String>) -> Self { Self { templates } }
 
     /// Render a named template with the given variable substitutions.
     ///
     /// Escaped braces (`{{` / `}}`) are preserved as literal `{` / `}`.
     /// Missing variables produce an error.
-    pub fn render(
-        &self,
-        template_name: &str,
-        vars: &HashMap<String, String>,
-    ) -> Result<String> {
-        let template = self
-            .templates
-            .get(template_name)
-            .ok_or_else(|| {
-                TemplateNotFoundSnafu {
-                    name: template_name.to_owned(),
-                }
-                .build()
-            })?;
+    pub fn render(&self, template_name: &str, vars: &HashMap<String, String>) -> Result<String> {
+        let template = self.templates.get(template_name).ok_or_else(|| {
+            TemplateNotFoundSnafu {
+                name: template_name.to_owned(),
+            }
+            .build()
+        })?;
 
         substitute(template, vars, template_name)
     }
@@ -127,7 +118,8 @@ impl PromptRenderer {
 /// Perform `{variable}` substitution on a template string.
 ///
 /// `{{` and `}}` are treated as escaped literal braces.
-/// Unmatched `{name}` placeholders with no corresponding variable produce an error.
+/// Unmatched `{name}` placeholders with no corresponding variable produce an
+/// error.
 fn substitute(
     template: &str,
     vars: &HashMap<String, String>,
@@ -156,7 +148,7 @@ fn substitute(
                         Some(value) => result.push_str(value),
                         None => {
                             return Err(MissingVariableSnafu {
-                                name: var_name,
+                                name:     var_name,
                                 template: template_name.to_owned(),
                             }
                             .build());
@@ -307,7 +299,10 @@ prompt = "Hello {who}!"
 
         let mut vars = HashMap::new();
         vars.insert("hypothesis".to_owned(), "Use RSI crossover".to_owned());
-        vars.insert("strategy_trait".to_owned(), "trait TradingStrategy { ... }".to_owned());
+        vars.insert(
+            "strategy_trait".to_owned(),
+            "trait TradingStrategy { ... }".to_owned(),
+        );
         vars.insert("prior_code".to_owned(), "fn old() {}".to_owned());
         vars.insert("compile_errors".to_owned(), "none".to_owned());
 
@@ -323,7 +318,10 @@ prompt = "Hello {who}!"
 
         let mut vars = HashMap::new();
         vars.insert("hypothesis".to_owned(), "Mean reversion works".to_owned());
-        vars.insert("backtest_result".to_owned(), "Sharpe: 2.0, PnL: 500".to_owned());
+        vars.insert(
+            "backtest_result".to_owned(),
+            "Sharpe: 2.0, PnL: 500".to_owned(),
+        );
         vars.insert("sota_result".to_owned(), "Sharpe: 1.5, PnL: 300".to_owned());
         vars.insert("strategy_code".to_owned(), "fn strategy() {}".to_owned());
 

--- a/crates/rara-research/src/research_loop.rs
+++ b/crates/rara-research/src/research_loop.rs
@@ -1,27 +1,30 @@
-//! Research loop orchestration — the full propose -> code -> compile -> backtest -> evaluate cycle.
+//! Research loop orchestration — the full propose -> code -> compile ->
+//! backtest -> evaluate cycle.
 
-use std::path::PathBuf;
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use bon::Builder;
+use rara_domain::{
+    event::{Event, EventType},
+    research::{
+        Experiment, Hypothesis, HypothesisFeedback, ResearchStrategy, ResearchStrategyStatus,
+    },
+    timeframe::Timeframe,
+};
+use rara_event_bus::bus::EventBus;
 use rust_decimal::Decimal;
 use serde::Serialize;
 use snafu::{ResultExt, Snafu};
 use uuid::Uuid;
 
-use rara_domain::event::{Event, EventType};
-use rara_domain::research::{
-    Experiment, Hypothesis, HypothesisFeedback, ResearchStrategy, ResearchStrategyStatus,
+use crate::{
+    backtester::Backtester,
+    feedback_gen::FeedbackGenerator,
+    hypothesis_gen::HypothesisGenerator,
+    prompt_renderer::PromptRenderer,
+    strategy_manager::{StrategyManager, StrategyManagerError},
+    trace::{DagSelection, Trace},
 };
-use rara_domain::timeframe::Timeframe;
-use rara_event_bus::bus::EventBus;
-
-use crate::backtester::Backtester;
-use crate::feedback_gen::FeedbackGenerator;
-use crate::hypothesis_gen::HypothesisGenerator;
-use crate::prompt_renderer::PromptRenderer;
-use crate::strategy_manager::{StrategyManager, StrategyManagerError};
-use crate::trace::{DagSelection, Trace};
 
 /// Event payload for hypothesis creation.
 #[derive(Debug, Serialize)]
@@ -36,7 +39,7 @@ struct ExperimentCompletedPayload {
     /// UUID of the completed experiment.
     experiment_id: String,
     /// Whether the experiment met acceptance criteria.
-    accepted: bool,
+    accepted:      bool,
 }
 
 /// Event payload for a strategy candidate.
@@ -106,11 +109,11 @@ pub struct IterationResult {
     /// The experiment that was run.
     pub experiment: Experiment,
     /// The feedback on the experiment.
-    pub feedback: HypothesisFeedback,
+    pub feedback:   HypothesisFeedback,
     /// Whether the experiment was accepted.
-    pub accepted: bool,
+    pub accepted:   bool,
     /// The compiled research strategy.
-    pub strategy: ResearchStrategy,
+    pub strategy:   ResearchStrategy,
 }
 
 /// Orchestrates the full RD-Agent style research loop:
@@ -118,30 +121,30 @@ pub struct IterationResult {
 #[derive(Builder)]
 pub struct ResearchLoop {
     /// Generates new hypotheses from trace history.
-    hypothesis_gen: HypothesisGenerator,
+    hypothesis_gen:      HypothesisGenerator,
     /// Manages the full strategy lifecycle (code gen, compile, load).
-    strategy_manager: Arc<dyn StrategyManager>,
+    strategy_manager:    Arc<dyn StrategyManager>,
     /// Runs backtests against loaded strategy handles.
-    backtester: Arc<dyn Backtester>,
+    backtester:          Arc<dyn Backtester>,
     /// LLM-driven feedback evaluator.
-    feedback_gen: FeedbackGenerator,
+    feedback_gen:        FeedbackGenerator,
     /// Prompt template renderer.
     #[allow(dead_code)]
-    prompt_renderer: PromptRenderer,
+    prompt_renderer:     PromptRenderer,
     /// DAG trace storage.
-    trace: Trace,
+    trace:               Trace,
     /// Domain event bus.
-    event_bus: Arc<EventBus>,
+    event_bus:           Arc<EventBus>,
     /// Maximum attempts to fix compile errors before giving up.
     #[builder(default = 3)]
     max_compile_retries: u32,
     /// Directory for saving generated strategy source code each iteration.
     /// When set, each iteration's `.rs` source is persisted here for debugging
     /// and reproducibility.
-    generated_dir: Option<PathBuf>,
+    generated_dir:       Option<PathBuf>,
     /// Timeframes to evaluate each hypothesis on.
     #[builder(default = vec![Timeframe::Hour1, Timeframe::Hour4, Timeframe::Day1])]
-    timeframes: Vec<Timeframe>,
+    timeframes:          Vec<Timeframe>,
 }
 
 impl ResearchLoop {
@@ -187,9 +190,7 @@ impl ResearchLoop {
         }
 
         // 6. Compile with retries, producing a persisted ResearchStrategy
-        let strategy = self
-            .compile_with_retries(&mut code, &hypothesis)
-            .await?;
+        let strategy = self.compile_with_retries(&mut code, &hypothesis).await?;
 
         // 7. Validate the module loads successfully
         let _loaded = self
@@ -204,9 +205,7 @@ impl ResearchLoop {
             .build();
 
         // 9. Run backtests across all configured timeframes, pick best result
-        let backtest_result = self
-            .run_multi_timeframe_backtest(strategy.id)
-            .await?;
+        let backtest_result = self.run_multi_timeframe_backtest(strategy.id).await?;
 
         // 10. Persist experiment with backtest result attached
         experiment.backtest_result = Some(backtest_result.clone());
@@ -276,10 +275,11 @@ impl ResearchLoop {
         })
     }
 
-    /// Attempt to compile strategy code, retrying with LLM-driven fixes on failure.
+    /// Attempt to compile strategy code, retrying with LLM-driven fixes on
+    /// failure.
     ///
-    /// Only persists the strategy record and artifact after a successful compilation,
-    /// avoiding orphaned records from failed attempts.
+    /// Only persists the strategy record and artifact after a successful
+    /// compilation, avoiding orphaned records from failed attempts.
     #[tracing::instrument(skip(self, code, hypothesis), fields(hypothesis_id = %hypothesis.id))]
     async fn compile_with_retries(
         &self,
@@ -321,7 +321,8 @@ impl ResearchLoop {
         })
     }
 
-    /// Run backtests across all configured timeframes, returning the best result.
+    /// Run backtests across all configured timeframes, returning the best
+    /// result.
     ///
     /// Each timeframe is tested sequentially. Failed individual timeframes are
     /// logged as warnings but do not abort the entire run. The result with the
@@ -380,11 +381,7 @@ impl ResearchLoop {
     }
 
     /// Helper to publish a domain event with a typed payload.
-    fn publish_event(
-        &self,
-        event_type: EventType,
-        payload: &impl Serialize,
-    ) -> Result<()> {
+    fn publish_event(&self, event_type: EventType, payload: &impl Serialize) -> Result<()> {
         let event = Event::builder()
             .event_type(event_type)
             .source("research_loop")

--- a/crates/rara-research/src/strategy_coder.rs
+++ b/crates/rara-research/src/strategy_coder.rs
@@ -2,10 +2,9 @@
 
 use std::sync::Arc;
 
-use snafu::{ResultExt, Snafu};
-
 use rara_domain::research::Hypothesis;
 use rara_infra::llm::LlmClient;
+use snafu::{ResultExt, Snafu};
 
 /// Errors from strategy code generation.
 #[derive(Debug, Snafu)]
@@ -29,24 +28,14 @@ pub struct StrategyCoder {
 
 impl StrategyCoder {
     /// Create a new strategy coder backed by the given LLM client.
-    pub fn new(llm: Arc<dyn LlmClient>) -> Self {
-        Self { llm }
-    }
+    pub fn new(llm: Arc<dyn LlmClient>) -> Self { Self { llm } }
 
     /// Generate strategy code based on a hypothesis and additional context.
-    pub async fn generate_code(
-        &self,
-        hypothesis: &Hypothesis,
-        context: &str,
-    ) -> Result<String> {
+    pub async fn generate_code(&self, hypothesis: &Hypothesis, context: &str) -> Result<String> {
         let prompt = format!(
-            "Generate trading strategy code for this hypothesis:\n\
-             Hypothesis: {}\n\
-             Reason: {}\n\
-             Context: {context}\n\n\
-             Return only the strategy code.",
-            hypothesis.text,
-            hypothesis.reason
+            "Generate trading strategy code for this hypothesis:\nHypothesis: {}\nReason: \
+             {}\nContext: {context}\n\nReturn only the strategy code.",
+            hypothesis.text, hypothesis.reason
         );
 
         self.llm.complete(&prompt).await.context(LlmSnafu)
@@ -60,11 +49,9 @@ impl StrategyCoder {
         hypothesis: &Hypothesis,
     ) -> Result<String> {
         let prompt = format!(
-            "Fix the following Rust strategy code compilation errors.\n\n\
-             Hypothesis: {}\n\n\
-             Current code:\n```rust\n{code}\n```\n\n\
-             Compilation errors:\n{}\n\n\
-             Return only the corrected Rust code.",
+            "Fix the following Rust strategy code compilation errors.\n\nHypothesis: \
+             {}\n\nCurrent code:\n```rust\n{code}\n```\n\nCompilation errors:\n{}\n\nReturn only \
+             the corrected Rust code.",
             hypothesis.text,
             errors.join("\n")
         );
@@ -75,18 +62,21 @@ impl StrategyCoder {
 
 #[cfg(test)]
 mod tests {
+    use rara_agent::{
+        backend::{CliBackend, OutputFormat, PromptMode},
+        executor::CliExecutor,
+    };
+
     use super::*;
-    use rara_agent::backend::{CliBackend, OutputFormat, PromptMode};
-    use rara_agent::executor::CliExecutor;
 
     fn echo_executor(response: &str) -> CliExecutor {
         CliExecutor::new(CliBackend {
-            command: "sh".to_string(),
-            args: vec!["-c".to_string(), format!("printf '{response}\\n'")],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "sh".to_string(),
+            args:          vec!["-c".to_string(), format!("printf '{response}\\n'")],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         })
     }
 

--- a/crates/rara-research/src/strategy_executor.rs
+++ b/crates/rara-research/src/strategy_executor.rs
@@ -1,4 +1,5 @@
-//! Abstract strategy execution interface, decoupled from any specific runtime (WASM, Python, etc.).
+//! Abstract strategy execution interface, decoupled from any specific runtime
+//! (WASM, Python, etc.).
 
 use rara_strategy_api::{Candle, RiskLevels, Side, Signal, StrategyMeta};
 use snafu::Snafu;
@@ -33,7 +34,8 @@ pub trait StrategyExecutor: Send + Sync {
     fn load(&self, artifact: &[u8]) -> Result<Box<dyn StrategyHandle>>;
 }
 
-/// Executable strategy handle — runtime-agnostic interface for calling strategy functions.
+/// Executable strategy handle — runtime-agnostic interface for calling strategy
+/// functions.
 pub trait StrategyHandle: Send {
     /// Return strategy metadata.
     fn meta(&mut self) -> Result<StrategyMeta>;

--- a/crates/rara-research/src/strategy_manager.rs
+++ b/crates/rara-research/src/strategy_manager.rs
@@ -4,10 +4,9 @@
 //! and persistence so the research loop is runtime-agnostic.
 
 use async_trait::async_trait;
+use rara_domain::research::{Hypothesis, ResearchStrategy, ResearchStrategyStatus};
 use snafu::Snafu;
 use uuid::Uuid;
-
-use rara_domain::research::{Hypothesis, ResearchStrategy, ResearchStrategyStatus};
 
 use crate::strategy_executor::StrategyHandle;
 

--- a/crates/rara-research/src/strategy_promoter.rs
+++ b/crates/rara-research/src/strategy_promoter.rs
@@ -1,4 +1,5 @@
-//! Strategy promotion — saves accepted WASM strategies for paper trading pickup.
+//! Strategy promotion — saves accepted WASM strategies for paper trading
+//! pickup.
 //!
 //! When the research loop accepts a candidate strategy, the promoter persists
 //! the compiled WASM binary and metadata so downstream systems (paper trading,
@@ -7,16 +8,15 @@
 use std::path::{Path, PathBuf};
 
 use bon::Builder;
+use rara_strategy_api::StrategyMeta;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use uuid::Uuid;
 
-use rara_strategy_api::StrategyMeta;
-
-use crate::compiler::StrategyCompiler;
-use crate::strategy_executor::StrategyExecutor;
-use crate::trace::Trace;
-use crate::wasm_executor::WasmExecutor;
+use crate::{
+    compiler::StrategyCompiler, strategy_executor::StrategyExecutor, trace::Trace,
+    wasm_executor::WasmExecutor,
+};
 
 /// Errors from strategy promotion operations.
 #[derive(Debug, Snafu)]
@@ -90,38 +90,28 @@ pub struct PromotedStrategy {
     /// The hypothesis the experiment tested.
     hypothesis_id: Uuid,
     /// Filesystem path to the promoted WASM binary.
-    wasm_path: PathBuf,
+    wasm_path:     PathBuf,
     /// Strategy metadata extracted from the WASM module.
-    meta: StrategyMeta,
+    meta:          StrategyMeta,
     /// Filesystem path to the saved `.rs` source code, if available.
-    source_path: Option<PathBuf>,
+    source_path:   Option<PathBuf>,
 }
 
 impl PromotedStrategy {
     /// Returns the experiment ID.
-    pub const fn experiment_id(&self) -> Uuid {
-        self.experiment_id
-    }
+    pub const fn experiment_id(&self) -> Uuid { self.experiment_id }
 
     /// Returns the hypothesis ID.
-    pub const fn hypothesis_id(&self) -> Uuid {
-        self.hypothesis_id
-    }
+    pub const fn hypothesis_id(&self) -> Uuid { self.hypothesis_id }
 
     /// Returns the path to the promoted WASM binary.
-    pub fn wasm_path(&self) -> &Path {
-        &self.wasm_path
-    }
+    pub fn wasm_path(&self) -> &Path { &self.wasm_path }
 
     /// Returns the strategy metadata.
-    pub const fn meta(&self) -> &StrategyMeta {
-        &self.meta
-    }
+    pub const fn meta(&self) -> &StrategyMeta { &self.meta }
 
     /// Returns the path to the saved `.rs` source code, if available.
-    pub fn source_path(&self) -> Option<&Path> {
-        self.source_path.as_deref()
-    }
+    pub fn source_path(&self) -> Option<&Path> { self.source_path.as_deref() }
 }
 
 /// Handles promotion of candidate strategies from research to paper trading.
@@ -132,11 +122,11 @@ impl PromotedStrategy {
 #[derive(Builder)]
 pub struct StrategyPromoter {
     /// Trace storage for looking up experiments and hypotheses.
-    trace: Trace,
+    trace:        Trace,
     /// WASM runtime for validating promoted modules.
-    runtime: WasmExecutor,
+    runtime:      WasmExecutor,
     /// Strategy compiler for producing WASM from source code.
-    compiler: StrategyCompiler,
+    compiler:     StrategyCompiler,
     /// Base directory for promoted strategies (e.g. `strategies/promoted/`).
     promoted_dir: PathBuf,
 }
@@ -182,9 +172,7 @@ impl StrategyPromoter {
         std::fs::create_dir_all(&self.promoted_dir).context(IoSnafu)?;
 
         // 5. Save WASM binary
-        let wasm_path = self
-            .promoted_dir
-            .join(format!("{experiment_id}.wasm"));
+        let wasm_path = self.promoted_dir.join(format!("{experiment_id}.wasm"));
         std::fs::write(&wasm_path, &wasm_bytes).context(IoSnafu)?;
 
         // 6. Save strategy source code alongside the binary
@@ -200,9 +188,7 @@ impl StrategyPromoter {
             .meta(meta)
             .build();
 
-        let meta_path = self
-            .promoted_dir
-            .join(format!("{experiment_id}.json"));
+        let meta_path = self.promoted_dir.join(format!("{experiment_id}.json"));
         let meta_json = serde_json::to_string_pretty(&promoted).context(SerializeSnafu)?;
         std::fs::write(&meta_path, meta_json).context(IoSnafu)?;
 
@@ -213,7 +199,8 @@ impl StrategyPromoter {
     ///
     /// Used when WASM bytes are already available (e.g. immediately after
     /// compilation in the research loop) to avoid a redundant compile step.
-    /// When `source_code` is provided, the `.rs` source is saved alongside the binary.
+    /// When `source_code` is provided, the `.rs` source is saved alongside the
+    /// binary.
     pub fn promote_from_wasm(
         &self,
         experiment_id: Uuid,
@@ -229,9 +216,7 @@ impl StrategyPromoter {
         std::fs::create_dir_all(&self.promoted_dir).context(IoSnafu)?;
 
         // 3. Save WASM binary
-        let wasm_path = self
-            .promoted_dir
-            .join(format!("{experiment_id}.wasm"));
+        let wasm_path = self.promoted_dir.join(format!("{experiment_id}.wasm"));
         std::fs::write(&wasm_path, wasm_bytes).context(IoSnafu)?;
 
         // 4. Save strategy source code if provided
@@ -252,16 +237,15 @@ impl StrategyPromoter {
             .meta(meta)
             .build();
 
-        let meta_path = self
-            .promoted_dir
-            .join(format!("{experiment_id}.json"));
+        let meta_path = self.promoted_dir.join(format!("{experiment_id}.json"));
         let meta_json = serde_json::to_string_pretty(&promoted).context(SerializeSnafu)?;
         std::fs::write(&meta_path, meta_json).context(IoSnafu)?;
 
         Ok(promoted)
     }
 
-    /// List all promoted strategies by reading metadata files from the promoted directory.
+    /// List all promoted strategies by reading metadata files from the promoted
+    /// directory.
     pub fn list_promoted(&self) -> Result<Vec<PromotedStrategy>> {
         if !self.promoted_dir.exists() {
             return Ok(vec![]);
@@ -287,9 +271,7 @@ impl StrategyPromoter {
 
     /// Load a promoted strategy's WASM bytes by experiment ID.
     pub fn load_promoted_wasm(&self, experiment_id: Uuid) -> Result<Vec<u8>> {
-        let wasm_path = self
-            .promoted_dir
-            .join(format!("{experiment_id}.wasm"));
+        let wasm_path = self.promoted_dir.join(format!("{experiment_id}.wasm"));
         std::fs::read(&wasm_path).context(IoSnafu)
     }
 }
@@ -327,8 +309,8 @@ mod tests {
         let exp_id = Uuid::new_v4();
         let hyp_id = Uuid::new_v4();
         let meta = StrategyMeta {
-            name: "test-strategy".into(),
-            version: 1,
+            name:        "test-strategy".into(),
+            version:     1,
             api_version: rara_strategy_api::API_VERSION,
             description: "A test".into(),
         };

--- a/crates/rara-research/src/strategy_registry.rs
+++ b/crates/rara-research/src/strategy_registry.rs
@@ -7,14 +7,12 @@
 use std::path::PathBuf;
 
 use bon::Builder;
+use rara_strategy_api::API_VERSION;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use tracing::{debug, info};
 
-use rara_strategy_api::API_VERSION;
-
-use crate::strategy_executor::StrategyExecutor;
-use crate::wasm_executor::WasmExecutor;
+use crate::{strategy_executor::StrategyExecutor, wasm_executor::WasmExecutor};
 
 /// Errors from strategy registry operations.
 #[derive(Debug, Snafu)]
@@ -33,7 +31,7 @@ pub enum RegistryError {
         /// HTTP status code.
         status: u16,
         /// Response body.
-        body: String,
+        body:   String,
     },
 
     /// No WASM asset found in the release.
@@ -45,13 +43,14 @@ pub enum RegistryError {
 
     /// WASM module API version is incompatible.
     #[snafu(display(
-        "API version mismatch: strategy requires v{strategy_version}, runtime supports v{runtime_version}"
+        "API version mismatch: strategy requires v{strategy_version}, runtime supports \
+         v{runtime_version}"
     ))]
     ApiVersionMismatch {
         /// The strategy's API version.
         strategy_version: u32,
         /// The runtime's supported API version.
-        runtime_version: u32,
+        runtime_version:  u32,
     },
 
     /// WASM runtime validation failed.
@@ -83,26 +82,26 @@ pub type Result<T> = std::result::Result<T, RegistryError>;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RegistryEntry {
     /// Release tag name (e.g. "btc-momentum-v0.1.0").
-    pub tag: String,
+    pub tag:           String,
     /// Strategy name derived from the tag.
-    pub name: String,
+    pub name:          String,
     /// Version string derived from the tag.
-    pub version: String,
+    pub version:       String,
     /// WASM asset download URL.
-    pub wasm_url: String,
+    pub wasm_url:      String,
     /// WASM asset filename.
     pub wasm_filename: String,
     /// Asset size in bytes.
-    pub size: u64,
+    pub size:          u64,
 }
 
 /// Metadata saved alongside a fetched registry strategy.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FetchedStrategy {
     /// Original registry entry.
-    pub entry: RegistryEntry,
+    pub entry:     RegistryEntry,
     /// Strategy metadata extracted from the WASM module.
-    pub meta: rara_strategy_api::StrategyMeta,
+    pub meta:      rara_strategy_api::StrategyMeta,
     /// Local filesystem path to the saved WASM binary.
     pub wasm_path: PathBuf,
 }
@@ -110,8 +109,8 @@ pub struct FetchedStrategy {
 /// GitHub Release asset from the API response.
 #[derive(Debug, Deserialize)]
 struct GitHubAsset {
-    name: String,
-    size: u64,
+    name:                 String,
+    size:                 u64,
     browser_download_url: String,
 }
 
@@ -119,7 +118,7 @@ struct GitHubAsset {
 #[derive(Debug, Deserialize)]
 struct GitHubRelease {
     tag_name: String,
-    assets: Vec<GitHubAsset>,
+    assets:   Vec<GitHubAsset>,
 }
 
 /// Client for the rara-strategies GitHub Release registry.
@@ -136,10 +135,7 @@ pub struct StrategyRegistry {
 impl StrategyRegistry {
     /// List all available strategies from the GitHub registry.
     pub async fn list_available(&self) -> Result<Vec<RegistryEntry>> {
-        let url = format!(
-            "https://api.github.com/repos/{}/releases",
-            self.repo
-        );
+        let url = format!("https://api.github.com/repos/{}/releases", self.repo);
 
         let client = reqwest::Client::new();
         let response = client
@@ -164,14 +160,11 @@ impl StrategyRegistry {
         let entries = releases
             .into_iter()
             .filter_map(|release| {
-                let wasm_asset = release
-                    .assets
-                    .into_iter()
-                    .find(|a| {
-                        std::path::Path::new(&a.name)
-                            .extension()
-                            .is_some_and(|ext| ext.eq_ignore_ascii_case("wasm"))
-                    })?;
+                let wasm_asset = release.assets.into_iter().find(|a| {
+                    std::path::Path::new(&a.name)
+                        .extension()
+                        .is_some_and(|ext| ext.eq_ignore_ascii_case("wasm"))
+                })?;
 
                 let (name, version) = parse_tag(&release.tag_name)?;
 
@@ -189,7 +182,8 @@ impl StrategyRegistry {
         Ok(entries)
     }
 
-    /// Fetch a strategy by name, validate it, and save to the promoted directory.
+    /// Fetch a strategy by name, validate it, and save to the promoted
+    /// directory.
     pub async fn fetch(&self, strategy_name: &str) -> Result<FetchedStrategy> {
         let entries = self.list_available().await?;
 
@@ -234,7 +228,7 @@ impl StrategyRegistry {
         if meta.api_version != API_VERSION {
             return Err(RegistryError::ApiVersionMismatch {
                 strategy_version: meta.api_version,
-                runtime_version: API_VERSION,
+                runtime_version:  API_VERSION,
             });
         }
 
@@ -248,9 +242,7 @@ impl StrategyRegistry {
         // Save to promoted directory
         std::fs::create_dir_all(&self.promoted_dir).context(IoSnafu)?;
 
-        let wasm_path = self
-            .promoted_dir
-            .join(format!("{}.wasm", entry.name));
+        let wasm_path = self.promoted_dir.join(format!("{}.wasm", entry.name));
         std::fs::write(&wasm_path, &wasm_bytes).context(IoSnafu)?;
 
         // Save metadata JSON alongside the WASM file
@@ -274,7 +266,8 @@ impl StrategyRegistry {
         Ok(fetched)
     }
 
-    /// List strategies that have been fetched from the registry and saved locally.
+    /// List strategies that have been fetched from the registry and saved
+    /// locally.
     pub fn list_installed(&self) -> Result<Vec<FetchedStrategy>> {
         if !self.promoted_dir.exists() {
             return Ok(Vec::new());

--- a/crates/rara-research/src/strategy_store.rs
+++ b/crates/rara-research/src/strategy_store.rs
@@ -1,14 +1,14 @@
 //! Sled-backed persistence for research strategies.
 //!
 //! Stores [`ResearchStrategy`] metadata in sled and compiled artifacts
-//! on the filesystem. Provides CRUD operations for strategy lifecycle management.
+//! on the filesystem. Provides CRUD operations for strategy lifecycle
+//! management.
 
 use std::path::{Path, PathBuf};
 
+use rara_domain::research::{ResearchStrategy, ResearchStrategyStatus};
 use snafu::{ResultExt, Snafu};
 use uuid::Uuid;
-
-use rara_domain::research::{ResearchStrategy, ResearchStrategyStatus};
 
 /// Errors from strategy store operations.
 #[derive(Debug, Snafu)]
@@ -37,7 +37,7 @@ pub type Result<T> = std::result::Result<T, StrategyStoreError>;
 /// Sled-backed store for research strategy metadata and artifacts.
 pub struct StrategyStore {
     /// sled tree for strategy metadata (id -> JSON).
-    strategies: sled::Tree,
+    strategies:   sled::Tree,
     /// Filesystem directory for compiled artifacts.
     artifact_dir: PathBuf,
 }
@@ -102,7 +102,10 @@ impl StrategyStore {
     }
 
     /// List all strategies, optionally filtered by status.
-    pub fn list(&self, status_filter: Option<ResearchStrategyStatus>) -> Result<Vec<ResearchStrategy>> {
+    pub fn list(
+        &self,
+        status_filter: Option<ResearchStrategyStatus>,
+    ) -> Result<Vec<ResearchStrategy>> {
         self.strategies
             .iter()
             .map(|item| {

--- a/crates/rara-research/src/trace.rs
+++ b/crates/rara-research/src/trace.rs
@@ -2,10 +2,9 @@
 
 use std::path::Path;
 
+use rara_domain::research::{Experiment, Hypothesis, HypothesisFeedback};
 use snafu::{ResultExt, Snafu};
 use uuid::Uuid;
-
-use rara_domain::research::{Experiment, Hypothesis, HypothesisFeedback};
 
 /// Errors that can occur in trace storage.
 #[derive(Debug, Snafu)]
@@ -42,13 +41,14 @@ pub enum DagSelection {
 /// DAG storage for the research loop, persisting hypotheses, experiments,
 /// and feedback in sled trees.
 pub struct Trace {
-    hypotheses: sled::Tree,
+    hypotheses:  sled::Tree,
     experiments: sled::Tree,
-    feedbacks: sled::Tree,
-    /// Maps `u64_be_bytes` node index to `serde_json Vec<u64>` of parent indices.
+    feedbacks:   sled::Tree,
+    /// Maps `u64_be_bytes` node index to `serde_json Vec<u64>` of parent
+    /// indices.
     dag_parents: sled::Tree,
     /// Maps `u64_be_bytes` sequential index to experiment ID bytes.
-    hist_order: sled::Tree,
+    hist_order:  sled::Tree,
 }
 
 impl Trace {
@@ -151,14 +151,14 @@ impl Trace {
     /// Find the experiment with the best accepted feedback.
     ///
     /// Scans all feedbacks and returns the first accepted experiment found,
-    /// along with its feedback. Returns `None` if no accepted experiments exist.
+    /// along with its feedback. Returns `None` if no accepted experiments
+    /// exist.
     pub fn get_best_experiment(&self) -> Result<Option<(Experiment, HypothesisFeedback)>> {
         let mut best: Option<(Experiment, HypothesisFeedback)> = None;
 
         for res in &self.feedbacks {
             let (_, bytes) = res.context(SledSnafu)?;
-            let fb: HypothesisFeedback =
-                serde_json::from_slice(&bytes).context(SerializeSnafu)?;
+            let fb: HypothesisFeedback = serde_json::from_slice(&bytes).context(SerializeSnafu)?;
 
             if !fb.decision {
                 continue;
@@ -276,8 +276,7 @@ impl Trace {
 
         for res in &self.feedbacks {
             let (_, bytes) = res.context(SledSnafu)?;
-            let fb: HypothesisFeedback =
-                serde_json::from_slice(&bytes).context(SerializeSnafu)?;
+            let fb: HypothesisFeedback = serde_json::from_slice(&bytes).context(SerializeSnafu)?;
 
             if !fb.decision {
                 continue;
@@ -292,7 +291,9 @@ impl Trace {
                 .as_ref()
                 .map_or(f64::NEG_INFINITY, |result| result.sharpe_ratio);
 
-            let dominated = best.as_ref().is_some_and(|(_, _, best_sharpe)| *best_sharpe >= sharpe);
+            let dominated = best
+                .as_ref()
+                .is_some_and(|(_, _, best_sharpe)| *best_sharpe >= sharpe);
             if !dominated {
                 best = Some((exp, fb, sharpe));
             }
@@ -328,10 +329,7 @@ impl Trace {
     ///
     /// Scans all `dag_parents` entries and returns nodes whose parent list
     /// contains `parent_idx`.
-    pub fn children(
-        &self,
-        parent_idx: u64,
-    ) -> Result<Vec<(Experiment, HypothesisFeedback)>> {
+    pub fn children(&self, parent_idx: u64) -> Result<Vec<(Experiment, HypothesisFeedback)>> {
         self.dag_parents
             .iter()
             .filter_map(|res| {
@@ -412,7 +410,8 @@ impl Trace {
     /// Render trace history as structured text for LLM prompt injection.
     ///
     /// Shows the most recent `max_entries` entries from `hist_order`, formatted
-    /// as one line per iteration with hypothesis, result, metrics, and feedback.
+    /// as one line per iteration with hypothesis, result, metrics, and
+    /// feedback.
     pub fn format_for_prompt(&self, max_entries: usize) -> Result<String> {
         let total = self.hist_order.len();
         let skip = total.saturating_sub(max_entries);
@@ -459,7 +458,8 @@ impl Trace {
                 let iteration = skip + i;
 
                 Some(Ok(format!(
-                    "[Iteration {iteration}] Hypothesis: {hyp_text} | Result: {decision_str} | Sharpe: {sharpe} | PnL: {pnl} | Feedback: {}",
+                    "[Iteration {iteration}] Hypothesis: {hyp_text} | Result: {decision_str} | \
+                     Sharpe: {sharpe} | PnL: {pnl} | Feedback: {}",
                     fb.reason
                 )))
             })
@@ -471,9 +471,8 @@ impl Trace {
 
 #[cfg(test)]
 mod tests {
-    use rust_decimal_macros::dec;
-
     use rara_domain::research::BacktestResult;
+    use rust_decimal_macros::dec;
 
     use super::*;
 
@@ -658,17 +657,23 @@ mod tests {
         // Accepted with low Sharpe
         let exp_low = make_experiment(h.id, "low", Some(0.5));
         let fb_low = make_feedback(exp_low.id, true, "low sharpe reason");
-        trace.record(&exp_low, &fb_low, &DagSelection::NewRoot).unwrap();
+        trace
+            .record(&exp_low, &fb_low, &DagSelection::NewRoot)
+            .unwrap();
 
         // Rejected with high Sharpe (should not win)
         let exp_rej = make_experiment(h.id, "rejected", Some(5.0));
         let fb_rej = make_feedback(exp_rej.id, false, "rejected reason");
-        trace.record(&exp_rej, &fb_rej, &DagSelection::Latest).unwrap();
+        trace
+            .record(&exp_rej, &fb_rej, &DagSelection::Latest)
+            .unwrap();
 
         // Accepted with high Sharpe (should win)
         let exp_high = make_experiment(h.id, "high", Some(2.5));
         let fb_high = make_feedback(exp_high.id, true, "high sharpe reason");
-        trace.record(&exp_high, &fb_high, &DagSelection::Latest).unwrap();
+        trace
+            .record(&exp_high, &fb_high, &DagSelection::Latest)
+            .unwrap();
 
         let sota = trace.get_sota().unwrap().unwrap();
         assert_eq!(sota.0.id, exp_high.id);

--- a/crates/rara-research/src/wasm_executor.rs
+++ b/crates/rara-research/src/wasm_executor.rs
@@ -1,5 +1,6 @@
-//! WASM-based strategy executor — implements [`StrategyExecutor`] and [`StrategyHandle`]
-//! by delegating to `wasmtime` for compiled `.wasm` strategy files.
+//! WASM-based strategy executor — implements [`StrategyExecutor`] and
+//! [`StrategyHandle`] by delegating to `wasmtime` for compiled `.wasm` strategy
+//! files.
 
 use bon::Builder;
 use rara_strategy_api::{Candle, RiskLevels, Side, Signal, StrategyMeta};
@@ -10,8 +11,9 @@ use crate::strategy_executor::{ExecutorError, Result, StrategyExecutor, Strategy
 
 /// WASM-based strategy executor powered by `wasmtime`.
 ///
-/// Loads compiled `.wasm` strategy artifacts and produces [`WasmStrategyHandle`] instances
-/// that communicate via the JSON-based protocol.
+/// Loads compiled `.wasm` strategy artifacts and produces
+/// [`WasmStrategyHandle`] instances that communicate via the JSON-based
+/// protocol.
 #[derive(Debug, Builder)]
 pub struct WasmExecutor {
     /// Maximum fuel (computation budget) for WASM execution.
@@ -21,16 +23,17 @@ pub struct WasmExecutor {
 
 /// A loaded WASM strategy ready to execute.
 ///
-/// Wraps a `wasmtime` store and cached function handles for the strategy protocol.
+/// Wraps a `wasmtime` store and cached function handles for the strategy
+/// protocol.
 pub struct WasmStrategyHandle {
-    store: Store<WasiP1Ctx>,
-    memory: Memory,
+    store:               Store<WasiP1Ctx>,
+    memory:              Memory,
     // Cached typed function handles
-    fn_alloc: TypedFunc<u32, u32>,
-    fn_get_output_ptr: TypedFunc<(), u32>,
-    fn_get_output_len: TypedFunc<(), u32>,
-    fn_wasm_meta: TypedFunc<(), u32>,
-    fn_wasm_on_candles: TypedFunc<(), u32>,
+    fn_alloc:            TypedFunc<u32, u32>,
+    fn_get_output_ptr:   TypedFunc<(), u32>,
+    fn_get_output_len:   TypedFunc<(), u32>,
+    fn_wasm_meta:        TypedFunc<(), u32>,
+    fn_wasm_on_candles:  TypedFunc<(), u32>,
     fn_wasm_risk_levels: TypedFunc<(), u32>,
 }
 
@@ -65,7 +68,8 @@ impl StrategyExecutor for WasmExecutor {
         config.consume_fuel(true);
         let engine = Engine::new(&config).map_err(|e| load_err("WASM engine error", e))?;
 
-        let module = Module::new(&engine, artifact).map_err(|e| load_err("WASM module error", e))?;
+        let module =
+            Module::new(&engine, artifact).map_err(|e| load_err("WASM module error", e))?;
 
         let wasi_ctx = wasmtime_wasi::WasiCtxBuilder::new().build_p1();
 
@@ -82,13 +86,15 @@ impl StrategyExecutor for WasmExecutor {
             .instantiate(&mut store, &module)
             .map_err(|e| load_err("WASM instantiation error", e))?;
 
-        let memory = instance
-            .get_memory(&mut store, "memory")
-            .ok_or_else(|| ExecutorError::Load {
-                message: "missing WASM export: memory".into(),
-            })?;
+        let memory =
+            instance
+                .get_memory(&mut store, "memory")
+                .ok_or_else(|| ExecutorError::Load {
+                    message: "missing WASM export: memory".into(),
+                })?;
 
-        // Resolve each exported function handle individually to preserve type information
+        // Resolve each exported function handle individually to preserve type
+        // information
         let fn_alloc: TypedFunc<u32, u32> = instance
             .get_typed_func(&mut store, "alloc")
             .map_err(|e| load_err("missing export: alloc", e))?;
@@ -149,7 +155,7 @@ impl StrategyHandle for WasmStrategyHandle {
         #[derive(serde::Serialize)]
         struct Input {
             entry_price: f64,
-            side: Side,
+            side:        Side,
         }
         let input = serde_json::to_vec(&Input { entry_price, side })
             .map_err(|e| serde_err("failed to serialize risk_levels input", e))?;

--- a/crates/rara-research/src/wasm_strategy_manager.rs
+++ b/crates/rara-research/src/wasm_strategy_manager.rs
@@ -6,16 +6,17 @@
 
 use async_trait::async_trait;
 use bon::Builder;
+use rara_domain::research::{Hypothesis, ResearchStrategy, ResearchStrategyStatus};
 use uuid::Uuid;
 
-use rara_domain::research::{Hypothesis, ResearchStrategy, ResearchStrategyStatus};
-
-use crate::compiler::StrategyCompiler;
-use crate::strategy_coder::StrategyCoder;
-use crate::strategy_executor::{StrategyExecutor, StrategyHandle};
-use crate::strategy_manager::{Result, StrategyManager, StrategyManagerError};
-use crate::strategy_store::StrategyStore;
-use crate::wasm_executor::WasmExecutor;
+use crate::{
+    compiler::StrategyCompiler,
+    strategy_coder::StrategyCoder,
+    strategy_executor::{StrategyExecutor, StrategyHandle},
+    strategy_manager::{Result, StrategyManager, StrategyManagerError},
+    strategy_store::StrategyStore,
+    wasm_executor::WasmExecutor,
+};
 
 /// WASM-based strategy manager.
 ///
@@ -25,9 +26,9 @@ use crate::wasm_executor::WasmExecutor;
 #[derive(Builder)]
 pub struct WasmStrategyManager {
     /// Sled-backed strategy persistence.
-    store: StrategyStore,
+    store:    StrategyStore,
     /// LLM-backed code generator.
-    coder: StrategyCoder,
+    coder:    StrategyCoder,
     /// Rust → WASM compiler.
     compiler: StrategyCompiler,
     /// WASM runtime for loading artifacts.
@@ -46,13 +47,11 @@ impl StrategyManager for WasmStrategyManager {
     }
 
     async fn try_compile(&self, source_code: &str) -> Result<Vec<u8>> {
-        let result = self
-            .compiler
-            .compile(source_code)
-            .await
-            .map_err(|e| StrategyManagerError::Compile {
+        let result = self.compiler.compile(source_code).await.map_err(|e| {
+            StrategyManagerError::Compile {
                 message: e.to_string(),
-            })?;
+            }
+        })?;
 
         if !result.success {
             return Err(StrategyManagerError::CompileFailed {
@@ -104,12 +103,12 @@ impl StrategyManager for WasmStrategyManager {
     }
 
     fn load_handle(&self, strategy_id: Uuid) -> Result<Box<dyn StrategyHandle>> {
-        let artifact = self
-            .store
-            .load_artifact(strategy_id)
-            .map_err(|e| StrategyManagerError::Store {
-                message: e.to_string(),
-            })?;
+        let artifact =
+            self.store
+                .load_artifact(strategy_id)
+                .map_err(|e| StrategyManagerError::Store {
+                    message: e.to_string(),
+                })?;
 
         self.executor
             .load(&artifact)

--- a/crates/rara-sentinel/src/analyzer.rs
+++ b/crates/rara-sentinel/src/analyzer.rs
@@ -3,23 +3,23 @@
 
 use std::str::FromStr;
 
+use rara_domain::sentinel::{SentinelSignal, Severity, SignalSource, SignalType};
 use serde::Serialize;
 use snafu::{ResultExt, Snafu};
-
-use rara_domain::sentinel::{Severity, SignalSource, SignalType, SentinelSignal};
 
 /// Raw data captured during signal analysis, attached to the resulting
 /// [`SentinelSignal`].
 #[derive(Debug, Serialize)]
 struct AnalyzerRawData<'a> {
     /// Name of the originating data source.
-    source_name: &'a str,
+    source_name:  &'a str,
     /// Original textual content that was analyzed.
-    content: &'a str,
+    content:      &'a str,
     /// Full LLM response text.
     llm_response: &'a str,
 }
 use rara_infra::llm::LlmClient;
+
 use crate::source::RawSignal;
 
 /// Errors that can occur during signal analysis.
@@ -49,9 +49,7 @@ pub struct SignalAnalyzer<L: LlmClient> {
 
 impl<L: LlmClient> SignalAnalyzer<L> {
     /// Create a new analyzer backed by the given LLM client.
-    pub const fn new(llm: L) -> Self {
-        Self { llm }
-    }
+    pub const fn new(llm: L) -> Self { Self { llm } }
 
     /// Analyze a raw signal and return an actionable `SentinelSignal` if the
     /// LLM determines it warrants attention, or `None` if no action is needed.
@@ -132,8 +130,8 @@ fn parse_response(
         .summary(summary_str)
         .raw_data(
             serde_json::to_value(AnalyzerRawData {
-                source_name: &raw.source_name,
-                content: &raw.content,
+                source_name:  &raw.source_name,
+                content:      &raw.content,
                 llm_response: response,
             })
             .expect("AnalyzerRawData must serialize"),
@@ -156,40 +154,46 @@ fn infer_source(source_name: &str) -> SignalSource {
 
 #[cfg(test)]
 mod tests {
-    use rara_agent::backend::{CliBackend, OutputFormat, PromptMode};
-    use rara_agent::executor::CliExecutor;
+    use rara_agent::{
+        backend::{CliBackend, OutputFormat, PromptMode},
+        executor::CliExecutor,
+    };
 
     use super::*;
 
     fn echo_executor(response: &str) -> CliExecutor {
         CliExecutor::new(CliBackend {
-            command: "sh".to_string(),
-            args: vec!["-c".to_string(), format!("printf '{response}\\n'")],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "sh".to_string(),
+            args:          vec!["-c".to_string(), format!("printf '{response}\\n'")],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         })
     }
 
     fn make_raw_signal() -> RawSignal {
         RawSignal {
             source_name: "test-source".to_owned(),
-            content: "Major exchange hack detected".to_owned(),
-            metadata: serde_json::json!({}),
-            timestamp: jiff::Timestamp::now(),
+            content:     "Major exchange hack detected".to_owned(),
+            metadata:    serde_json::json!({}),
+            timestamp:   jiff::Timestamp::now(),
         }
     }
 
     #[tokio::test]
     async fn parses_critical_signal_correctly() {
         let executor = echo_executor(
-            "SEVERITY: Critical\nTYPE: BlackSwan\nCONTRACTS: BTC-PERP,ETH-PERP\nSUMMARY: Major exchange hack detected",
+            "SEVERITY: Critical\nTYPE: BlackSwan\nCONTRACTS: BTC-PERP,ETH-PERP\nSUMMARY: Major \
+             exchange hack detected",
         );
         let analyzer = SignalAnalyzer::new(executor);
         let raw = make_raw_signal();
 
-        let result = analyzer.analyze(&raw).await.expect("analysis should succeed");
+        let result = analyzer
+            .analyze(&raw)
+            .await
+            .expect("analysis should succeed");
         let signal = result.expect("should return Some for Critical severity");
 
         assert_eq!(signal.severity, Severity::Critical);
@@ -205,7 +209,10 @@ mod tests {
         let analyzer = SignalAnalyzer::new(executor);
         let raw = make_raw_signal();
 
-        let result = analyzer.analyze(&raw).await.expect("analysis should succeed");
+        let result = analyzer
+            .analyze(&raw)
+            .await
+            .expect("analysis should succeed");
         assert!(result.is_none());
     }
 }

--- a/crates/rara-sentinel/src/engine.rs
+++ b/crates/rara-sentinel/src/engine.rs
@@ -3,14 +3,18 @@
 
 use std::sync::Arc;
 
-use snafu::{ResultExt, Snafu};
-
-use rara_domain::event::{Event, EventType};
-use rara_domain::sentinel::SentinelSignal;
+use rara_domain::{
+    event::{Event, EventType},
+    sentinel::SentinelSignal,
+};
 use rara_event_bus::bus::EventBus;
 use rara_infra::llm::LlmClient;
-use crate::analyzer::{AnalyzerError, SignalAnalyzer};
-use crate::source::{DataSource, SourceError};
+use snafu::{ResultExt, Snafu};
+
+use crate::{
+    analyzer::{AnalyzerError, SignalAnalyzer},
+    source::{DataSource, SourceError},
+};
 
 /// Errors that can occur in the sentinel engine.
 #[derive(Debug, Snafu)]
@@ -22,7 +26,7 @@ pub enum SentinelError {
         /// Name of the failing source.
         source_name: String,
         /// The underlying source error.
-        source: SourceError,
+        source:      SourceError,
     },
     /// The analyzer failed to classify a signal.
     #[snafu(display("analyzer error: {source}"))]
@@ -42,9 +46,9 @@ pub enum SentinelError {
 /// with an LLM, and publishes actionable events to the event bus.
 pub struct SentinelEngine<L: LlmClient> {
     /// Registered data sources to poll.
-    sources: Vec<Box<dyn DataSource>>,
+    sources:   Vec<Box<dyn DataSource>>,
     /// LLM-backed signal analyzer.
-    analyzer: SignalAnalyzer<L>,
+    analyzer:  SignalAnalyzer<L>,
     /// Event bus for publishing detected signals.
     event_bus: Arc<EventBus>,
 }
@@ -101,24 +105,24 @@ impl<L: LlmClient> SentinelEngine<L> {
 mod tests {
     use std::sync::Arc;
 
+    use rara_agent::{
+        backend::{CliBackend, OutputFormat, PromptMode},
+        executor::CliExecutor,
+    };
+    use rara_domain::sentinel::{SignalSource, SignalType};
     use serde_json::json;
 
-    use rara_agent::backend::{CliBackend, OutputFormat, PromptMode};
-    use rara_agent::executor::CliExecutor;
-    use rara_domain::sentinel::{SignalSource, SignalType};
-    use crate::source::RawSignal;
-    use crate::sources::webhook::WebhookDataSource;
-
     use super::*;
+    use crate::{source::RawSignal, sources::webhook::WebhookDataSource};
 
     fn echo_executor(response: &str) -> CliExecutor {
         CliExecutor::new(CliBackend {
-            command: "sh".to_string(),
-            args: vec!["-c".to_string(), format!("printf '{response}\\n'")],
-            prompt_mode: PromptMode::Arg,
-            prompt_flag: None,
+            command:       "sh".to_string(),
+            args:          vec!["-c".to_string(), format!("printf '{response}\\n'")],
+            prompt_mode:   PromptMode::Arg,
+            prompt_flag:   None,
             output_format: OutputFormat::Text,
-            env_vars: vec![],
+            env_vars:      vec![],
         })
     }
 
@@ -129,16 +133,17 @@ mod tests {
 
         let raw = RawSignal {
             source_name: "webhook-news".to_owned(),
-            content: "Exchange hacked, funds drained".to_owned(),
-            metadata: json!({}),
-            timestamp: jiff::Timestamp::now(),
+            content:     "Exchange hacked, funds drained".to_owned(),
+            metadata:    json!({}),
+            timestamp:   jiff::Timestamp::now(),
         };
 
         let source = WebhookDataSource::new("webhook-news");
         source.push(raw).await;
 
         let executor = echo_executor(
-            "SEVERITY: Critical\nTYPE: BlackSwan\nCONTRACTS: BTC-PERP\nSUMMARY: Exchange hack detected",
+            "SEVERITY: Critical\nTYPE: BlackSwan\nCONTRACTS: BTC-PERP\nSUMMARY: Exchange hack \
+             detected",
         );
 
         let analyzer = SignalAnalyzer::new(executor);
@@ -161,9 +166,9 @@ mod tests {
 
         let raw = RawSignal {
             source_name: "webhook-news".to_owned(),
-            content: "Routine market update".to_owned(),
-            metadata: json!({}),
-            timestamp: jiff::Timestamp::now(),
+            content:     "Routine market update".to_owned(),
+            metadata:    json!({}),
+            timestamp:   jiff::Timestamp::now(),
         };
 
         let source = WebhookDataSource::new("webhook-news");
@@ -192,21 +197,22 @@ mod tests {
         // Simulate a trump-code signal via webhook
         let raw = RawSignal {
             source_name: "trump-code".to_owned(),
-            content: "Trump Code signals for 2026-03-25: TARIFF(x3), DEAL(x1). \
-                      Consensus: BULLISH. Posts today: 12. \
-                      Opus insight: Deal signals suggest resolution".to_owned(),
-            metadata: json!({
+            content:     "Trump Code signals for 2026-03-25: TARIFF(x3), DEAL(x1). Consensus: \
+                          BULLISH. Posts today: 12. Opus insight: Deal signals suggest resolution"
+                .to_owned(),
+            metadata:    json!({
                 "consensus": "BULLISH",
                 "signal_confidence": {"TARIFF": 0.65, "DEAL": 0.72},
             }),
-            timestamp: jiff::Timestamp::now(),
+            timestamp:   jiff::Timestamp::now(),
         };
 
         let source = WebhookDataSource::new("trump-code");
         source.push(raw).await;
 
         let executor = echo_executor(
-            "SEVERITY: Warning\nTYPE: PoliticalSignal\nCONTRACTS: SPY,SPX\nSUMMARY: Trump tariff signals with deal offset",
+            "SEVERITY: Warning\nTYPE: PoliticalSignal\nCONTRACTS: SPY,SPX\nSUMMARY: Trump tariff \
+             signals with deal offset",
         );
 
         let analyzer = SignalAnalyzer::new(executor);

--- a/crates/rara-sentinel/src/source.rs
+++ b/crates/rara-sentinel/src/source.rs
@@ -9,11 +9,11 @@ pub struct RawSignal {
     /// Name of the source that produced this signal.
     pub source_name: String,
     /// Raw textual content to be analyzed.
-    pub content: String,
+    pub content:     String,
     /// Arbitrary metadata from the source.
-    pub metadata: serde_json::Value,
+    pub metadata:    serde_json::Value,
     /// When the raw signal was captured.
-    pub timestamp: jiff::Timestamp,
+    pub timestamp:   jiff::Timestamp,
 }
 
 /// Errors that can occur when polling a data source.

--- a/crates/rara-sentinel/src/sources/rss.rs
+++ b/crates/rara-sentinel/src/sources/rss.rs
@@ -10,9 +10,9 @@ use crate::source::{DataSource, RawSignal, SourceError};
 #[derive(Debug, Serialize)]
 struct RssEntryMetadata {
     /// Entry title.
-    title: String,
+    title:     String,
     /// Entry permalink.
-    link: String,
+    link:      String,
     /// Publication timestamp (RFC 3339).
     published: String,
 }
@@ -21,18 +21,16 @@ struct RssEntryMetadata {
 #[derive(Builder)]
 pub struct RssDataSource {
     /// Human-readable name for this source.
-    name: String,
+    name:   String,
     /// URL of the RSS/Atom feed.
-    url: String,
+    url:    String,
     /// HTTP client for fetching feeds.
     client: reqwest::Client,
 }
 
 #[async_trait]
 impl DataSource for RssDataSource {
-    fn name(&self) -> &str {
-        &self.name
-    }
+    fn name(&self) -> &str { &self.name }
 
     async fn poll(&self) -> Result<Vec<RawSignal>, SourceError> {
         let response = self
@@ -48,10 +46,9 @@ impl DataSource for RssDataSource {
             message: format!("reading body from {} failed: {e}", self.url),
         })?;
 
-        let feed =
-            feed_rs::parser::parse(&bytes[..]).map_err(|e| SourceError::Fetch {
-                message: format!("failed to parse feed from {}: {e}", self.url),
-            })?;
+        let feed = feed_rs::parser::parse(&bytes[..]).map_err(|e| SourceError::Fetch {
+            message: format!("failed to parse feed from {}: {e}", self.url),
+        })?;
 
         let signals = feed
             .entries

--- a/crates/rara-sentinel/src/sources/trump_code.rs
+++ b/crates/rara-sentinel/src/sources/trump_code.rs
@@ -12,22 +12,22 @@ use crate::source::{DataSource, RawSignal, SourceError};
 #[derive(Debug, Deserialize)]
 pub struct SignalsResponse {
     /// Date string for the current analysis window.
-    pub date: String,
+    pub date:              String,
     /// Active signal types detected today.
-    pub signals: Vec<String>,
+    pub signals:           Vec<String>,
     /// Number of posts analyzed.
-    pub posts: u32,
+    pub posts:             u32,
     /// Overall market consensus derived from signals.
-    pub consensus: String,
+    pub consensus:         String,
     /// Per-day signal breakdown keyed by date string.
-    pub recent_days: HashMap<String, Vec<DaySignal>>,
+    pub recent_days:       HashMap<String, Vec<DaySignal>>,
     /// Confidence scores per signal type (0.0–1.0).
     pub signal_confidence: HashMap<String, f64>,
     /// Playbook summary with notable patterns.
-    pub playbook_summary: PlaybookSummary,
+    pub playbook_summary:  PlaybookSummary,
     /// Optional long-form insight from Opus analysis.
     #[serde(default)]
-    pub opus_insight: String,
+    pub opus_insight:      String,
 }
 
 /// A single signal type and its occurrence count for a given day.
@@ -37,16 +37,16 @@ pub struct DaySignal {
     #[serde(rename = "type")]
     pub signal_type: String,
     /// How many times this signal was detected.
-    pub count: u32,
+    pub count:       u32,
 }
 
 /// Notable pattern summaries from the playbook analysis.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PlaybookSummary {
     /// The most dangerous signal pattern observed.
-    pub most_dangerous: String,
+    pub most_dangerous:   String,
     /// The most profitable signal pattern observed.
-    pub most_profitable: String,
+    pub most_profitable:  String,
     /// The biggest surprise in the data.
     pub biggest_surprise: String,
 }
@@ -55,19 +55,19 @@ pub struct PlaybookSummary {
 #[derive(Debug, Serialize)]
 pub struct TrumpCodeMetadata<'a> {
     /// Date of the signal day.
-    pub date: &'a str,
+    pub date:              &'a str,
     /// Overall directional consensus.
-    pub consensus: &'a str,
+    pub consensus:         &'a str,
     /// Number of posts analyzed today.
-    pub posts_today: u32,
+    pub posts_today:       u32,
     /// Per-signal-type confidence scores.
     pub signal_confidence: &'a HashMap<String, f64>,
     /// Playbook pattern summaries.
-    pub playbook: &'a PlaybookSummary,
+    pub playbook:          &'a PlaybookSummary,
     /// Claude Opus deep analysis insight.
-    pub opus_insight: &'a str,
+    pub opus_insight:      &'a str,
     /// Individual signal observations for this day.
-    pub day_signals: &'a [DaySignal],
+    pub day_signals:       &'a [DaySignal],
 }
 
 impl SignalsResponse {
@@ -108,17 +108,17 @@ impl SignalsResponse {
                 );
 
                 let metadata = TrumpCodeMetadata {
-                    date: &date,
-                    consensus: &consensus,
-                    posts_today: posts,
+                    date:              &date,
+                    consensus:         &consensus,
+                    posts_today:       posts,
                     signal_confidence: &signal_confidence,
-                    playbook: &playbook,
-                    opus_insight: &opus_insight,
-                    day_signals: &day_signals,
+                    playbook:          &playbook,
+                    opus_insight:      &opus_insight,
+                    day_signals:       &day_signals,
                 };
 
-                let metadata = serde_json::to_value(&metadata)
-                    .expect("TrumpCodeMetadata must serialize");
+                let metadata =
+                    serde_json::to_value(&metadata).expect("TrumpCodeMetadata must serialize");
 
                 RawSignal {
                     source_name: "trump-code".to_owned(),
@@ -138,15 +138,13 @@ pub struct TrumpCodeDataSource {
     #[builder(default = "https://trumpcode.washinmura.jp".to_owned())]
     pub base_url: String,
     /// HTTP client for API requests.
-    pub client: reqwest::Client,
+    pub client:   reqwest::Client,
 }
 
 #[async_trait]
 impl DataSource for TrumpCodeDataSource {
     #[allow(clippy::unnecessary_literal_bound)]
-    fn name(&self) -> &str {
-        "trump-code"
-    }
+    fn name(&self) -> &str { "trump-code" }
 
     async fn poll(&self) -> Result<Vec<RawSignal>, SourceError> {
         let url = format!("{}/api/signals", self.base_url);

--- a/crates/rara-sentinel/src/sources/webhook.rs
+++ b/crates/rara-sentinel/src/sources/webhook.rs
@@ -9,31 +9,28 @@ use crate::source::{DataSource, RawSignal, SourceError};
 /// Useful for webhook endpoints or API-push integrations.
 pub struct WebhookDataSource {
     /// Human-readable name for this source.
-    name: String,
+    name:   String,
     /// Internal buffer of signals waiting to be drained.
     buffer: Mutex<Vec<RawSignal>>,
 }
 
 impl WebhookDataSource {
-    /// Create a new webhook data source with the given name and an empty buffer.
+    /// Create a new webhook data source with the given name and an empty
+    /// buffer.
     pub fn new(name: impl Into<String>) -> Self {
         Self {
-            name: name.into(),
+            name:   name.into(),
             buffer: Mutex::new(Vec::new()),
         }
     }
 
     /// Push a raw signal into the internal buffer for the next poll cycle.
-    pub async fn push(&self, signal: RawSignal) {
-        self.buffer.lock().await.push(signal);
-    }
+    pub async fn push(&self, signal: RawSignal) { self.buffer.lock().await.push(signal); }
 }
 
 #[async_trait]
 impl DataSource for WebhookDataSource {
-    fn name(&self) -> &str {
-        &self.name
-    }
+    fn name(&self) -> &str { &self.name }
 
     async fn poll(&self) -> Result<Vec<RawSignal>, SourceError> {
         let drained = self.buffer.lock().await.drain(..).collect();

--- a/crates/rara-server/src/health.rs
+++ b/crates/rara-server/src/health.rs
@@ -1,7 +1,9 @@
 //! Lightweight health probes for external service dependencies.
 
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 
 use tokio::net::TcpStream;
 use tracing::debug;
@@ -9,11 +11,11 @@ use tracing::debug;
 /// Configuration for health probes.
 pub struct HealthConfig {
     /// `PostgreSQL` connection URL (parsed for host:port TCP probe).
-    pub database_url: String,
+    pub database_url:   String,
     /// Agent backend command name to look up in PATH.
-    pub llm_backend: String,
+    pub llm_backend:    String,
     /// Shared flag set by the WebSocket layer when a connection is active.
-    pub ws_connected: Arc<AtomicBool>,
+    pub ws_connected:   Arc<AtomicBool>,
     /// Number of configured trading contracts.
     pub contract_count: u32,
 }
@@ -21,11 +23,11 @@ pub struct HealthConfig {
 /// Probe results for a single status poll.
 pub struct HealthStatus {
     /// Whether the database TCP port is reachable.
-    pub database_connected: bool,
+    pub database_connected:  bool,
     /// Whether the WebSocket market-data feed is active.
     pub websocket_connected: bool,
     /// Whether the configured LLM backend CLI is found in PATH.
-    pub llm_available: bool,
+    pub llm_available:       bool,
 }
 
 /// Run all health probes and return aggregated status.
@@ -57,9 +59,7 @@ async fn probe_database(url: &str) -> bool {
 }
 
 /// Check if the LLM backend command exists in PATH.
-fn probe_llm(backend: &str) -> bool {
-    which::which(backend).is_ok()
-}
+fn probe_llm(backend: &str) -> bool { which::which(backend).is_ok() }
 
 /// Extract `host:port` from a `PostgreSQL` URL.
 ///

--- a/crates/rara-server/src/service.rs
+++ b/crates/rara-server/src/service.rs
@@ -1,26 +1,27 @@
 //! gRPC service implementation for [`RaraService`].
 
-use std::pin::Pin;
-use std::sync::Arc;
-use std::time::Instant;
+use std::{pin::Pin, sync::Arc, time::Instant};
 
+use rara_event_bus::bus::EventBus;
 use tokio_stream::Stream;
 use tonic::{Request, Response, Status};
 use tracing::info;
 
-use rara_event_bus::bus::EventBus;
-
-use crate::health::{self, HealthConfig};
-use crate::rara_proto::rara_service_server::RaraService;
-use crate::rara_proto::{Empty, EventFilter, EventMessage, SystemStatus};
+use crate::{
+    health::{self, HealthConfig},
+    rara_proto::{
+        Empty, EventFilter, EventMessage, SystemStatus, rara_service_server::RaraService,
+    },
+};
 
 /// Holds shared state needed by the gRPC handlers.
 pub struct RaraServiceImpl {
     /// Application start time, used to compute uptime.
-    start_time: Instant,
+    start_time:    Instant,
     /// Event bus for subscribing to real-time events.
-    event_bus: Option<Arc<EventBus>>,
-    /// Health probe configuration (None = legacy scaffold mode, all indicators false).
+    event_bus:     Option<Arc<EventBus>>,
+    /// Health probe configuration (None = legacy scaffold mode, all indicators
+    /// false).
     health_config: Option<Arc<HealthConfig>>,
 }
 
@@ -29,8 +30,8 @@ impl RaraServiceImpl {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            start_time: Instant::now(),
-            event_bus: None,
+            start_time:    Instant::now(),
+            event_bus:     None,
             health_config: None,
         }
     }
@@ -39,8 +40,8 @@ impl RaraServiceImpl {
     #[must_use]
     pub fn with_health(health_config: HealthConfig) -> Self {
         Self {
-            start_time: Instant::now(),
-            event_bus: None,
+            start_time:    Instant::now(),
+            event_bus:     None,
             health_config: Some(Arc::new(health_config)),
         }
     }
@@ -49,8 +50,8 @@ impl RaraServiceImpl {
     #[must_use]
     pub fn with_event_bus(event_bus: Arc<EventBus>) -> Self {
         Self {
-            start_time: Instant::now(),
-            event_bus: Some(event_bus),
+            start_time:    Instant::now(),
+            event_bus:     Some(event_bus),
             health_config: None,
         }
     }
@@ -64,13 +65,14 @@ impl RaraServiceImpl {
 }
 
 impl Default for RaraServiceImpl {
-    fn default() -> Self {
-        Self::new()
-    }
+    fn default() -> Self { Self::new() }
 }
 
 #[tonic::async_trait]
 impl RaraService for RaraServiceImpl {
+    type StreamEventsStream =
+        Pin<Box<dyn Stream<Item = Result<EventMessage, Status>> + Send + 'static>>;
+
     async fn get_system_status(
         &self,
         _request: Request<Empty>,
@@ -83,20 +85,29 @@ impl RaraService for RaraServiceImpl {
         let (database_connected, websocket_connected, llm_available, contract_count) =
             if let Some(ref config) = self.health_config {
                 let h = health::probe(config).await;
-                (h.database_connected, h.websocket_connected, h.llm_available, config.contract_count)
+                (
+                    h.database_connected,
+                    h.websocket_connected,
+                    h.llm_available,
+                    config.contract_count,
+                )
             } else {
                 (false, false, false, 0)
             };
 
         let mut warnings = Vec::new();
         if contract_count == 0 {
-            warnings.push("No contracts configured. Run `rara setup -i` to add trading pairs.".to_string());
+            warnings.push(
+                "No contracts configured. Run `rara setup -i` to add trading pairs.".to_string(),
+            );
         }
         if !database_connected {
             warnings.push("Database unreachable. Check PostgreSQL is running.".to_string());
         }
         if !llm_available {
-            warnings.push("LLM backend not found in PATH. Run `rara setup -i` to configure.".to_string());
+            warnings.push(
+                "LLM backend not found in PATH. Run `rara setup -i` to configure.".to_string(),
+            );
         }
 
         let status = SystemStatus {
@@ -113,9 +124,6 @@ impl RaraService for RaraServiceImpl {
         info!("GetSystemStatus called, uptime={}", status.uptime);
         Ok(Response::new(status))
     }
-
-    type StreamEventsStream =
-        Pin<Box<dyn Stream<Item = Result<EventMessage, Status>> + Send + 'static>>;
 
     async fn stream_events(
         &self,

--- a/crates/rara-server/tests/service_test.rs
+++ b/crates/rara-server/tests/service_test.rs
@@ -3,20 +3,21 @@
 //! Each test spins up a real tonic server on a random port, connects a real
 //! gRPC client, and exercises the actual RPC behaviour.
 
-use std::sync::Arc;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
+use rara_domain::event::{Event, EventType};
+use rara_event_bus::bus::EventBus;
+use rara_server::{
+    rara_proto::{
+        Empty, EventFilter, rara_service_client::RaraServiceClient,
+        rara_service_server::RaraServiceServer,
+    },
+    service::RaraServiceImpl,
+};
 use serde_json::json;
 use tokio::net::TcpListener;
 use tokio_stream::StreamExt;
 use tonic::transport::Server;
-
-use rara_domain::event::{Event, EventType};
-use rara_event_bus::bus::EventBus;
-use rara_server::rara_proto::rara_service_client::RaraServiceClient;
-use rara_server::rara_proto::rara_service_server::RaraServiceServer;
-use rara_server::rara_proto::{Empty, EventFilter};
-use rara_server::service::RaraServiceImpl;
 
 /// Start a real tonic gRPC server on a random port and return the endpoint URL.
 async fn start_test_server(service: RaraServiceImpl) -> String {
@@ -53,10 +54,7 @@ async fn get_system_status_returns_uptime() {
     let status = response.into_inner();
 
     // Uptime should be formatted as HH:MM:SS
-    assert!(
-        !status.uptime.is_empty(),
-        "uptime must be non-empty"
-    );
+    assert!(!status.uptime.is_empty(), "uptime must be non-empty");
     assert!(
         status.uptime.contains(':'),
         "uptime should be HH:MM:SS format, got: {}",
@@ -93,8 +91,12 @@ async fn stream_events_delivers_published_events() {
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     // Publish two events
-    let seq1 = bus.publish(&make_event(EventType::TradingOrderSubmitted, "test-1")).unwrap();
-    let seq2 = bus.publish(&make_event(EventType::ResearchHypothesisCreated, "test-2")).unwrap();
+    let seq1 = bus
+        .publish(&make_event(EventType::TradingOrderSubmitted, "test-1"))
+        .unwrap();
+    let seq2 = bus
+        .publish(&make_event(EventType::ResearchHypothesisCreated, "test-2"))
+        .unwrap();
 
     // Receive them in order
     let msg1 = tokio::time::timeout(Duration::from_secs(2), stream.next())
@@ -138,11 +140,15 @@ async fn stream_events_filters_by_topic() {
 
     tokio::time::sleep(Duration::from_millis(50)).await;
 
-    // Publish a trading event (should be filtered out) and a research event (should pass)
+    // Publish a trading event (should be filtered out) and a research event (should
+    // pass)
     bus.publish(&make_event(EventType::TradingOrderFilled, "trading-src"))
         .unwrap();
     let research_seq = bus
-        .publish(&make_event(EventType::ResearchExperimentCompleted, "research-src"))
+        .publish(&make_event(
+            EventType::ResearchExperimentCompleted,
+            "research-src",
+        ))
         .unwrap();
 
     // We should only receive the research event
@@ -159,7 +165,10 @@ async fn stream_events_filters_by_topic() {
     // Verify the trading event was filtered: publish another research event and
     // confirm it arrives next (proving trading event was skipped, not delayed).
     let seq2 = bus
-        .publish(&make_event(EventType::ResearchStrategyCandidate, "research-src-2"))
+        .publish(&make_event(
+            EventType::ResearchStrategyCandidate,
+            "research-src-2",
+        ))
         .unwrap();
 
     let msg2 = tokio::time::timeout(Duration::from_secs(2), stream.next())

--- a/crates/rara-strategy-api/src/lib.rs
+++ b/crates/rara-strategy-api/src/lib.rs
@@ -1,7 +1,8 @@
 //! Strategy API types for WASM-compiled trading strategies.
 //!
-//! This crate defines the interface between the native backtester/trading engine
-//! and WASM-compiled strategies. All types use `f64` for WASM compatibility.
+//! This crate defines the interface between the native backtester/trading
+//! engine and WASM-compiled strategies. All types use `f64` for WASM
+//! compatibility.
 
 use serde::{Deserialize, Serialize};
 
@@ -14,15 +15,15 @@ pub struct Candle {
     /// Unix timestamp in seconds.
     pub timestamp: i64,
     /// Opening price.
-    pub open: f64,
+    pub open:      f64,
     /// Highest price.
-    pub high: f64,
+    pub high:      f64,
     /// Lowest price.
-    pub low: f64,
+    pub low:       f64,
     /// Closing price.
-    pub close: f64,
+    pub close:     f64,
     /// Trading volume.
-    pub volume: f64,
+    pub volume:    f64,
 }
 
 /// Which side of the market.
@@ -40,7 +41,7 @@ pub enum Signal {
     /// Enter a position with given side and strength (0.0..=1.0).
     Entry {
         /// Which side to enter.
-        side: Side,
+        side:     Side,
         /// Signal strength from 0.0 to 1.0.
         strength: f64,
     },
@@ -54,7 +55,7 @@ pub enum Signal {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RiskLevels {
     /// Price at which to cut losses.
-    pub stop_loss: f64,
+    pub stop_loss:   f64,
     /// Price at which to take profits.
     pub take_profit: f64,
 }
@@ -63,9 +64,9 @@ pub struct RiskLevels {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StrategyMeta {
     /// Human-readable strategy name.
-    pub name: String,
+    pub name:        String,
     /// Strategy version (incremented on each iteration).
-    pub version: u32,
+    pub version:     u32,
     /// API version this strategy was compiled against.
     pub api_version: u32,
     /// Brief description of the strategy.

--- a/crates/rara-trading-engine/src/account_config.rs
+++ b/crates/rara-trading-engine/src/account_config.rs
@@ -16,18 +16,18 @@ pub struct AccountsConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AccountConfig {
     /// Unique account identifier.
-    pub id: String,
+    pub id:            String,
     /// Human-readable label.
-    pub label: Option<String>,
+    pub label:         Option<String>,
     /// Broker-specific configuration (discriminated by `broker` field).
     #[serde(flatten)]
     pub broker_config: BrokerConfig,
     /// Whether the account is active.
     #[serde(default = "default_true")]
-    pub enabled: bool,
+    pub enabled:       bool,
     /// Contracts to trade on this account.
     #[serde(default)]
-    pub contracts: Vec<String>,
+    pub contracts:     Vec<String>,
 }
 
 impl AccountConfig {
@@ -100,23 +100,21 @@ pub struct PaperBrokerConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CcxtBrokerConfig {
     /// Exchange identifier: "binance", "bybit", "okx".
-    pub exchange: String,
+    pub exchange:   String,
     /// Use exchange sandbox/testnet.
     #[serde(default)]
-    pub sandbox: bool,
+    pub sandbox:    bool,
     /// API key (sensitive — masked in CLI output).
     #[serde(default)]
-    pub api_key: String,
+    pub api_key:    String,
     /// API secret (sensitive — masked in CLI output).
     #[serde(default)]
-    pub secret: String,
+    pub secret:     String,
     /// API passphrase (OKX only, sensitive).
     pub passphrase: Option<String>,
 }
 
-const fn default_true() -> bool {
-    true
-}
+const fn default_true() -> bool { true }
 
 #[cfg(test)]
 mod tests {
@@ -202,13 +200,13 @@ mod tests {
     fn serialize_roundtrip() {
         let cfg = AccountsConfig {
             accounts: vec![AccountConfig {
-                id: "test".to_string(),
-                label: Some("Test Account".to_string()),
+                id:            "test".to_string(),
+                label:         Some("Test Account".to_string()),
                 broker_config: BrokerConfig::Paper(PaperBrokerConfig {
                     fill_price: Some(100.0),
                 }),
-                enabled: true,
-                contracts: vec!["BTC-USDT".to_string()],
+                enabled:       true,
+                contracts:     vec!["BTC-USDT".to_string()],
             }],
         };
         let serialized = toml::to_string_pretty(&cfg).unwrap();
@@ -220,17 +218,17 @@ mod tests {
     #[test]
     fn mask_secrets_hides_sensitive_fields() {
         let mut acc = AccountConfig {
-            id: "test".to_string(),
-            label: None,
+            id:            "test".to_string(),
+            label:         None,
             broker_config: BrokerConfig::Ccxt(CcxtBrokerConfig {
-                exchange: "binance".to_string(),
-                sandbox: false,
-                api_key: "my-secret-key".to_string(),
-                secret: "my-secret-value".to_string(),
+                exchange:   "binance".to_string(),
+                sandbox:    false,
+                api_key:    "my-secret-key".to_string(),
+                secret:     "my-secret-value".to_string(),
                 passphrase: Some("my-pass".to_string()),
             }),
-            enabled: true,
-            contracts: vec![],
+            enabled:       true,
+            contracts:     vec![],
         };
         acc.mask_secrets();
         if let BrokerConfig::Ccxt(ref c) = acc.broker_config {

--- a/crates/rara-trading-engine/src/account_manager.rs
+++ b/crates/rara-trading-engine/src/account_manager.rs
@@ -10,19 +10,21 @@ use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 
-use crate::account_config::AccountConfig;
-use crate::health::{BrokerHealth, BrokerHealthInfo};
-use crate::uta::UnifiedTradingAccount;
+use crate::{
+    account_config::AccountConfig,
+    health::{BrokerHealth, BrokerHealthInfo},
+    uta::UnifiedTradingAccount,
+};
 
 /// Summary of a registered account.
 #[derive(Debug, Clone, Serialize, Deserialize, Builder)]
 pub struct AccountSummary {
     /// Account identifier.
     #[builder(into)]
-    pub id: String,
+    pub id:     String,
     /// Human-readable label.
     #[builder(into)]
-    pub label: String,
+    pub label:  String,
     /// Current health snapshot.
     pub health: BrokerHealthInfo,
 }
@@ -31,13 +33,13 @@ pub struct AccountSummary {
 #[derive(Debug, Clone, Serialize, Deserialize, Builder)]
 pub struct AggregatedEquity {
     /// Sum of equity from all healthy accounts.
-    pub total_equity: Decimal,
+    pub total_equity:         Decimal,
     /// Sum of cash from all healthy accounts.
-    pub total_cash: Decimal,
+    pub total_cash:           Decimal,
     /// Sum of unrealized P&L from all healthy accounts.
     pub total_unrealized_pnl: Decimal,
     /// Per-account equity breakdown.
-    pub accounts: Vec<AccountEquity>,
+    pub accounts:             Vec<AccountEquity>,
 }
 
 /// Single account equity entry within an aggregated view.
@@ -45,18 +47,18 @@ pub struct AggregatedEquity {
 pub struct AccountEquity {
     /// Account identifier.
     #[builder(into)]
-    pub id: String,
+    pub id:             String,
     /// Human-readable label.
     #[builder(into)]
-    pub label: String,
+    pub label:          String,
     /// Account equity (zero if offline).
-    pub equity: Decimal,
+    pub equity:         Decimal,
     /// Account cash (zero if offline).
-    pub cash: Decimal,
+    pub cash:           Decimal,
     /// Unrealized P&L (zero if offline).
     pub unrealized_pnl: Decimal,
     /// Health status at the time of query.
-    pub health: BrokerHealth,
+    pub health:         BrokerHealth,
 }
 
 /// Error from account manager operations.
@@ -81,7 +83,7 @@ pub enum AccountManagerError {
     #[snafu(display("failed to create broker for account '{id}': {source}"))]
     BrokerCreate {
         /// Account whose broker could not be created.
-        id: String,
+        id:     String,
         /// The underlying registry error.
         source: crate::broker_registry::BrokerRegistryError,
     },
@@ -106,7 +108,7 @@ impl AccountManager {
             let type_key = acc.broker_config.type_key();
             let entry = crate::broker_registry::find_broker(type_key).ok_or_else(|| {
                 AccountManagerError::BrokerCreate {
-                    id: acc.id.clone(),
+                    id:     acc.id.clone(),
                     source: crate::broker_registry::BrokerRegistryError::UnknownType {
                         type_key: type_key.to_string(),
                     },
@@ -128,29 +130,19 @@ impl AccountManager {
     }
 
     /// Register a UTA. Uses `uta.id` as the key, replacing any previous entry.
-    pub fn add(&mut self, uta: UnifiedTradingAccount) {
-        self.accounts.insert(uta.id.clone(), uta);
-    }
+    pub fn add(&mut self, uta: UnifiedTradingAccount) { self.accounts.insert(uta.id.clone(), uta); }
 
     /// Remove and return a UTA by its ID.
-    pub fn remove(&mut self, id: &str) -> Option<UnifiedTradingAccount> {
-        self.accounts.remove(id)
-    }
+    pub fn remove(&mut self, id: &str) -> Option<UnifiedTradingAccount> { self.accounts.remove(id) }
 
     /// Look up a UTA by exact ID.
-    pub fn get(&self, id: &str) -> Option<&UnifiedTradingAccount> {
-        self.accounts.get(id)
-    }
+    pub fn get(&self, id: &str) -> Option<&UnifiedTradingAccount> { self.accounts.get(id) }
 
     /// Check whether an account with the given ID is registered.
-    pub fn has(&self, id: &str) -> bool {
-        self.accounts.contains_key(id)
-    }
+    pub fn has(&self, id: &str) -> bool { self.accounts.contains_key(id) }
 
     /// Return the number of registered accounts.
-    pub fn size(&self) -> usize {
-        self.accounts.len()
-    }
+    pub fn size(&self) -> usize { self.accounts.len() }
 
     /// Return `(id, label)` pairs for all registered accounts.
     pub fn list(&self) -> Vec<(&str, &str)> {
@@ -260,9 +252,7 @@ impl AccountManager {
 }
 
 impl Default for AccountManager {
-    fn default() -> Self {
-        Self::new()
-    }
+    fn default() -> Self { Self::new() }
 }
 
 #[cfg(test)]
@@ -270,11 +260,12 @@ mod tests {
     use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
 
-    use crate::account_config::{BrokerConfig, PaperBrokerConfig};
-    use crate::brokers::paper::PaperBroker;
-    use crate::uta::UnifiedTradingAccount;
-
     use super::*;
+    use crate::{
+        account_config::{BrokerConfig, PaperBrokerConfig},
+        brokers::paper::PaperBroker,
+        uta::UnifiedTradingAccount,
+    };
 
     fn make_uta(id: &str) -> UnifiedTradingAccount {
         let broker = PaperBroker::new(Decimal::new(100_000, 0));
@@ -387,22 +378,20 @@ mod tests {
     fn from_config_creates_enabled_accounts() {
         let accounts = vec![
             AccountConfig {
-                id: "paper-1".to_string(),
-                label: Some("Paper One".to_string()),
+                id:            "paper-1".to_string(),
+                label:         Some("Paper One".to_string()),
                 broker_config: BrokerConfig::Paper(PaperBrokerConfig {
                     fill_price: Some(100.0),
                 }),
-                enabled: true,
-                contracts: vec!["BTC-USDT".to_string()],
+                enabled:       true,
+                contracts:     vec!["BTC-USDT".to_string()],
             },
             AccountConfig {
-                id: "paper-2".to_string(),
-                label: None,
-                broker_config: BrokerConfig::Paper(PaperBrokerConfig {
-                    fill_price: None,
-                }),
-                enabled: false,
-                contracts: vec![],
+                id:            "paper-2".to_string(),
+                label:         None,
+                broker_config: BrokerConfig::Paper(PaperBrokerConfig { fill_price: None }),
+                enabled:       false,
+                contracts:     vec![],
             },
         ];
         let mgr = AccountManager::from_config(&accounts).unwrap();
@@ -414,11 +403,11 @@ mod tests {
     #[test]
     fn from_config_uses_label() {
         let accounts = vec![AccountConfig {
-            id: "test".to_string(),
-            label: Some("My Label".to_string()),
+            id:            "test".to_string(),
+            label:         Some("My Label".to_string()),
             broker_config: BrokerConfig::Paper(PaperBrokerConfig { fill_price: None }),
-            enabled: true,
-            contracts: vec![],
+            enabled:       true,
+            contracts:     vec![],
         }];
         let mgr = AccountManager::from_config(&accounts).unwrap();
         let list = mgr.list();

--- a/crates/rara-trading-engine/src/binding.rs
+++ b/crates/rara-trading-engine/src/binding.rs
@@ -19,48 +19,36 @@ pub enum TradingMode {
 pub struct StrategyBinding {
     /// Strategy identifier.
     #[builder(into)]
-    strategy_id: String,
+    strategy_id:       String,
     /// Strategy version number.
-    strategy_version: u32,
+    strategy_version:  u32,
     /// Target contract identifier.
     #[builder(into)]
-    contract_id: String,
+    contract_id:       String,
     /// Paper or live trading mode.
-    mode: TradingMode,
+    mode:              TradingMode,
     /// Capital allocated to this binding.
     allocated_capital: Decimal,
     /// When this binding was activated.
-    activated_at: jiff::Timestamp,
+    activated_at:      jiff::Timestamp,
 }
 
 impl StrategyBinding {
     /// Returns the strategy identifier.
-    pub fn strategy_id(&self) -> &str {
-        &self.strategy_id
-    }
+    pub fn strategy_id(&self) -> &str { &self.strategy_id }
 
     /// Returns the strategy version.
-    pub const fn strategy_version(&self) -> u32 {
-        self.strategy_version
-    }
+    pub const fn strategy_version(&self) -> u32 { self.strategy_version }
 
     /// Returns the target contract identifier.
-    pub fn contract_id(&self) -> &str {
-        &self.contract_id
-    }
+    pub fn contract_id(&self) -> &str { &self.contract_id }
 
     /// Returns the trading mode.
-    pub const fn mode(&self) -> &TradingMode {
-        &self.mode
-    }
+    pub const fn mode(&self) -> &TradingMode { &self.mode }
 
     /// Returns the allocated capital.
-    pub const fn allocated_capital(&self) -> Decimal {
-        self.allocated_capital
-    }
+    pub const fn allocated_capital(&self) -> Decimal { self.allocated_capital }
 
     /// Returns the activation timestamp.
-    pub const fn activated_at(&self) -> jiff::Timestamp {
-        self.activated_at
-    }
+    pub const fn activated_at(&self) -> jiff::Timestamp { self.activated_at }
 }

--- a/crates/rara-trading-engine/src/broker.rs
+++ b/crates/rara-trading-engine/src/broker.rs
@@ -2,31 +2,33 @@
 
 use async_trait::async_trait;
 use bon::Builder;
+use rara_domain::{
+    contract::Contract,
+    trading::{OrderType, Side, StagedAction},
+};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
-
-use rara_domain::contract::Contract;
-use rara_domain::trading::{OrderType, Side, StagedAction};
 
 /// Result of submitting an order to a broker.
 #[derive(Debug, Clone, Serialize, Deserialize, Builder)]
 pub struct OrderResult {
     /// Broker-assigned order identifier.
     #[builder(into)]
-    pub order_id: String,
+    pub order_id:     String,
     /// Contract the order targets.
     #[builder(into)]
-    pub contract_id: String,
+    pub contract_id:  String,
     /// Current status of the order.
-    pub status: OrderStatus,
+    pub status:       OrderStatus,
     /// Trade direction.
-    pub side: Side,
+    pub side:         Side,
     /// Filled quantity.
-    pub quantity: Decimal,
+    pub quantity:     Decimal,
     /// Execution price.
-    pub price: Decimal,
-    /// Realized `PnL` from closing/reducing a position (zero for new positions).
+    pub price:        Decimal,
+    /// Realized `PnL` from closing/reducing a position (zero for new
+    /// positions).
     #[builder(default)]
     pub realized_pnl: Decimal,
 }
@@ -49,20 +51,20 @@ pub enum OrderStatus {
 pub struct ExecutionReport {
     /// Broker-assigned order identifier.
     #[builder(into)]
-    pub order_id: String,
+    pub order_id:    String,
     /// Contract the order targets.
     #[builder(into)]
     pub contract_id: String,
     /// Trade direction.
-    pub side: Side,
+    pub side:        Side,
     /// Filled quantity.
-    pub quantity: Decimal,
+    pub quantity:    Decimal,
     /// Execution price.
-    pub price: Decimal,
+    pub price:       Decimal,
     /// Current order status.
-    pub status: OrderStatus,
+    pub status:      OrderStatus,
     /// When the order was filled.
-    pub filled_at: jiff::Timestamp,
+    pub filled_at:   jiff::Timestamp,
 }
 
 /// A currently held position.
@@ -70,28 +72,28 @@ pub struct ExecutionReport {
 pub struct Position {
     /// Contract identifier.
     #[builder(into)]
-    pub contract_id: String,
+    pub contract_id:     String,
     /// Position direction.
-    pub side: Side,
+    pub side:            Side,
     /// Position size.
-    pub quantity: Decimal,
+    pub quantity:        Decimal,
     /// Average entry price.
     pub avg_entry_price: Decimal,
     /// Unrealized profit/loss.
-    pub unrealized_pnl: Decimal,
+    pub unrealized_pnl:  Decimal,
 }
 
 /// Account-level information.
 #[derive(Debug, Clone, Serialize, Deserialize, Builder)]
 pub struct AccountInfo {
     /// Total equity including unrealized P&L.
-    pub total_equity: Decimal,
+    pub total_equity:   Decimal,
     /// Available cash for new orders.
     pub available_cash: Decimal,
     /// Currently held positions.
-    pub positions: Vec<Position>,
+    pub positions:      Vec<Position>,
     /// Realized profit/loss across closed positions.
-    pub realized_pnl: Decimal,
+    pub realized_pnl:   Decimal,
 }
 
 /// A currently open (unfilled) order.
@@ -99,20 +101,20 @@ pub struct AccountInfo {
 pub struct OpenOrder {
     /// Broker-assigned order identifier.
     #[builder(into)]
-    pub order_id: String,
+    pub order_id:       String,
     /// Contract this order targets.
     #[builder(into)]
-    pub contract_id: String,
+    pub contract_id:    String,
     /// Trade direction.
-    pub side: Side,
+    pub side:           Side,
     /// Order type.
-    pub order_type: OrderType,
+    pub order_type:     OrderType,
     /// Total requested quantity.
-    pub quantity: Decimal,
+    pub quantity:       Decimal,
     /// Limit price (for limit orders).
-    pub limit_price: Option<Decimal>,
+    pub limit_price:    Option<Decimal>,
     /// Current order status.
-    pub status: OrderStatus,
+    pub status:         OrderStatus,
     /// Average fill price so far.
     pub avg_fill_price: Option<Decimal>,
 }

--- a/crates/rara-trading-engine/src/broker_registry.rs
+++ b/crates/rara-trading-engine/src/broker_registry.rs
@@ -1,8 +1,8 @@
 //! Broker registry — self-describing broker types for dynamic UI generation.
 //!
 //! Each broker registers a [`BrokerRegistryEntry`] that describes its config
-//! fields, allowing the setup wizard to render forms without hard-coded knowledge
-//! of individual brokers.
+//! fields, allowing the setup wizard to render forms without hard-coded
+//! knowledge of individual brokers.
 
 use std::collections::HashMap;
 
@@ -10,8 +10,7 @@ use bon::Builder;
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 
-use crate::account_config::BrokerConfig;
-use crate::broker::Broker;
+use crate::{account_config::BrokerConfig, broker::Broker};
 
 /// Factory function that creates a [`Broker`] from a raw config map.
 pub type CreateBrokerFn =
@@ -54,28 +53,28 @@ pub struct SelectOption {
 pub struct ConfigField {
     /// Machine-readable field name (used as the key in config maps).
     #[builder(into)]
-    pub name: String,
+    pub name:        String,
     /// The input type for this field.
-    pub field_type: ConfigFieldType,
+    pub field_type:  ConfigFieldType,
     /// Human-readable label shown in the UI.
     #[builder(into)]
-    pub label: String,
+    pub label:       String,
     /// Placeholder text shown when the field is empty.
     #[builder(into)]
     pub placeholder: Option<String>,
     /// Default value if the user provides none.
     #[builder(into)]
-    pub default: Option<String>,
+    pub default:     Option<String>,
     /// Whether the field must be filled.
-    pub required: bool,
+    pub required:    bool,
     /// Available choices for [`ConfigFieldType::Select`] fields.
     #[builder(default)]
-    pub options: Vec<SelectOption>,
+    pub options:     Vec<SelectOption>,
     /// Help text describing the field's purpose.
     #[builder(into)]
     pub description: Option<String>,
     /// Whether the field contains sensitive data (passwords, keys).
-    pub sensitive: bool,
+    pub sensitive:   bool,
 }
 
 /// Errors that can occur during broker registry operations.
@@ -92,7 +91,7 @@ pub enum BrokerRegistryError {
     #[snafu(display("invalid value for field '{field}': {reason}"))]
     InvalidValue {
         /// Name of the field with the invalid value.
-        field: String,
+        field:  String,
         /// Why the value is invalid.
         reason: String,
     },
@@ -114,11 +113,11 @@ pub type Result<T> = std::result::Result<T, BrokerRegistryError>;
 /// render broker configuration forms.
 pub struct BrokerRegistryEntry {
     /// Unique identifier for this broker type (e.g. "paper", "ccxt").
-    pub type_key: &'static str,
+    pub type_key:      &'static str,
     /// Human-readable broker name.
-    pub name: &'static str,
+    pub name:          &'static str,
     /// Short description of the broker.
-    pub description: &'static str,
+    pub description:   &'static str,
     /// Returns the config fields this broker requires.
     pub config_fields: fn() -> Vec<ConfigField>,
     /// Create a [`Broker`] instance from a raw config map.

--- a/crates/rara-trading-engine/src/brokers/ccxt.rs
+++ b/crates/rara-trading-engine/src/brokers/ccxt.rs
@@ -3,33 +3,34 @@
 //! Wraps the `ccxt-rust` library to provide a unified broker interface
 //! across multiple cryptocurrency exchanges (Binance, OKX, Bybit).
 
-use std::collections::HashMap;
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use async_trait::async_trait;
 use bon::Builder;
-use rust_decimal::Decimal;
-use tracing::{debug, instrument, warn};
-
 use ccxt_rust::prelude::{
     Amount, Binance, BinanceBuilder, Bybit, BybitBuilder, Okx, OkxBuilder,
     OrderSide as CcxtOrderSide, OrderStatus as CcxtOrderStatus, OrderType as CcxtOrderType, Price,
 };
-
 use rara_domain::trading::{ActionType, OrderType, Side, StagedAction};
-use crate::account_config::{BrokerConfig, CcxtBrokerConfig};
-use crate::broker::{
-    AccountInfo, Broker, BrokerError, ExecutionReport, OrderResult, OrderStatus, Position,
-};
-use crate::broker_registry::{
-    BrokerRegistryEntry, BrokerRegistryError, ConfigField, ConfigFieldType, InvalidValueSnafu,
-    MissingFieldSnafu, SelectOption,
+use rust_decimal::Decimal;
+use tracing::{debug, instrument, warn};
+
+use crate::{
+    account_config::{BrokerConfig, CcxtBrokerConfig},
+    broker::{
+        AccountInfo, Broker, BrokerError, ExecutionReport, OrderResult, OrderStatus, Position,
+    },
+    broker_registry::{
+        BrokerRegistryEntry, BrokerRegistryError, ConfigField, ConfigFieldType, InvalidValueSnafu,
+        MissingFieldSnafu, SelectOption,
+    },
 };
 
 /// Default interval between order status polls.
 const DEFAULT_POLL_INTERVAL_MS: u64 = 1000;
 
-/// Default maximum number of polling attempts before returning last known status.
+/// Default maximum number of polling attempts before returning last known
+/// status.
 const DEFAULT_MAX_POLL_RETRIES: u32 = 30;
 
 /// Configuration for order status polling after submission.
@@ -44,14 +45,14 @@ pub struct OrderPollConfig {
     pub poll_interval_ms: u64,
     /// Maximum number of poll attempts before returning last known status.
     #[builder(default = DEFAULT_MAX_POLL_RETRIES)]
-    pub max_retries: u32,
+    pub max_retries:      u32,
 }
 
 impl Default for OrderPollConfig {
     fn default() -> Self {
         Self {
             poll_interval_ms: DEFAULT_POLL_INTERVAL_MS,
-            max_retries: DEFAULT_MAX_POLL_RETRIES,
+            max_retries:      DEFAULT_MAX_POLL_RETRIES,
         }
     }
 }
@@ -81,12 +82,13 @@ impl ExchangeId {
     }
 }
 
-/// Parsed CCXT config fields shared between `create_broker` and `create_config`.
+/// Parsed CCXT config fields shared between `create_broker` and
+/// `create_config`.
 struct CcxtFields {
-    exchange: String,
-    sandbox: bool,
-    api_key: String,
-    secret: String,
+    exchange:   String,
+    sandbox:    bool,
+    api_key:    String,
+    secret:     String,
     passphrase: Option<String>,
 }
 
@@ -106,21 +108,16 @@ fn parse_ccxt_fields(fields: &HashMap<String, String>) -> Result<CcxtFields, Bro
     // Validate exchange value
     ExchangeId::parse(&exchange).map_err(|_| {
         InvalidValueSnafu {
-            field: "exchange".to_string(),
+            field:  "exchange".to_string(),
             reason: format!("unsupported exchange: {exchange}"),
         }
         .build()
     })?;
 
-    let sandbox = fields
-        .get("sandbox")
-        .is_none_or(|v| v == "true");
+    let sandbox = fields.get("sandbox").is_none_or(|v| v == "true");
     let api_key = fields.get("api_key").cloned().unwrap_or_default();
     let secret = fields.get("secret").cloned().unwrap_or_default();
-    let passphrase = fields
-        .get("passphrase")
-        .filter(|v| !v.is_empty())
-        .cloned();
+    let passphrase = fields.get("passphrase").filter(|v| !v.is_empty()).cloned();
 
     Ok(CcxtFields {
         exchange,
@@ -142,9 +139,18 @@ fn ccxt_config_fields() -> Vec<ConfigField> {
             .sensitive(false)
             .default("binance")
             .options(vec![
-                SelectOption { value: "binance".into(), label: "Binance".into() },
-                SelectOption { value: "bybit".into(), label: "Bybit".into() },
-                SelectOption { value: "okx".into(), label: "OKX".into() },
+                SelectOption {
+                    value: "binance".into(),
+                    label: "Binance".into(),
+                },
+                SelectOption {
+                    value: "bybit".into(),
+                    label: "Bybit".into(),
+                },
+                SelectOption {
+                    value: "okx".into(),
+                    label: "OKX".into(),
+                },
             ])
             .build(),
         ConfigField::builder()
@@ -178,7 +184,9 @@ fn ccxt_config_fields() -> Vec<ConfigField> {
             .label("API passphrase (OKX only)")
             .required(false)
             .sensitive(true)
-            .description("Exchange API passphrase. Can also be set via RARA_BROKER_PASSPHRASE env var.")
+            .description(
+                "Exchange API passphrase. Can also be set via RARA_BROKER_PASSPHRASE env var.",
+            )
             .build(),
     ]
 }
@@ -186,9 +194,9 @@ fn ccxt_config_fields() -> Vec<ConfigField> {
 /// Build the broker registry entry for the CCXT broker.
 pub fn registry_entry() -> BrokerRegistryEntry {
     BrokerRegistryEntry {
-        type_key: "ccxt",
-        name: "CCXT (Crypto Exchanges)",
-        description: "Trade on Binance, Bybit, OKX, and other crypto exchanges via CCXT.",
+        type_key:      "ccxt",
+        name:          "CCXT (Crypto Exchanges)",
+        description:   "Trade on Binance, Bybit, OKX, and other crypto exchanges via CCXT.",
         config_fields: ccxt_config_fields,
         create_broker: |fields: &HashMap<String, String>| {
             let f = parse_ccxt_fields(fields)?;
@@ -204,10 +212,10 @@ pub fn registry_entry() -> BrokerRegistryEntry {
         create_config: |fields: &HashMap<String, String>| {
             let f = parse_ccxt_fields(fields)?;
             Ok(BrokerConfig::Ccxt(CcxtBrokerConfig {
-                exchange: f.exchange,
-                sandbox: f.sandbox,
-                api_key: f.api_key,
-                secret: f.secret,
+                exchange:   f.exchange,
+                sandbox:    f.sandbox,
+                api_key:    f.api_key,
+                secret:     f.secret,
                 passphrase: f.passphrase,
             }))
         },
@@ -342,16 +350,16 @@ pub struct CcxtBroker {
     exchange_id: String,
     /// API key for authentication.
     #[builder(into)]
-    api_key: String,
+    api_key:     String,
     /// API secret for authentication.
     #[builder(into)]
-    secret: String,
+    secret:      String,
     /// Passphrase for exchanges that require it (e.g., OKX).
     #[builder(into)]
-    passphrase: Option<String>,
+    passphrase:  Option<String>,
     /// Whether to use the exchange's sandbox/testnet environment.
     #[builder(default = false)]
-    sandbox: bool,
+    sandbox:     bool,
     /// Configuration for post-submission order status polling.
     #[builder(default)]
     poll_config: OrderPollConfig,
@@ -368,7 +376,8 @@ impl std::fmt::Debug for CcxtBroker {
 }
 
 impl CcxtBroker {
-    /// Create the underlying exchange client based on the configured exchange ID.
+    /// Create the underlying exchange client based on the configured exchange
+    /// ID.
     fn build_client(&self) -> Result<ExchangeClient, BrokerError> {
         let exchange_id = ExchangeId::parse(&self.exchange_id)?;
 
@@ -413,10 +422,11 @@ impl CcxtBroker {
 
     /// Poll the exchange for a terminal order status after submission.
     ///
-    /// Repeatedly calls `fetch_order` at the configured interval until the order
-    /// reaches a terminal state (closed, cancelled, expired, rejected) or the
-    /// maximum number of retries is exhausted. On timeout, returns the last known
-    /// order state so callers always get a result rather than an error.
+    /// Repeatedly calls `fetch_order` at the configured interval until the
+    /// order reaches a terminal state (closed, cancelled, expired,
+    /// rejected) or the maximum number of retries is exhausted. On timeout,
+    /// returns the last known order state so callers always get a result
+    /// rather than an error.
     ///
     /// Individual fetch failures are logged and retried — a single transient
     /// network error does not abort the polling loop.
@@ -486,10 +496,7 @@ const fn is_terminal_ccxt_status(status: CcxtOrderStatus) -> bool {
 
 /// Build an `OrderResult` from a ccxt `Order`, using the action's fields as
 /// fallbacks for values the exchange may not yet have populated.
-fn order_to_result(
-    order: &ccxt_rust::prelude::Order,
-    action: &StagedAction,
-) -> OrderResult {
+fn order_to_result(order: &ccxt_rust::prelude::Order, action: &StagedAction) -> OrderResult {
     OrderResult::builder()
         .order_id(&order.id)
         .contract_id(&action.contract_id)
@@ -751,17 +758,19 @@ impl Broker for CcxtBroker {
     async fn account_info(&self) -> Result<AccountInfo, BrokerError> {
         let client = self.build_client()?;
 
-        let balance = client.fetch_balance().await.map_err(|e| map_ccxt_error(&e))?;
+        let balance = client
+            .fetch_balance()
+            .await
+            .map_err(|e| map_ccxt_error(&e))?;
 
         // Sum all currency balances. A production system would convert to a
         // single quote currency for a meaningful equity figure.
-        let (total_equity, available_cash) =
-            balance
-                .balances
-                .values()
-                .fold((Decimal::ZERO, Decimal::ZERO), |(eq, cash), entry| {
-                    (eq + entry.total, cash + entry.free)
-                });
+        let (total_equity, available_cash) = balance
+            .balances
+            .values()
+            .fold((Decimal::ZERO, Decimal::ZERO), |(eq, cash), entry| {
+                (eq + entry.total, cash + entry.free)
+            });
 
         let positions = self.positions().await?;
 
@@ -923,12 +932,13 @@ mod tests {
 
     #[test]
     fn test_ccxt_error_classification() {
-        let auth_err =
-            map_ccxt_error(&ccxt_rust::prelude::Error::authentication("invalid apiKey"));
+        let auth_err = map_ccxt_error(&ccxt_rust::prelude::Error::authentication("invalid apiKey"));
         assert!(matches!(auth_err, BrokerError::Authentication { .. }));
 
-        let exchange_err =
-            map_ccxt_error(&ccxt_rust::prelude::Error::exchange("exchange", "server error"));
+        let exchange_err = map_ccxt_error(&ccxt_rust::prelude::Error::exchange(
+            "exchange",
+            "server error",
+        ));
         assert!(matches!(exchange_err, BrokerError::Exchange { .. }));
     }
 

--- a/crates/rara-trading-engine/src/brokers/paper.rs
+++ b/crates/rara-trading-engine/src/brokers/paper.rs
@@ -1,21 +1,22 @@
 //! Paper trading broker — immediately fills all orders at a configurable
 //! price for use in paper trading mode.
 
+use std::collections::HashMap;
+
 use async_trait::async_trait;
+use rara_domain::trading::{Side, StagedAction};
 use rust_decimal::Decimal;
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
-use std::collections::HashMap;
-
-use rara_domain::trading::{Side, StagedAction};
-
-use crate::account_config::{BrokerConfig, PaperBrokerConfig};
-use crate::broker::{
-    AccountInfo, Broker, BrokerError, ExecutionReport, OrderResult, OrderStatus, Position,
-};
-use crate::broker_registry::{
-    BrokerRegistryEntry, BrokerRegistryError, ConfigField, ConfigFieldType, InvalidValueSnafu,
+use crate::{
+    account_config::{BrokerConfig, PaperBrokerConfig},
+    broker::{
+        AccountInfo, Broker, BrokerError, ExecutionReport, OrderResult, OrderStatus, Position,
+    },
+    broker_registry::{
+        BrokerRegistryEntry, BrokerRegistryError, ConfigField, ConfigFieldType, InvalidValueSnafu,
+    },
 };
 
 /// A paper trading broker that fills every order immediately at a fixed price.
@@ -24,7 +25,7 @@ pub struct PaperBroker {
     /// be updated between trades (e.g. to simulate changing market prices).
     fill_price: Mutex<Decimal>,
     /// Internal position state.
-    positions: Mutex<Vec<Position>>,
+    positions:  Mutex<Vec<Position>>,
     /// Record of all executions.
     executions: Mutex<Vec<ExecutionReport>>,
 }
@@ -32,18 +33,20 @@ pub struct PaperBroker {
 /// Build the broker registry entry for the paper trading broker.
 pub fn registry_entry() -> BrokerRegistryEntry {
     BrokerRegistryEntry {
-        type_key: "paper",
-        name: "Paper Trading",
-        description: "Simulated fills with no real money — great for testing strategies.",
+        type_key:      "paper",
+        name:          "Paper Trading",
+        description:   "Simulated fills with no real money — great for testing strategies.",
         config_fields: || {
-            vec![ConfigField::builder()
-                .name("fill_price")
-                .field_type(ConfigFieldType::Number)
-                .label("Fill price")
-                .required(false)
-                .sensitive(false)
-                .description("Fixed price for all simulated fills (0 = use market price).")
-                .build()]
+            vec![
+                ConfigField::builder()
+                    .name("fill_price")
+                    .field_type(ConfigFieldType::Number)
+                    .label("Fill price")
+                    .required(false)
+                    .sensitive(false)
+                    .description("Fixed price for all simulated fills (0 = use market price).")
+                    .build(),
+            ]
         },
         create_broker: |fields: &HashMap<String, String>| {
             let fill_price = parse_fill_price(fields)?;
@@ -59,7 +62,8 @@ pub fn registry_entry() -> BrokerRegistryEntry {
     }
 }
 
-/// Parse the `fill_price` field from a config map, defaulting to zero (market price).
+/// Parse the `fill_price` field from a config map, defaulting to zero (market
+/// price).
 fn parse_fill_price(fields: &HashMap<String, String>) -> Result<Decimal, BrokerRegistryError> {
     fields
         .get("fill_price")
@@ -69,7 +73,7 @@ fn parse_fill_price(fields: &HashMap<String, String>) -> Result<Decimal, BrokerR
             |v| {
                 v.parse::<Decimal>().map_err(|e| {
                     InvalidValueSnafu {
-                        field: "fill_price".to_string(),
+                        field:  "fill_price".to_string(),
                         reason: e.to_string(),
                     }
                     .build()
@@ -83,7 +87,7 @@ impl PaperBroker {
     pub fn new(fill_price: Decimal) -> Self {
         Self {
             fill_price: Mutex::new(fill_price),
-            positions: Mutex::new(Vec::new()),
+            positions:  Mutex::new(Vec::new()),
             executions: Mutex::new(Vec::new()),
         }
     }
@@ -91,9 +95,7 @@ impl PaperBroker {
     /// Update the fill price for subsequent orders.
     ///
     /// Useful for simulating price movement between trades in tests.
-    pub async fn set_fill_price(&self, price: Decimal) {
-        *self.fill_price.lock().await = price;
-    }
+    pub async fn set_fill_price(&self, price: Decimal) { *self.fill_price.lock().await = price; }
 }
 
 #[async_trait]
@@ -146,9 +148,8 @@ impl Broker for PaperBroker {
                                 Side::Buy => Decimal::ONE,
                                 Side::Sell => -Decimal::ONE,
                             };
-                            realized_pnl = (fill_price - pos.avg_entry_price)
-                                * close_qty
-                                * side_multiplier;
+                            realized_pnl =
+                                (fill_price - pos.avg_entry_price) * close_qty * side_multiplier;
 
                             if action.quantity >= pos.quantity {
                                 // Full close or flip: remainder opens a new position
@@ -212,9 +213,8 @@ impl Broker for PaperBroker {
 
 #[cfg(test)]
 mod tests {
-    use rust_decimal_macros::dec;
-
     use rara_domain::trading::{ActionType, OrderType, Side, StagedAction};
+    use rust_decimal_macros::dec;
 
     use super::*;
 

--- a/crates/rara-trading-engine/src/engine.rs
+++ b/crates/rara-trading-engine/src/engine.rs
@@ -3,11 +3,12 @@
 
 use std::sync::Arc;
 
+use rara_domain::{
+    event::{Event, EventType},
+    trading::{Side, TradingCommit},
+};
 use serde::Serialize;
 use snafu::Snafu;
-
-use rara_domain::event::{Event, EventType};
-use rara_domain::trading::{Side, TradingCommit};
 
 /// Event payload for an order submission.
 #[derive(Debug, Serialize)]
@@ -15,34 +16,37 @@ struct OrderSubmittedPayload<'a> {
     /// Contract identifier.
     contract_id: &'a str,
     /// Order side (buy/sell).
-    side: &'a Side,
+    side:        &'a Side,
     /// Quantity as decimal string.
-    quantity: String,
+    quantity:    String,
 }
 
 /// Event payload for an order outcome.
 #[derive(Debug, Serialize)]
 struct OrderOutcomePayload<'a> {
     /// Broker-assigned order identifier.
-    order_id: &'a str,
+    order_id:     &'a str,
     /// Contract identifier.
-    contract_id: &'a str,
+    contract_id:  &'a str,
     /// Order status.
-    status: &'a OrderStatus,
+    status:       &'a OrderStatus,
     /// Trade direction.
-    side: &'a Side,
+    side:         &'a Side,
     /// Filled quantity as decimal string.
-    quantity: String,
+    quantity:     String,
     /// Execution price as decimal string.
-    price: String,
+    price:        String,
     /// Realized `PnL` as decimal string (zero for new positions).
     realized_pnl: String,
 }
 use rara_event_bus::bus::EventBus;
-use crate::binding::StrategyBinding;
-use crate::broker::{Broker, OrderResult, OrderStatus};
-use crate::guard_pipeline::GuardPipeline;
-use crate::guards::GuardResult;
+
+use crate::{
+    binding::StrategyBinding,
+    broker::{Broker, OrderResult, OrderStatus},
+    guard_pipeline::GuardPipeline,
+    guards::GuardResult,
+};
 
 /// Errors that can occur during trading engine operations.
 #[derive(Debug, Snafu)]
@@ -75,13 +79,13 @@ pub type Result<T> = std::result::Result<T, EngineError>;
 /// trading commits.
 pub struct TradingEngine {
     /// Broker for order execution.
-    broker: Box<dyn Broker>,
+    broker:         Box<dyn Broker>,
     /// Pre-trade risk guard pipeline.
     guard_pipeline: GuardPipeline,
     /// Active strategy bindings.
-    bindings: Vec<StrategyBinding>,
+    bindings:       Vec<StrategyBinding>,
     /// Event bus for publishing trading events.
-    event_bus: Arc<EventBus>,
+    event_bus:      Arc<EventBus>,
 }
 
 impl TradingEngine {
@@ -100,9 +104,7 @@ impl TradingEngine {
     }
 
     /// Register a strategy binding.
-    pub fn add_binding(&mut self, binding: StrategyBinding) {
-        self.bindings.push(binding);
-    }
+    pub fn add_binding(&mut self, binding: StrategyBinding) { self.bindings.push(binding); }
 
     /// Execute a trading commit: run guards, push to broker, publish events.
     #[tracing::instrument(skip(self, commit), fields(strategy_id = %commit.strategy_id, actions = commit.actions.len()))]
@@ -128,8 +130,8 @@ impl TradingEngine {
                 .payload(
                     serde_json::to_value(OrderSubmittedPayload {
                         contract_id: &action.contract_id,
-                        side: &action.side,
-                        quantity: action.quantity.to_string(),
+                        side:        &action.side,
+                        quantity:    action.quantity.to_string(),
                     })
                     .expect("OrderSubmittedPayload must serialize"),
                 )
@@ -164,12 +166,12 @@ impl TradingEngine {
                 .strategy_id(commit.strategy_id.clone())
                 .payload(
                     serde_json::to_value(OrderOutcomePayload {
-                        order_id: &result.order_id,
-                        contract_id: &result.contract_id,
-                        status: &result.status,
-                        side: &result.side,
-                        quantity: result.quantity.to_string(),
-                        price: result.price.to_string(),
+                        order_id:     &result.order_id,
+                        contract_id:  &result.contract_id,
+                        status:       &result.status,
+                        side:         &result.side,
+                        quantity:     result.quantity.to_string(),
+                        price:        result.price.to_string(),
                         realized_pnl: result.realized_pnl.to_string(),
                     })
                     .expect("OrderOutcomePayload must serialize"),
@@ -189,27 +191,28 @@ impl TradingEngine {
 
 #[cfg(test)]
 mod tests {
+    use rara_domain::trading::{ActionType, OrderType, Side, StagedAction, TradingCommit};
     use rust_decimal::Decimal;
 
-    use rara_domain::trading::{ActionType, OrderType, Side, StagedAction, TradingCommit};
-    use crate::broker::OrderStatus;
-    use crate::brokers::paper::PaperBroker;
-    use crate::guards::symbol_whitelist::SymbolWhitelist;
-
     use super::*;
+    use crate::{
+        broker::OrderStatus, brokers::paper::PaperBroker, guards::symbol_whitelist::SymbolWhitelist,
+    };
 
     fn test_commit(contract_id: &str) -> TradingCommit {
         TradingCommit::builder()
             .message("test")
             .strategy_id("strat-1")
             .strategy_version(1)
-            .actions(vec![StagedAction::builder()
-                .action_type(ActionType::PlaceOrder)
-                .contract_id(contract_id)
-                .side(Side::Buy)
-                .quantity(Decimal::ONE)
-                .order_type(OrderType::Market)
-                .build()])
+            .actions(vec![
+                StagedAction::builder()
+                    .action_type(ActionType::PlaceOrder)
+                    .contract_id(contract_id)
+                    .side(Side::Buy)
+                    .quantity(Decimal::ONE)
+                    .order_type(OrderType::Market)
+                    .build(),
+            ])
             .build()
     }
 
@@ -224,10 +227,7 @@ mod tests {
 
         let engine = TradingEngine::new(Box::new(broker), pipeline, event_bus);
 
-        let results = engine
-            .execute_commit(test_commit("BTC-USD"))
-            .await
-            .unwrap();
+        let results = engine.execute_commit(test_commit("BTC-USD")).await.unwrap();
 
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].status, OrderStatus::Filled);

--- a/crates/rara-trading-engine/src/guard_pipeline.rs
+++ b/crates/rara-trading-engine/src/guard_pipeline.rs
@@ -1,8 +1,11 @@
 //! Sequential guard pipeline that short-circuits on the first rejection.
 
 use rara_domain::trading::TradingCommit;
-use crate::broker::AccountInfo;
-use crate::guards::{Guard, GuardResult};
+
+use crate::{
+    broker::AccountInfo,
+    guards::{Guard, GuardResult},
+};
 
 /// Runs a sequence of guards, stopping at the first rejection.
 pub struct GuardPipeline {
@@ -12,9 +15,7 @@ pub struct GuardPipeline {
 
 impl GuardPipeline {
     /// Create a new pipeline from the given guards.
-    pub fn new(guards: Vec<Box<dyn Guard>>) -> Self {
-        Self { guards }
-    }
+    pub fn new(guards: Vec<Box<dyn Guard>>) -> Self { Self { guards } }
 
     /// Run all guards in order. Returns the first rejection, or `Allow` if
     /// all guards pass.
@@ -32,26 +33,26 @@ impl GuardPipeline {
 
 #[cfg(test)]
 mod tests {
+    use rara_domain::trading::{ActionType, OrderType, Side, StagedAction, TradingCommit};
     use rust_decimal::Decimal;
 
-    use rara_domain::trading::{ActionType, OrderType, Side, StagedAction, TradingCommit};
-    use crate::broker::AccountInfo;
-    use crate::guards::symbol_whitelist::SymbolWhitelist;
-
     use super::*;
+    use crate::{broker::AccountInfo, guards::symbol_whitelist::SymbolWhitelist};
 
     fn test_commit() -> TradingCommit {
         TradingCommit::builder()
             .message("test commit")
             .strategy_id("strat-1")
             .strategy_version(1)
-            .actions(vec![StagedAction::builder()
-                .action_type(ActionType::PlaceOrder)
-                .contract_id("BTC-USD")
-                .side(Side::Buy)
-                .quantity(Decimal::ONE)
-                .order_type(OrderType::Market)
-                .build()])
+            .actions(vec![
+                StagedAction::builder()
+                    .action_type(ActionType::PlaceOrder)
+                    .contract_id("BTC-USD")
+                    .side(Side::Buy)
+                    .quantity(Decimal::ONE)
+                    .order_type(OrderType::Market)
+                    .build(),
+            ])
             .build()
     }
 
@@ -66,9 +67,9 @@ mod tests {
 
     #[tokio::test]
     async fn pipeline_allows_when_all_guards_pass() {
-        let pipeline = GuardPipeline::new(vec![Box::new(SymbolWhitelist::new(
-            vec!["BTC-USD".to_string()],
-        ))]);
+        let pipeline = GuardPipeline::new(vec![Box::new(SymbolWhitelist::new(vec![
+            "BTC-USD".to_string(),
+        ]))]);
 
         let result = pipeline.run(&test_commit(), &test_account()).await;
         assert!(matches!(result, GuardResult::Allow));

--- a/crates/rara-trading-engine/src/guards/drawdown_limit.rs
+++ b/crates/rara-trading-engine/src/guards/drawdown_limit.rs
@@ -2,18 +2,17 @@
 //! threshold from its peak.
 
 use async_trait::async_trait;
+use rara_domain::trading::TradingCommit;
 use rust_decimal::Decimal;
 
-use rara_domain::trading::TradingCommit;
-use crate::broker::AccountInfo;
-
 use super::{Guard, GuardResult};
+use crate::broker::AccountInfo;
 
 /// Rejects commits when current equity is below `(1 - max_drawdown_pct) *
 /// peak_equity`.
 pub struct DrawdownLimit {
     /// Peak equity observed (set externally or tracked over time).
-    peak_equity: Decimal,
+    peak_equity:      Decimal,
     /// Maximum allowed drawdown as a fraction (e.g. 0.20 = 20%).
     max_drawdown_pct: Decimal,
 }
@@ -30,9 +29,7 @@ impl DrawdownLimit {
 
 #[async_trait]
 impl Guard for DrawdownLimit {
-    fn name(&self) -> &'static str {
-        "DrawdownLimit"
-    }
+    fn name(&self) -> &'static str { "DrawdownLimit" }
 
     async fn check(&self, _commit: &TradingCommit, account: &AccountInfo) -> GuardResult {
         let threshold = self.peak_equity * (Decimal::ONE - self.max_drawdown_pct);
@@ -40,8 +37,8 @@ impl Guard for DrawdownLimit {
         if account.total_equity < threshold {
             return GuardResult::Reject {
                 reason: format!(
-                    "equity {} is below drawdown threshold {threshold} \
-                     (peak: {}, max drawdown: {})",
+                    "equity {} is below drawdown threshold {threshold} (peak: {}, max drawdown: \
+                     {})",
                     account.total_equity, self.peak_equity, self.max_drawdown_pct,
                 ),
             };

--- a/crates/rara-trading-engine/src/guards/max_position_size.rs
+++ b/crates/rara-trading-engine/src/guards/max_position_size.rs
@@ -2,18 +2,17 @@
 //! of total equity.
 
 use async_trait::async_trait;
+use rara_domain::trading::TradingCommit;
 use rust_decimal::Decimal;
 
-use rara_domain::trading::TradingCommit;
-use crate::broker::AccountInfo;
-
 use super::{Guard, GuardResult};
+use crate::broker::AccountInfo;
 
 /// Rejects commits where any single action's notional value exceeds a maximum
 /// percentage of total equity.
 pub struct MaxPositionSize {
     /// Maximum allowed position size as a fraction (e.g. 0.10 = 10%).
-    max_pct: Decimal,
+    max_pct:         Decimal,
     /// Assumed price for notional calculation. In production this would come
     /// from a market data feed; here we use a fixed estimate.
     estimated_price: Decimal,
@@ -32,9 +31,7 @@ impl MaxPositionSize {
 
 #[async_trait]
 impl Guard for MaxPositionSize {
-    fn name(&self) -> &'static str {
-        "MaxPositionSize"
-    }
+    fn name(&self) -> &'static str { "MaxPositionSize" }
 
     async fn check(&self, commit: &TradingCommit, account: &AccountInfo) -> GuardResult {
         let max_notional = account.total_equity * self.max_pct;
@@ -44,10 +41,9 @@ impl Guard for MaxPositionSize {
             if notional > max_notional {
                 return GuardResult::Reject {
                     reason: format!(
-                        "action on {} has notional {notional} exceeding max {max_notional} \
-                         ({} of equity)",
-                        action.contract_id,
-                        self.max_pct,
+                        "action on {} has notional {notional} exceeding max {max_notional} ({} of \
+                         equity)",
+                        action.contract_id, self.max_pct,
                     ),
                 };
             }

--- a/crates/rara-trading-engine/src/guards/mod.rs
+++ b/crates/rara-trading-engine/src/guards/mod.rs
@@ -6,8 +6,8 @@ pub mod sentinel_gate;
 pub mod symbol_whitelist;
 
 use async_trait::async_trait;
-
 use rara_domain::trading::TradingCommit;
+
 use crate::broker::AccountInfo;
 
 /// Outcome of a guard check.

--- a/crates/rara-trading-engine/src/guards/sentinel_gate.rs
+++ b/crates/rara-trading-engine/src/guards/sentinel_gate.rs
@@ -3,12 +3,11 @@
 use std::collections::HashSet;
 
 use async_trait::async_trait;
+use rara_domain::trading::TradingCommit;
 use tokio::sync::RwLock;
 
-use rara_domain::trading::TradingCommit;
-use crate::broker::AccountInfo;
-
 use super::{Guard, GuardResult};
+use crate::broker::AccountInfo;
 
 /// Rejects commits targeting contracts that have been blocked due to critical
 /// sentinel signals.
@@ -40,16 +39,12 @@ impl SentinelGate {
 }
 
 impl Default for SentinelGate {
-    fn default() -> Self {
-        Self::new()
-    }
+    fn default() -> Self { Self::new() }
 }
 
 #[async_trait]
 impl Guard for SentinelGate {
-    fn name(&self) -> &'static str {
-        "SentinelGate"
-    }
+    fn name(&self) -> &'static str { "SentinelGate" }
 
     async fn check(&self, commit: &TradingCommit, _account: &AccountInfo) -> GuardResult {
         let blocked = self.blocked.read().await;

--- a/crates/rara-trading-engine/src/guards/symbol_whitelist.rs
+++ b/crates/rara-trading-engine/src/guards/symbol_whitelist.rs
@@ -3,11 +3,10 @@
 use std::collections::HashSet;
 
 use async_trait::async_trait;
-
 use rara_domain::trading::TradingCommit;
-use crate::broker::AccountInfo;
 
 use super::{Guard, GuardResult};
+use crate::broker::AccountInfo;
 
 /// Rejects commits containing actions on contracts not present in the allowed
 /// set.
@@ -27,9 +26,7 @@ impl SymbolWhitelist {
 
 #[async_trait]
 impl Guard for SymbolWhitelist {
-    fn name(&self) -> &'static str {
-        "SymbolWhitelist"
-    }
+    fn name(&self) -> &'static str { "SymbolWhitelist" }
 
     async fn check(&self, commit: &TradingCommit, _account: &AccountInfo) -> GuardResult {
         for action in &commit.actions {

--- a/crates/rara-trading-engine/src/health.rs
+++ b/crates/rara-trading-engine/src/health.rs
@@ -1,7 +1,8 @@
 //! Broker connection health tracking with automatic degradation detection.
 //!
-//! Tracks consecutive failures and maps them to health states using configurable
-//! thresholds. Supports manual disable/enable and exponential backoff for recovery.
+//! Tracks consecutive failures and maps them to health states using
+//! configurable thresholds. Supports manual disable/enable and exponential
+//! backoff for recovery.
 
 use bon::Builder;
 use serde::{Deserialize, Serialize};
@@ -36,19 +37,19 @@ pub enum BrokerHealth {
 #[derive(Debug, Clone, Serialize, Deserialize, Builder)]
 pub struct BrokerHealthInfo {
     /// Current health status.
-    pub status: BrokerHealth,
+    pub status:               BrokerHealth,
     /// Number of consecutive failures without a success.
     pub consecutive_failures: u32,
     /// Most recent error message, if any.
-    pub last_error: Option<String>,
+    pub last_error:           Option<String>,
     /// Timestamp of the last successful operation.
-    pub last_success_at: Option<jiff::Timestamp>,
+    pub last_success_at:      Option<jiff::Timestamp>,
     /// Timestamp of the last failed operation.
-    pub last_failure_at: Option<jiff::Timestamp>,
+    pub last_failure_at:      Option<jiff::Timestamp>,
     /// Whether a recovery attempt is in progress.
-    pub recovering: bool,
+    pub recovering:           bool,
     /// Whether the broker has been manually disabled.
-    pub disabled: bool,
+    pub disabled:             bool,
 }
 
 /// Tracks broker connection health and computes status from failure history.
@@ -59,11 +60,11 @@ pub struct BrokerHealthInfo {
 /// - Manually disabled brokers always report `Offline`.
 pub struct HealthTracker {
     consecutive_failures: u32,
-    last_error: Option<String>,
-    last_success_at: Option<jiff::Timestamp>,
-    last_failure_at: Option<jiff::Timestamp>,
-    recovering: bool,
-    disabled: bool,
+    last_error:           Option<String>,
+    last_success_at:      Option<jiff::Timestamp>,
+    last_failure_at:      Option<jiff::Timestamp>,
+    recovering:           bool,
+    disabled:             bool,
 }
 
 impl HealthTracker {
@@ -71,15 +72,16 @@ impl HealthTracker {
     pub const fn new() -> Self {
         Self {
             consecutive_failures: 0,
-            last_error: None,
-            last_success_at: None,
-            last_failure_at: None,
-            recovering: false,
-            disabled: false,
+            last_error:           None,
+            last_success_at:      None,
+            last_failure_at:      None,
+            recovering:           false,
+            disabled:             false,
         }
     }
 
-    /// Returns the current health status based on failure count and disabled flag.
+    /// Returns the current health status based on failure count and disabled
+    /// flag.
     pub const fn status(&self) -> BrokerHealth {
         if self.disabled {
             return BrokerHealth::Offline;
@@ -96,13 +98,13 @@ impl HealthTracker {
     /// Returns a serializable snapshot of the current health state.
     pub fn info(&self) -> BrokerHealthInfo {
         BrokerHealthInfo {
-            status: self.status(),
+            status:               self.status(),
             consecutive_failures: self.consecutive_failures,
-            last_error: self.last_error.clone(),
-            last_success_at: self.last_success_at,
-            last_failure_at: self.last_failure_at,
-            recovering: self.recovering,
-            disabled: self.disabled,
+            last_error:           self.last_error.clone(),
+            last_success_at:      self.last_success_at,
+            last_failure_at:      self.last_failure_at,
+            recovering:           self.recovering,
+            disabled:             self.disabled,
         }
     }
 
@@ -128,21 +130,16 @@ impl HealthTracker {
     }
 
     /// Re-enables a previously disabled broker.
-    pub const fn enable(&mut self) {
-        self.disabled = false;
-    }
+    pub const fn enable(&mut self) { self.disabled = false; }
 
     /// Returns whether the broker has been manually disabled.
-    pub const fn is_disabled(&self) -> bool {
-        self.disabled
-    }
+    pub const fn is_disabled(&self) -> bool { self.disabled }
 
     /// Sets the recovering flag to indicate a recovery attempt is in progress.
-    pub const fn set_recovering(&mut self, recovering: bool) {
-        self.recovering = recovering;
-    }
+    pub const fn set_recovering(&mut self, recovering: bool) { self.recovering = recovering; }
 
-    /// Computes the recovery delay for a given attempt using exponential backoff.
+    /// Computes the recovery delay for a given attempt using exponential
+    /// backoff.
     ///
     /// Delay doubles each attempt starting from [`RECOVERY_BASE_MS`],
     /// capped at [`RECOVERY_MAX_MS`].
@@ -153,9 +150,7 @@ impl HealthTracker {
 }
 
 impl Default for HealthTracker {
-    fn default() -> Self {
-        Self::new()
-    }
+    fn default() -> Self { Self::new() }
 }
 
 #[cfg(test)]

--- a/crates/rara-trading-engine/src/signal_loop.rs
+++ b/crates/rara-trading-engine/src/signal_loop.rs
@@ -1,19 +1,18 @@
 //! Signal generation loop — connects candle stream to strategy execution.
 //!
 //! Receives [`AggregatedCandle`]s from a broadcast channel, feeds them to every
-//! loaded WASM strategy, converts resulting [`Signal`]s into [`TradingCommit`]s,
-//! and executes them through the [`TradingEngine`].
+//! loaded WASM strategy, converts resulting [`Signal`]s into
+//! [`TradingCommit`]s, and executes them through the [`TradingEngine`].
 
 use std::sync::Arc;
-
-use rust_decimal::Decimal;
-use snafu::Snafu;
-use tokio::sync::broadcast;
 
 use rara_domain::trading::{ActionType, OrderType, Side, StagedAction, TradingCommit};
 use rara_market_data::stream::aggregator::AggregatedCandle;
 use rara_research::strategy_executor::StrategyHandle;
 use rara_strategy_api::{Candle, Signal};
+use rust_decimal::Decimal;
+use snafu::Snafu;
+use tokio::sync::broadcast;
 
 use crate::engine::TradingEngine;
 
@@ -25,7 +24,7 @@ pub enum SignalLoopError {
     #[snafu(display("strategy '{name}' signal error: {source}"))]
     StrategySignal {
         /// Strategy name that failed.
-        name: String,
+        name:   String,
         /// Underlying executor error.
         source: rara_research::strategy_executor::ExecutorError,
     },
@@ -47,15 +46,15 @@ pub type Result<T> = std::result::Result<T, SignalLoopError>;
 /// [`TradingCommit`]s from its signals.
 pub struct LoadedStrategy {
     /// Strategy name (from WASM metadata).
-    pub name: String,
+    pub name:          String,
     /// Strategy version (from WASM metadata).
-    pub version: u32,
+    pub version:       u32,
     /// Contract this strategy trades (e.g., "BTCUSDT").
-    pub contract_id: String,
+    pub contract_id:   String,
     /// Position size per signal.
     pub position_size: Decimal,
     /// The WASM strategy handle for signal generation.
-    pub handle: Box<dyn StrategyHandle>,
+    pub handle:        Box<dyn StrategyHandle>,
 }
 
 /// Convert a strategy [`Signal`] into a list of [`StagedAction`]s.
@@ -68,22 +67,26 @@ fn signal_to_actions(signal: &Signal, strategy: &LoadedStrategy) -> Vec<StagedAc
                 rara_strategy_api::Side::Long => Side::Buy,
                 rara_strategy_api::Side::Short => Side::Sell,
             };
-            vec![StagedAction::builder()
-                .action_type(ActionType::PlaceOrder)
-                .contract_id(&strategy.contract_id)
-                .side(domain_side)
-                .quantity(strategy.position_size)
-                .order_type(OrderType::Market)
-                .build()]
+            vec![
+                StagedAction::builder()
+                    .action_type(ActionType::PlaceOrder)
+                    .contract_id(&strategy.contract_id)
+                    .side(domain_side)
+                    .quantity(strategy.position_size)
+                    .order_type(OrderType::Market)
+                    .build(),
+            ]
         }
         Signal::Exit => {
-            vec![StagedAction::builder()
-                .action_type(ActionType::ClosePosition)
-                .contract_id(&strategy.contract_id)
-                .side(Side::Sell)
-                .quantity(strategy.position_size)
-                .order_type(OrderType::Market)
-                .build()]
+            vec![
+                StagedAction::builder()
+                    .action_type(ActionType::ClosePosition)
+                    .contract_id(&strategy.contract_id)
+                    .side(Side::Sell)
+                    .quantity(strategy.position_size)
+                    .order_type(OrderType::Market)
+                    .build(),
+            ]
         }
         Signal::Hold => vec![],
     }
@@ -93,11 +96,11 @@ fn signal_to_actions(signal: &Signal, strategy: &LoadedStrategy) -> Vec<StagedAc
 const fn to_api_candle(candle: &AggregatedCandle) -> Candle {
     Candle {
         timestamp: candle.ts.timestamp(),
-        open: candle.open,
-        high: candle.high,
-        low: candle.low,
-        close: candle.close,
-        volume: candle.volume,
+        open:      candle.open,
+        high:      candle.high,
+        low:       candle.low,
+        close:     candle.close,
+        volume:    candle.volume,
     }
 }
 
@@ -112,10 +115,7 @@ pub async fn run_signal_loop(
     engine: Arc<TradingEngine>,
     mut strategies: Vec<LoadedStrategy>,
 ) {
-    tracing::info!(
-        strategy_count = strategies.len(),
-        "signal loop started"
-    );
+    tracing::info!(strategy_count = strategies.len(), "signal loop started");
 
     loop {
         match candle_rx.recv().await {

--- a/crates/rara-trading-engine/src/trading_git.rs
+++ b/crates/rara-trading-engine/src/trading_git.rs
@@ -6,15 +6,18 @@
 //! - `push` dispatches operations to the broker and records results
 
 use async_trait::async_trait;
+use rara_domain::trading::{
+    git::{
+        AddResult, CommitHash, CommitLogEntry, CommitPrepareResult, GitCommit, GitExportState,
+        GitState, GitStatus, OperationSummary, OrderStatusUpdate, PushResult, RejectResult,
+        SyncResult,
+    },
+    operation::{Operation, OperationResult, OperationStatus},
+};
 use sha2::{Digest, Sha256};
 use snafu::{OptionExt, ResultExt, Snafu};
 
 use crate::broker::BrokerError;
-use rara_domain::trading::git::{
-    AddResult, CommitHash, CommitLogEntry, CommitPrepareResult, GitCommit, GitExportState,
-    GitState, GitStatus, OperationSummary, OrderStatusUpdate, PushResult, RejectResult, SyncResult,
-};
-use rara_domain::trading::operation::{Operation, OperationResult, OperationStatus};
 
 /// Errors from `TradingGit` operations.
 #[derive(Debug, Snafu)]
@@ -51,38 +54,38 @@ pub struct PendingOrder {
     /// Broker-assigned order ID.
     pub order_id: String,
     /// Trading symbol.
-    pub symbol: String,
+    pub symbol:   String,
 }
 
 /// Core git-like operation tracker for the UTA workflow.
 ///
-/// All state is held in memory. Use [`export_state`](TradingGit::export_state) /
-/// [`restore`](TradingGit::restore) for persistence.
+/// All state is held in memory. Use [`export_state`](TradingGit::export_state)
+/// / [`restore`](TradingGit::restore) for persistence.
 pub struct TradingGit {
     /// Operations staged but not yet committed.
-    staging: Vec<Operation>,
+    staging:         Vec<Operation>,
     /// Message of the committed-but-not-pushed batch.
     pending_message: Option<String>,
     /// Hash of the committed-but-not-pushed batch.
-    pending_hash: Option<CommitHash>,
+    pending_hash:    Option<CommitHash>,
     /// Immutable commit history.
-    commits: Vec<GitCommit>,
+    commits:         Vec<GitCommit>,
     /// Current HEAD commit hash.
-    head: Option<CommitHash>,
+    head:            Option<CommitHash>,
     /// Optional trading round number attached to new commits.
-    current_round: Option<u32>,
+    current_round:   Option<u32>,
 }
 
 impl TradingGit {
     /// Create a new, empty `TradingGit` instance.
     pub const fn new() -> Self {
         Self {
-            staging: Vec::new(),
+            staging:         Vec::new(),
             pending_message: None,
-            pending_hash: None,
-            commits: Vec::new(),
-            head: None,
-            current_round: None,
+            pending_hash:    None,
+            commits:         Vec::new(),
+            head:            None,
+            current_round:   None,
         }
     }
 
@@ -100,9 +103,7 @@ impl TradingGit {
     }
 
     /// Set the current trading round number for subsequent commits.
-    pub const fn set_current_round(&mut self, round: u32) {
-        self.current_round = Some(round);
-    }
+    pub const fn set_current_round(&mut self, round: u32) { self.current_round = Some(round); }
 
     /// Stage an operation for the next commit.
     pub fn add(&mut self, operation: Operation) -> AddResult {
@@ -194,13 +195,13 @@ impl TradingGit {
         let hash = generate_commit_hash(&message, &updates);
 
         let results = vec![OperationResult {
-            action: Operation::SyncOrders,
-            success: true,
-            order_id: None,
-            status: OperationStatus::Submitted,
-            filled_qty: None,
+            action:       Operation::SyncOrders,
+            success:      true,
+            order_id:     None,
+            status:       OperationStatus::Submitted,
+            filled_qty:   None,
             filled_price: None,
-            error: None,
+            error:        None,
         }];
 
         let commit = GitCommit {
@@ -283,13 +284,13 @@ impl TradingGit {
         let results: Vec<OperationResult> = operations
             .iter()
             .map(|op| OperationResult {
-                action: op.clone(),
-                success: false,
-                order_id: None,
-                status: OperationStatus::UserRejected,
-                filled_qty: None,
+                action:       op.clone(),
+                success:      false,
+                order_id:     None,
+                status:       OperationStatus::UserRejected,
+                filled_qty:   None,
                 filled_price: None,
-                error: Some(reason.to_string()),
+                error:        Some(reason.to_string()),
             })
             .collect();
 
@@ -318,11 +319,11 @@ impl TradingGit {
     /// Return the current staging area and commit state.
     pub fn status(&self) -> GitStatus {
         GitStatus {
-            staged: self.staging.clone(),
+            staged:          self.staging.clone(),
             pending_message: self.pending_message.clone(),
-            pending_hash: self.pending_hash.clone(),
-            head: self.head.clone(),
-            commit_count: self.commits.len(),
+            pending_hash:    self.pending_hash.clone(),
+            head:            self.head.clone(),
+            commit_count:    self.commits.len(),
         }
     }
 
@@ -331,19 +332,15 @@ impl TradingGit {
         self.commits
             .iter()
             .rev()
-            .filter(|c| {
-                symbol.is_none_or(|s| {
-                    c.operations.iter().any(|op| op.symbol() == Some(s))
-                })
-            })
+            .filter(|c| symbol.is_none_or(|s| c.operations.iter().any(|op| op.symbol() == Some(s))))
             .take(limit)
             .map(|c| CommitLogEntry {
-                hash: c.hash.clone(),
+                hash:        c.hash.clone(),
                 parent_hash: c.parent_hash.clone(),
-                message: c.message.clone(),
-                timestamp: c.timestamp.clone(),
-                round: c.round,
-                operations: build_operation_summaries(c),
+                message:     c.message.clone(),
+                timestamp:   c.timestamp.clone(),
+                round:       c.round,
+                operations:  build_operation_summaries(c),
             })
             .collect()
     }
@@ -356,7 +353,8 @@ impl TradingGit {
     /// Scan commit history for orders still in `Submitted` status.
     ///
     /// An order is considered pending if its most recent result across all
-    /// commits is `Submitted` (i.e. never transitioned to Filled/Cancelled/Rejected).
+    /// commits is `Submitted` (i.e. never transitioned to
+    /// Filled/Cancelled/Rejected).
     pub fn pending_order_ids(&self) -> Vec<PendingOrder> {
         use std::collections::HashMap;
 
@@ -366,11 +364,7 @@ impl TradingGit {
         for commit in &self.commits {
             for result in &commit.results {
                 if let Some(oid) = &result.order_id {
-                    let symbol = result
-                        .action
-                        .symbol()
-                        .unwrap_or("unknown")
-                        .to_string();
+                    let symbol = result.action.symbol().unwrap_or("unknown").to_string();
                     latest.insert(oid.clone(), (result.status, symbol));
                 }
             }
@@ -387,18 +381,17 @@ impl TradingGit {
     pub fn export_state(&self) -> GitExportState {
         GitExportState {
             commits: self.commits.clone(),
-            head: self.head.clone(),
+            head:    self.head.clone(),
         }
     }
 }
 
 impl Default for TradingGit {
-    fn default() -> Self {
-        Self::new()
-    }
+    fn default() -> Self { Self::new() }
 }
 
-/// Generate an 8-character hex commit hash from message + serialized content + timestamp.
+/// Generate an 8-character hex commit hash from message + serialized content +
+/// timestamp.
 fn generate_commit_hash(message: &str, content: &impl serde::Serialize) -> CommitHash {
     let mut hasher = Sha256::new();
     hasher.update(message.as_bytes());
@@ -425,9 +418,7 @@ fn build_operation_summaries(commit: &GitCommit) -> Vec<OperationSummary> {
                     order_type,
                     limit_price,
                 } => {
-                    let price_info = limit_price
-                        .map(|p| format!(" @ {p}"))
-                        .unwrap_or_default();
+                    let price_info = limit_price.map(|p| format!(" @ {p}")).unwrap_or_default();
                     (
                         contract.symbol.clone(),
                         order_type.to_string(),
@@ -486,12 +477,13 @@ fn build_operation_summaries(commit: &GitCommit) -> Vec<OperationSummary> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use rara_domain::{
+        contract::Contract,
+        trading::{Side, operation::OperationOrderType},
+    };
     use rust_decimal_macros::dec;
 
-    use rara_domain::contract::Contract;
-    use rara_domain::trading::operation::OperationOrderType;
-    use rara_domain::trading::Side;
+    use super::*;
 
     /// Always-successful dispatcher for testing.
     struct SuccessDispatcher;
@@ -500,13 +492,13 @@ mod tests {
     impl OperationDispatcher for SuccessDispatcher {
         async fn dispatch(&self, op: &Operation) -> OperationResult {
             OperationResult {
-                action: op.clone(),
-                success: true,
-                order_id: Some("ORD-001".to_string()),
-                status: OperationStatus::Submitted,
-                filled_qty: None,
+                action:       op.clone(),
+                success:      true,
+                order_id:     Some("ORD-001".to_string()),
+                status:       OperationStatus::Submitted,
+                filled_qty:   None,
                 filled_price: None,
-                error: None,
+                error:        None,
             }
         }
     }
@@ -523,25 +515,25 @@ mod tests {
 
     fn test_state() -> FixedState {
         FixedState(GitState {
-            net_liquidation: dec!(10000),
+            net_liquidation:  dec!(10000),
             total_cash_value: dec!(5000),
-            unrealized_pnl: dec!(100),
-            realized_pnl: dec!(200),
-            positions: vec![],
+            unrealized_pnl:   dec!(100),
+            realized_pnl:     dec!(200),
+            positions:        vec![],
         })
     }
 
     fn test_place_order() -> Operation {
         Operation::PlaceOrder {
-            contract: Contract::builder()
+            contract:    Contract::builder()
                 .symbol("BTCUSDT")
                 .exchange("binance")
                 .sec_type(rara_domain::contract::SecType::CryptoSpot)
                 .currency("USDT")
                 .build(),
-            side: Side::Buy,
-            order_type: OperationOrderType::Market,
-            quantity: dec!(0.1),
+            side:        Side::Buy,
+            order_type:  OperationOrderType::Market,
+            quantity:    dec!(0.1),
             limit_price: None,
         }
     }

--- a/crates/rara-trading-engine/src/uta.rs
+++ b/crates/rara-trading-engine/src/uta.rs
@@ -5,36 +5,40 @@
 //! [`OperationDispatcher`] and [`StateProvider`] via internal adapter structs.
 
 use async_trait::async_trait;
+use rara_domain::{
+    contract::Contract,
+    trading::{
+        OrderType, Side,
+        git::{
+            AddResult, CommitLogEntry, CommitPrepareResult, GitExportState, GitPosition, GitState,
+            GitStatus, OrderStatusUpdate, PushResult, RejectResult, SyncResult,
+        },
+        operation::{Operation, OperationOrderType, OperationResult, OperationStatus},
+    },
+};
 use rust_decimal::Decimal;
 use tokio::sync::Mutex;
 
-use rara_domain::contract::Contract;
-use rara_domain::trading::git::{
-    AddResult, CommitLogEntry, CommitPrepareResult, GitExportState, GitPosition, GitState,
-    GitStatus, OrderStatusUpdate, PushResult, RejectResult, SyncResult,
-};
-use rara_domain::trading::operation::{Operation, OperationOrderType, OperationResult, OperationStatus};
-use rara_domain::trading::{OrderType, Side};
-
-use crate::broker::{AccountInfo, Broker, BrokerError, OrderStatus, Position};
-use crate::health::{BrokerHealth, BrokerHealthInfo, HealthTracker};
-use crate::trading_git::{
-    OperationDispatcher, PendingOrder, StateProvider, TradingGit, TradingGitError,
+use crate::{
+    broker::{AccountInfo, Broker, BrokerError, OrderStatus, Position},
+    health::{BrokerHealth, BrokerHealthInfo, HealthTracker},
+    trading_git::{OperationDispatcher, PendingOrder, StateProvider, TradingGit, TradingGitError},
 };
 
-/// Unified Trading Account — the main entry point for the trading-as-git workflow.
+/// Unified Trading Account — the main entry point for the trading-as-git
+/// workflow.
 ///
-/// Owns a [`Broker`], a [`TradingGit`] history tracker, and a [`HealthTracker`].
-/// All broker calls are routed through health tracking, and all operations
-/// flow through the git stage -> commit -> push pipeline.
+/// Owns a [`Broker`], a [`TradingGit`] history tracker, and a
+/// [`HealthTracker`]. All broker calls are routed through health tracking, and
+/// all operations flow through the git stage -> commit -> push pipeline.
 pub struct UnifiedTradingAccount {
     /// Account identifier.
-    pub id: String,
+    pub id:    String,
     /// Human-readable label.
     pub label: String,
-    broker: Box<dyn Broker>,
-    git: Mutex<TradingGit>,
-    health: Mutex<HealthTracker>,
+    broker:    Box<dyn Broker>,
+    git:       Mutex<TradingGit>,
+    health:    Mutex<HealthTracker>,
 }
 
 impl UnifiedTradingAccount {
@@ -105,10 +109,10 @@ impl UnifiedTradingAccount {
         contract: Contract,
         quantity: Option<Decimal>,
     ) -> AddResult {
-        self.git.lock().await.add(Operation::ClosePosition {
-            contract,
-            quantity,
-        })
+        self.git
+            .lock()
+            .await
+            .add(Operation::ClosePosition { contract, quantity })
     }
 
     /// Stage an order cancellation.
@@ -251,9 +255,7 @@ impl UnifiedTradingAccount {
     // ── Queries ────────────────────────────────────────────────────────
 
     /// Return the current staging area and commit state.
-    pub async fn status(&self) -> GitStatus {
-        self.git.lock().await.status()
-    }
+    pub async fn status(&self) -> GitStatus { self.git.lock().await.status() }
 
     /// Return commit log entries, newest first.
     pub async fn log(&self, limit: usize, symbol: Option<&str>) -> Vec<CommitLogEntry> {
@@ -271,9 +273,7 @@ impl UnifiedTradingAccount {
     }
 
     /// Export the full git state for persistence.
-    pub async fn export_git_state(&self) -> GitExportState {
-        self.git.lock().await.export_state()
-    }
+    pub async fn export_git_state(&self) -> GitExportState { self.git.lock().await.export_state() }
 
     // ── Broker delegation (with health tracking) ───────────────────────
 
@@ -296,24 +296,16 @@ impl UnifiedTradingAccount {
     // ── Health ─────────────────────────────────────────────────────────
 
     /// Return the current health status.
-    pub async fn health(&self) -> BrokerHealth {
-        self.health.lock().await.status()
-    }
+    pub async fn health(&self) -> BrokerHealth { self.health.lock().await.status() }
 
     /// Return a detailed health info snapshot.
-    pub async fn health_info(&self) -> BrokerHealthInfo {
-        self.health.lock().await.info()
-    }
+    pub async fn health_info(&self) -> BrokerHealthInfo { self.health.lock().await.info() }
 
     /// Check whether the broker has been manually disabled.
-    pub async fn is_disabled(&self) -> bool {
-        self.health.lock().await.is_disabled()
-    }
+    pub async fn is_disabled(&self) -> bool { self.health.lock().await.is_disabled() }
 
     /// Re-enable a previously disabled broker.
-    pub async fn enable(&self) {
-        self.health.lock().await.enable();
-    }
+    pub async fn enable(&self) { self.health.lock().await.enable(); }
 
     /// Set the current trading round for subsequent commits.
     pub async fn set_current_round(&self, round: u32) {
@@ -357,13 +349,13 @@ impl OperationDispatcher for BrokerDispatcher<'_> {
             Operation::SyncOrders => {
                 // Sync is handled at the UTA level, not via dispatch
                 return OperationResult {
-                    action: op.clone(),
-                    success: true,
-                    order_id: None,
-                    status: OperationStatus::Filled,
-                    filled_qty: None,
+                    action:       op.clone(),
+                    success:      true,
+                    order_id:     None,
+                    status:       OperationStatus::Filled,
+                    filled_qty:   None,
                     filled_price: None,
-                    error: None,
+                    error:        None,
                 };
             }
         };
@@ -372,26 +364,26 @@ impl OperationDispatcher for BrokerDispatcher<'_> {
             Ok(order_result) => {
                 self.health.lock().await.record_success();
                 OperationResult {
-                    action: op.clone(),
-                    success: order_result.status != OrderStatus::Rejected,
-                    order_id: Some(order_result.order_id),
-                    status: map_order_status(order_result.status),
-                    filled_qty: None,
+                    action:       op.clone(),
+                    success:      order_result.status != OrderStatus::Rejected,
+                    order_id:     Some(order_result.order_id),
+                    status:       map_order_status(order_result.status),
+                    filled_qty:   None,
                     filled_price: None,
-                    error: None,
+                    error:        None,
                 }
             }
             Err(e) => {
                 let msg = e.to_string();
                 self.health.lock().await.record_failure(&msg);
                 OperationResult {
-                    action: op.clone(),
-                    success: false,
-                    order_id: None,
-                    status: OperationStatus::Rejected,
-                    filled_qty: None,
+                    action:       op.clone(),
+                    success:      false,
+                    order_id:     None,
+                    status:       OperationStatus::Rejected,
+                    filled_qty:   None,
                     filled_price: None,
-                    error: Some(msg),
+                    error:        Some(msg),
                 }
             }
         }
@@ -480,7 +472,11 @@ async fn call_broker_with_health<'a, T, F>(
     f: F,
 ) -> Result<T, BrokerError>
 where
-    F: FnOnce(&'a dyn Broker) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<T, BrokerError>> + Send + 'a>>,
+    F: FnOnce(
+        &'a dyn Broker,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<T, BrokerError>> + Send + 'a>,
+    >,
 {
     let result = f(broker).await;
     match &result {
@@ -492,12 +488,14 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use rara_domain::{
+        contract::{Contract, SecType},
+        trading::operation::OperationOrderType,
+    };
     use rust_decimal_macros::dec;
 
+    use super::*;
     use crate::brokers::paper::PaperBroker;
-    use rara_domain::contract::{Contract, SecType};
-    use rara_domain::trading::operation::OperationOrderType;
 
     fn test_contract() -> Contract {
         Contract::builder()
@@ -568,7 +566,10 @@ mod tests {
         uta.commit("risky trade").await.expect("should commit");
 
         // Reject instead of pushing
-        let reject = uta.reject("too risky").await.expect("reject should succeed");
+        let reject = uta
+            .reject("too risky")
+            .await
+            .expect("reject should succeed");
         assert_eq!(reject.operation_count, 1);
         assert!(reject.message.contains("REJECTED"));
 

--- a/crates/rara-trading-engine/tests/uta_integration.rs
+++ b/crates/rara-trading-engine/tests/uta_integration.rs
@@ -3,16 +3,15 @@
 //! Covers the stage → commit → push pipeline, reject workflow,
 //! health tracking, and `AccountManager` multi-account aggregation.
 
+use rara_domain::{
+    contract::{Contract, SecType},
+    trading::{Side, operation::OperationOrderType},
+};
+use rara_trading_engine::{
+    brokers::paper::PaperBroker, health::BrokerHealth, uta::UnifiedTradingAccount,
+};
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
-
-use rara_domain::contract::{Contract, SecType};
-use rara_domain::trading::operation::OperationOrderType;
-use rara_domain::trading::Side;
-
-use rara_trading_engine::brokers::paper::PaperBroker;
-use rara_trading_engine::health::BrokerHealth;
-use rara_trading_engine::uta::UnifiedTradingAccount;
 
 fn btc_contract() -> Contract {
     Contract::builder()
@@ -92,7 +91,10 @@ async fn full_lifecycle_stage_commit_push_log() {
     assert!(log[0].message.contains("buy BTC + ETH"));
 
     // Show by hash should return the same commit
-    let shown = uta.show(&push.hash).await.expect("commit should be retrievable by hash");
+    let shown = uta
+        .show(&push.hash)
+        .await
+        .expect("commit should be retrievable by hash");
     assert_eq!(shown.operations.len(), 2);
 
     // Export should contain 1 commit
@@ -117,7 +119,9 @@ async fn account_manager_multi_account() {
     assert_eq!(manager.size(), 2);
 
     // resolve_one should find by id
-    let found = manager.resolve_one("acct-btc").expect("should find acct-btc");
+    let found = manager
+        .resolve_one("acct-btc")
+        .expect("should find acct-btc");
     assert_eq!(found.id, "acct-btc");
 
     // resolve_one should fail on unknown
@@ -149,15 +153,27 @@ async fn reject_workflow() {
 
     // Commit but reject instead of pushing
     uta.commit("risky trade").await.expect("should commit");
-    let reject = uta.reject("risk limit exceeded").await.expect("reject should succeed");
+    let reject = uta
+        .reject("risk limit exceeded")
+        .await
+        .expect("reject should succeed");
 
     assert_eq!(reject.operation_count, 1);
-    assert!(reject.message.contains("REJECTED"), "message should indicate rejection");
-    assert!(reject.message.contains("risk limit exceeded"), "message should include reason");
+    assert!(
+        reject.message.contains("REJECTED"),
+        "message should indicate rejection"
+    );
+    assert!(
+        reject.message.contains("risk limit exceeded"),
+        "message should include reason"
+    );
 
     // Verify no positions were opened on the broker
     let positions = uta.get_positions().await.expect("should get positions");
-    assert!(positions.is_empty(), "rejected orders must not create positions");
+    assert!(
+        positions.is_empty(),
+        "rejected orders must not create positions"
+    );
 
     // Log should show 1 commit with UserRejected status
     let log = uta.log(10, None).await;
@@ -181,7 +197,10 @@ async fn health_tracking_with_broker() {
     assert!(!uta.is_disabled().await);
 
     // Successful broker query should keep it healthy
-    let _account = uta.get_account().await.expect("account_info should succeed");
+    let _account = uta
+        .get_account()
+        .await
+        .expect("account_info should succeed");
     assert_eq!(uta.health().await, BrokerHealth::Healthy);
 
     // A full stage-commit-push cycle also keeps health healthy
@@ -199,5 +218,8 @@ async fn health_tracking_with_broker() {
     let info = uta.health_info().await;
     assert_eq!(info.status, BrokerHealth::Healthy);
     assert_eq!(info.consecutive_failures, 0);
-    assert!(info.last_success_at.is_some(), "should have recorded a success timestamp");
+    assert!(
+        info.last_success_at.is_some(),
+        "should have recorded a success timestamp"
+    );
 }

--- a/crates/rara-tui/src/app.rs
+++ b/crates/rara-tui/src/app.rs
@@ -13,11 +13,12 @@ use crate::tabs::research::ResearchState;
 #[derive(Debug, Clone)]
 pub struct StrategyStatus {
     /// Human-readable strategy name.
-    pub name: String,
-    /// Current lifecycle state (e.g. "Running", "Promoted", "Paper", "Stopped").
+    pub name:   String,
+    /// Current lifecycle state (e.g. "Running", "Promoted", "Paper",
+    /// "Stopped").
     pub status: String,
     /// Cumulative profit-and-loss.
-    pub pnl: f64,
+    pub pnl:    f64,
     /// Annualized Sharpe ratio.
     pub sharpe: f64,
 }
@@ -26,24 +27,24 @@ pub struct StrategyStatus {
 #[derive(Debug, Clone)]
 pub struct RecentEvent {
     /// Formatted timestamp (e.g. "14:32:01").
-    pub time: String,
+    pub time:       String,
     /// Event category tag (e.g. "TRADE", "ERROR", "INFO").
     pub event_type: String,
     /// One-line event description.
-    pub summary: String,
+    pub summary:    String,
 }
 
 /// Aggregate progress of the autonomous research pipeline.
 #[derive(Debug, Clone)]
 pub struct ResearchProgress {
     /// Number of backtests completed so far.
-    pub current: u32,
+    pub current:     u32,
     /// Total backtests planned for this sweep.
-    pub total: u32,
+    pub total:       u32,
     /// Strategies that passed acceptance criteria.
-    pub accepted: u32,
+    pub accepted:    u32,
     /// Strategies that failed acceptance criteria.
-    pub rejected: u32,
+    pub rejected:    u32,
     /// Strategies currently being evaluated.
     pub in_progress: u32,
     /// Best Sharpe ratio discovered so far, if any.
@@ -74,19 +75,19 @@ pub const EVENTS_TAB_INDEX: usize = 4;
 #[derive(Debug, Clone)]
 pub struct EventEntry {
     /// Monotonically increasing sequence number.
-    pub seq: u64,
+    pub seq:         u64,
     /// Human-readable timestamp string.
-    pub time: String,
+    pub time:        String,
     /// Event topic (trading, research, feedback, sentinel).
-    pub topic: String,
+    pub topic:       String,
     /// The type/kind of event within the topic.
-    pub event_type: String,
+    pub event_type:  String,
     /// One-line summary of the event.
-    pub summary: String,
+    pub summary:     String,
     /// Optional strategy identifier associated with this event.
     pub strategy_id: Option<String>,
     /// Full event payload, typically JSON.
-    pub payload: String,
+    pub payload:     String,
 }
 
 /// Topic-level filter for the events stream.
@@ -107,17 +108,17 @@ pub enum EventFilter {
 /// State for the Events tab.
 pub struct EventsState {
     /// All received events (unfiltered buffer).
-    pub events: Vec<EventEntry>,
+    pub events:          Vec<EventEntry>,
     /// Current topic filter.
-    pub filter: EventFilter,
+    pub filter:          EventFilter,
     /// Whether auto-scroll is enabled (newest events stay visible).
-    pub auto_scroll: bool,
+    pub auto_scroll:     bool,
     /// Currently selected row index within the filtered view.
-    pub selected_index: usize,
+    pub selected_index:  usize,
     /// Current search query text.
-    pub search_query: String,
+    pub search_query:    String,
     /// Whether the search input is actively accepting keystrokes.
-    pub search_active: bool,
+    pub search_active:   bool,
     /// Whether the detail pane is expanded.
     pub detail_expanded: bool,
 }
@@ -125,12 +126,12 @@ pub struct EventsState {
 impl Default for EventsState {
     fn default() -> Self {
         Self {
-            events: Vec::new(),
-            filter: EventFilter::All,
-            auto_scroll: true,
-            selected_index: 0,
-            search_query: String::new(),
-            search_active: false,
+            events:          Vec::new(),
+            filter:          EventFilter::All,
+            auto_scroll:     true,
+            selected_index:  0,
+            search_query:    String::new(),
+            search_active:   false,
             detail_expanded: false,
         }
     }
@@ -146,9 +147,9 @@ pub const TRADING_TAB: usize = 2;
 #[derive(Debug, Clone)]
 pub struct AccountState {
     /// Total portfolio equity.
-    pub equity: f64,
+    pub equity:         f64,
     /// Available cash balance.
-    pub cash: f64,
+    pub cash:           f64,
     /// Unrealized profit/loss across all open positions.
     pub unrealized_pnl: f64,
     /// Portfolio change percentage for the current day.
@@ -158,8 +159,8 @@ pub struct AccountState {
 impl Default for AccountState {
     fn default() -> Self {
         Self {
-            equity: 0.0,
-            cash: 0.0,
+            equity:         0.0,
+            cash:           0.0,
             unrealized_pnl: 0.0,
             day_change_pct: 0.0,
         }
@@ -170,38 +171,38 @@ impl Default for AccountState {
 #[derive(Debug, Clone)]
 pub struct PositionInfo {
     /// Trading instrument symbol (e.g. "BTCUSDT").
-    pub symbol: String,
+    pub symbol:        String,
     /// Position direction ("Buy" or "Sell").
-    pub side: String,
+    pub side:          String,
     /// Number of units held.
-    pub quantity: f64,
+    pub quantity:      f64,
     /// Average entry price.
-    pub entry_price: f64,
+    pub entry_price:   f64,
     /// Current market price.
     pub current_price: f64,
     /// Unrealized profit/loss for this position.
-    pub pnl: f64,
+    pub pnl:           f64,
     /// Name of the strategy that opened this position.
-    pub strategy: String,
+    pub strategy:      String,
 }
 
 /// A single order entry in the order log.
 #[derive(Debug, Clone)]
 pub struct OrderEntry {
     /// Timestamp when the order was placed (HH:MM:SS format).
-    pub time: String,
+    pub time:         String,
     /// Trading instrument symbol.
-    pub symbol: String,
+    pub symbol:       String,
     /// Order direction ("Buy" or "Sell").
-    pub side: String,
+    pub side:         String,
     /// Order quantity.
-    pub quantity: f64,
+    pub quantity:     f64,
     /// Order price.
-    pub price: f64,
+    pub price:        f64,
     /// Order status: "Filled", "Rejected", or "Submitted".
-    pub status: String,
+    pub status:       String,
     /// Name of the strategy that generated the order.
-    pub strategy: String,
+    pub strategy:     String,
     /// Guard check result: "Pass" or rejection reason (e.g. "`MaxPos`").
     pub guard_result: String,
 }
@@ -240,17 +241,17 @@ impl PnlRange {
 #[derive(Debug, Clone)]
 pub struct TradingState {
     /// Account-level summary.
-    pub account: AccountState,
+    pub account:           AccountState,
     /// Currently open positions.
-    pub positions: Vec<PositionInfo>,
+    pub positions:         Vec<PositionInfo>,
     /// Order log entries (most recent first).
-    pub orders: Vec<OrderEntry>,
+    pub orders:            Vec<OrderEntry>,
     /// `PnL` data points for the sparkline chart.
-    pub pnl_data: Vec<u64>,
+    pub pnl_data:          Vec<u64>,
     /// Currently selected time range for the `PnL` sparkline.
-    pub pnl_range: PnlRange,
+    pub pnl_range:         PnlRange,
     /// Index of the currently selected order in the orders list.
-    pub selected_order: usize,
+    pub selected_order:    usize,
     /// Whether the order detail overlay is shown.
     pub show_order_detail: bool,
 }
@@ -258,12 +259,12 @@ pub struct TradingState {
 impl Default for TradingState {
     fn default() -> Self {
         Self {
-            account: AccountState::default(),
-            positions: Vec::new(),
-            orders: Vec::new(),
-            pnl_data: Vec::new(),
-            pnl_range: PnlRange::Hour1,
-            selected_order: 0,
+            account:           AccountState::default(),
+            positions:         Vec::new(),
+            orders:            Vec::new(),
+            pnl_data:          Vec::new(),
+            pnl_range:         PnlRange::Hour1,
+            selected_order:    0,
             show_order_detail: false,
         }
     }
@@ -283,9 +284,7 @@ impl TradingState {
     }
 
     /// Cycle the `PnL` sparkline time range.
-    pub const fn cycle_pnl_range(&mut self) {
-        self.pnl_range = self.pnl_range.next();
-    }
+    pub const fn cycle_pnl_range(&mut self) { self.pnl_range = self.pnl_range.next(); }
 
     /// Toggle the order detail overlay.
     pub const fn toggle_order_detail(&mut self) {
@@ -306,39 +305,40 @@ pub enum StrategyLifecycle {
 
 /// A single strategy entry displayed in the strategy list table.
 ///
-/// Populated from real installed strategies via `StrategyRegistry::list_installed()`.
+/// Populated from real installed strategies via
+/// `StrategyRegistry::list_installed()`.
 #[derive(Debug, Clone)]
 pub struct StrategyEntry {
     /// Display name of the strategy.
-    pub name: String,
+    pub name:            String,
     /// Version number of the strategy (from WASM metadata).
-    pub version: u32,
+    pub version:         u32,
     /// Release tag from the GitHub registry.
-    pub tag: String,
+    pub tag:             String,
     /// Release version string (e.g. "v0.1.0").
     pub release_version: String,
     /// API version the strategy was compiled against.
-    pub api_version: u32,
+    pub api_version:     u32,
     /// Brief description from the WASM metadata.
-    pub description: String,
+    pub description:     String,
     /// Current lifecycle status.
-    pub status: StrategyLifecycle,
+    pub status:          StrategyLifecycle,
     /// Local filesystem path to the WASM binary.
-    pub wasm_path: PathBuf,
+    pub wasm_path:       PathBuf,
     /// WASM file size in bytes.
-    pub file_size: u64,
+    pub file_size:       u64,
     /// WASM asset download URL from the registry.
-    pub wasm_url: String,
+    pub wasm_url:        String,
 }
 
 /// State for the Strategies tab, managing list selection and detail expansion.
 pub struct StrategiesState {
     /// All strategy entries to display.
-    pub strategies: Vec<StrategyEntry>,
+    pub strategies:     Vec<StrategyEntry>,
     /// Index of the currently selected strategy in the list.
     pub selected_index: usize,
     /// Whether the full description is shown in the detail panel.
-    pub show_detail: bool,
+    pub show_detail:    bool,
 }
 
 impl StrategiesState {
@@ -369,9 +369,7 @@ impl StrategiesState {
     }
 
     /// Toggle the detail expansion for the selected strategy.
-    pub const fn toggle_detail(&mut self) {
-        self.show_detail = !self.show_detail;
-    }
+    pub const fn toggle_detail(&mut self) { self.show_detail = !self.show_detail; }
 }
 
 /// Phase of the TUI application lifecycle.
@@ -380,7 +378,7 @@ pub enum AppPhase {
     /// Waiting for the gRPC server to become ready.
     StartingServer {
         /// Status message to display.
-        message: String,
+        message:  String,
         /// Number of connection attempts so far.
         attempts: u32,
     },
@@ -391,35 +389,35 @@ pub enum AppPhase {
 /// Root application state driving the TUI.
 pub struct App {
     /// Index of the currently active tab.
-    pub active_tab: usize,
+    pub active_tab:        usize,
     /// Whether the application is still running.
-    pub running: bool,
+    pub running:           bool,
     /// Current connection state to the gRPC server.
     pub connection_status: ConnectionStatus,
     /// Last received system status from the server.
-    pub system_status: Option<SystemStatus>,
+    pub system_status:     Option<SystemStatus>,
     /// gRPC server address the client connects to.
-    pub server_addr: String,
+    pub server_addr:       String,
     /// Live strategy statuses displayed on the overview tab.
-    pub strategies: Vec<StrategyStatus>,
+    pub strategies:        Vec<StrategyStatus>,
     /// Open positions displayed on the overview tab.
-    pub positions: Vec<PositionInfo>,
+    pub positions:         Vec<PositionInfo>,
     /// Rolling window of recent events.
-    pub recent_events: Vec<RecentEvent>,
+    pub recent_events:     Vec<RecentEvent>,
     /// Active alert messages.
-    pub alerts: Vec<String>,
+    pub alerts:            Vec<String>,
     /// Current research pipeline progress, if any.
     pub research_progress: Option<ResearchProgress>,
     /// State for the Research tab.
-    pub research: ResearchState,
+    pub research:          ResearchState,
     /// State for the Events tab.
-    pub events_state: EventsState,
+    pub events_state:      EventsState,
     /// State for the Trading tab.
-    pub trading: TradingState,
+    pub trading:           TradingState,
     /// State for the Strategies tab.
-    pub strategies_state: StrategiesState,
+    pub strategies_state:  StrategiesState,
     /// Current lifecycle phase of the TUI application.
-    pub phase: AppPhase,
+    pub phase:             AppPhase,
 }
 
 impl App {
@@ -444,7 +442,7 @@ impl App {
             trading: TradingState::default(),
             strategies_state: StrategiesState::from_installed(promoted_dir),
             phase: AppPhase::StartingServer {
-                message: "Starting gRPC server...".to_string(),
+                message:  "Starting gRPC server...".to_string(),
                 attempts: 0,
             },
         }
@@ -458,24 +456,22 @@ impl App {
     }
 
     /// Signal the application to quit.
-    pub const fn quit(&mut self) {
-        self.running = false;
-    }
+    pub const fn quit(&mut self) { self.running = false; }
 }
 
 /// Convert a `FetchedStrategy` from the registry into a TUI view model.
 fn fetched_to_entry(fetched: FetchedStrategy) -> StrategyEntry {
     StrategyEntry {
-        name: fetched.meta.name,
-        version: fetched.meta.version,
-        tag: fetched.entry.tag,
+        name:            fetched.meta.name,
+        version:         fetched.meta.version,
+        tag:             fetched.entry.tag,
         release_version: fetched.entry.version,
-        api_version: fetched.meta.api_version,
-        description: fetched.meta.description,
-        status: StrategyLifecycle::Installed,
-        wasm_path: fetched.wasm_path,
-        file_size: fetched.entry.size,
-        wasm_url: fetched.entry.wasm_url,
+        api_version:     fetched.meta.api_version,
+        description:     fetched.meta.description,
+        status:          StrategyLifecycle::Installed,
+        wasm_path:       fetched.wasm_path,
+        file_size:       fetched.entry.size,
+        wasm_url:        fetched.entry.wasm_url,
     }
 }
 

--- a/crates/rara-tui/src/event_loop.rs
+++ b/crates/rara-tui/src/event_loop.rs
@@ -3,29 +3,28 @@
 //! Handles crossterm input events, periodic status polling via gRPC, and
 //! terminal setup/teardown.
 
-use std::io;
-use std::path::PathBuf;
-use std::time::Duration;
+use std::{io, path::PathBuf, time::Duration};
 
-use crossterm::event::{self, Event, KeyCode, KeyEventKind};
-use crossterm::execute;
-use crossterm::terminal::{
-    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEventKind},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
-use ratatui::backend::CrosstermBackend;
-use ratatui::Terminal;
+use rara_server::rara_proto::{Empty, rara_service_client::RaraServiceClient};
+use ratatui::{Terminal, backend::CrosstermBackend};
 use snafu::ResultExt;
 use tonic::transport::Channel;
 use tracing::{info, warn};
 
-use rara_server::rara_proto::rara_service_client::RaraServiceClient;
-use rara_server::rara_proto::Empty;
-
-use crate::app::{App, AppPhase, ConnectionStatus, EventFilter, EVENTS_TAB_INDEX, STRATEGIES_TAB, TAB_RESEARCH, TRADING_TAB};
-use crate::error::{IoSnafu, Result};
-use crate::server_process::ServerProcess;
-use crate::tabs;
-use crate::ui;
+use crate::{
+    app::{
+        App, AppPhase, ConnectionStatus, EVENTS_TAB_INDEX, EventFilter, STRATEGIES_TAB,
+        TAB_RESEARCH, TRADING_TAB,
+    },
+    error::{IoSnafu, Result},
+    server_process::ServerProcess,
+    tabs, ui,
+};
 
 /// Duration between status poll ticks.
 const TICK_RATE: Duration = Duration::from_millis(1000);
@@ -91,7 +90,8 @@ pub async fn run(server_addr: Option<&str>, promoted_dir: PathBuf) -> Result<()>
 ///
 /// During the startup phase, only quit keys are accepted and the loop
 /// periodically attempts to connect to the gRPC server with a health check.
-/// Once the server is confirmed ready, transitions to the normal dashboard phase.
+/// Once the server is confirmed ready, transitions to the normal dashboard
+/// phase.
 async fn event_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     app: &mut App,
@@ -100,7 +100,9 @@ async fn event_loop(
 ) -> Result<()> {
     while app.running {
         // Render
-        terminal.draw(|frame| ui::render(frame, app)).context(IoSnafu)?;
+        terminal
+            .draw(|frame| ui::render(frame, app))
+            .context(IoSnafu)?;
 
         // Poll crossterm events (non-blocking with timeout)
         if event::poll(POLL_TIMEOUT).context(IoSnafu)?
@@ -127,12 +129,15 @@ async fn event_loop(
                 warn!("gRPC server did not become ready after {attempts} attempts, giving up");
                 app.phase = AppPhase::StartingServer {
                     message: format!(
-                        "Server failed to start after {MAX_STARTUP_ATTEMPTS} attempts. Press q to quit."
+                        "Server failed to start after {MAX_STARTUP_ATTEMPTS} attempts. Press q to \
+                         quit."
                     ),
                     attempts,
                 };
                 // Render one final frame, then just handle quit keys
-                terminal.draw(|frame| ui::render(frame, app)).context(IoSnafu)?;
+                terminal
+                    .draw(|frame| ui::render(frame, app))
+                    .context(IoSnafu)?;
                 loop {
                     if event::poll(POLL_TIMEOUT).context(IoSnafu)?
                         && let Event::Key(key) = event::read().context(IoSnafu)?
@@ -157,13 +162,13 @@ async fn event_loop(
                         *client = Some(c);
                     } else {
                         app.phase = AppPhase::StartingServer {
-                            message: "Server connected, waiting for ready...".to_string(),
+                            message:  "Server connected, waiting for ready...".to_string(),
                             attempts: attempts + 1,
                         };
                     }
                 } else {
                     app.phase = AppPhase::StartingServer {
-                        message: "Connecting to gRPC server...".to_string(),
+                        message:  "Connecting to gRPC server...".to_string(),
                         attempts: attempts + 1,
                     };
                 }
@@ -343,10 +348,7 @@ fn handle_strategies_key(app: &mut App, key: KeyCode) {
 }
 
 /// Poll the gRPC server for system status, handling reconnection on failure.
-async fn poll_status(
-    app: &mut App,
-    client: &mut Option<RaraServiceClient<Channel>>,
-) -> Result<()> {
+async fn poll_status(app: &mut App, client: &mut Option<RaraServiceClient<Channel>>) -> Result<()> {
     if let Some(c) = client.as_mut() {
         match c.get_system_status(Empty {}).await {
             Ok(response) => {

--- a/crates/rara-tui/src/server_process.rs
+++ b/crates/rara-tui/src/server_process.rs
@@ -1,10 +1,10 @@
 //! Manages a child gRPC server process for standalone TUI mode.
 //!
 //! When the TUI is launched without an explicit `--server` address, this module
-//! spawns the same binary with `serve --port <port>` and ensures cleanup on exit.
+//! spawns the same binary with `serve --port <port>` and ensures cleanup on
+//! exit.
 
-use std::net::TcpListener;
-use std::process::Stdio;
+use std::{net::TcpListener, process::Stdio};
 
 use snafu::ResultExt;
 use tokio::process::{Child, Command};
@@ -18,7 +18,7 @@ use crate::error::{IoSnafu, Result};
 /// The `port` field records which port the server is listening on.
 pub struct ServerProcess {
     pub port: u16,
-    child: Child,
+    child:    Child,
 }
 
 impl ServerProcess {
@@ -49,9 +49,7 @@ impl ServerProcess {
     }
 
     /// Build the gRPC server address string for this child process.
-    pub fn server_addr(&self) -> String {
-        format!("http://127.0.0.1:{}", self.port)
-    }
+    pub fn server_addr(&self) -> String { format!("http://127.0.0.1:{}", self.port) }
 
     /// Gracefully shut down the child process.
     ///
@@ -81,7 +79,8 @@ impl ServerProcess {
     }
 }
 
-/// Find an available TCP port by binding to port 0 and reading the assigned port.
+/// Find an available TCP port by binding to port 0 and reading the assigned
+/// port.
 fn pick_available_port() -> Result<u16> {
     let listener = TcpListener::bind("127.0.0.1:0").context(IoSnafu)?;
     let port = listener.local_addr().context(IoSnafu)?.port();

--- a/crates/rara-tui/src/tabs/events.rs
+++ b/crates/rara-tui/src/tabs/events.rs
@@ -3,14 +3,18 @@
 //! Displays system events in a `tail -f` style view with topic-based color
 //! coding, pause/resume auto-scroll, keyboard navigation, and text search.
 
-use ratatui::layout::{Constraint, Layout, Rect};
-use ratatui::style::{Modifier, Style};
-use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, Wrap};
-use ratatui::Frame;
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Cell, Paragraph, Row, Table, Wrap},
+};
 
-use crate::app::{EventFilter, EventsState};
-use crate::theme;
+use crate::{
+    app::{EventFilter, EventsState},
+    theme,
+};
 
 /// Map a topic string to its display color.
 fn topic_color(topic: &str) -> ratatui::style::Color {
@@ -187,9 +191,9 @@ pub fn render(frame: &mut Frame, state: &EventsState, area: Rect) {
     let detail_height = if state.detail_expanded { 10 } else { 0 };
 
     let chunks = Layout::vertical([
-        Constraint::Length(1),                    // filter bar
-        Constraint::Min(5),                       // event list
-        Constraint::Length(detail_height),         // detail pane
+        Constraint::Length(1),             // filter bar
+        Constraint::Min(5),                // event list
+        Constraint::Length(detail_height), // detail pane
     ])
     .split(area);
 
@@ -202,6 +206,4 @@ pub fn render(frame: &mut Frame, state: &EventsState, area: Rect) {
 }
 
 /// Count of events matching current filters (used for navigation bounds).
-pub fn filtered_count(state: &EventsState) -> usize {
-    filtered_events(state).len()
-}
+pub fn filtered_count(state: &EventsState) -> usize { filtered_events(state).len() }

--- a/crates/rara-tui/src/tabs/overview.rs
+++ b/crates/rara-tui/src/tabs/overview.rs
@@ -8,14 +8,15 @@
 //!
 //! **Narrow layout** (<120 cols): single-column stacked
 
-use ratatui::layout::{Constraint, Layout, Rect};
-use ratatui::style::Modifier;
-use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Cell, Gauge, List, ListItem, Paragraph, Row, Table};
-use ratatui::Frame;
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout, Rect},
+    style::Modifier,
+    text::{Line, Span},
+    widgets::{Block, Borders, Cell, Gauge, List, ListItem, Paragraph, Row, Table},
+};
 
-use crate::app::App;
-use crate::theme;
+use crate::{app::App, theme};
 
 /// Minimum width (in columns) to use the dual-column layout.
 const WIDE_THRESHOLD: u16 = 120;
@@ -31,8 +32,8 @@ pub fn render(frame: &mut Frame, app: &App, area: Rect) {
 
 /// Dual-column layout for wide terminals (≥120 cols).
 fn render_wide(frame: &mut Frame, app: &App, area: Rect) {
-    let columns = Layout::horizontal([Constraint::Percentage(60), Constraint::Percentage(40)])
-        .split(area);
+    let columns =
+        Layout::horizontal([Constraint::Percentage(60), Constraint::Percentage(40)]).split(area);
 
     // Left column: strategies, positions, recent events
     let left_panes = Layout::vertical([
@@ -65,10 +66,10 @@ fn render_wide(frame: &mut Frame, app: &App, area: Rect) {
 /// strategies, positions, alerts, and recent events vertically.
 fn render_narrow(frame: &mut Frame, app: &App, area: Rect) {
     let panes = Layout::vertical([
-        Constraint::Length(3),  // system + research compact bar
-        Constraint::Length(5),  // strategies (compact)
-        Constraint::Length(5),  // positions (compact)
-        Constraint::Length(4),  // alerts
+        Constraint::Length(3), // system + research compact bar
+        Constraint::Length(5), // strategies (compact)
+        Constraint::Length(5), // positions (compact)
+        Constraint::Length(4), // alerts
         Constraint::Min(3),    // recent events (fill)
     ])
     .split(area);
@@ -128,10 +129,9 @@ fn render_strategies(frame: &mut Frame, app: &App, area: Rect) {
     let block = pane_block(" Strategies ");
 
     if app.strategies.is_empty() {
-        let empty =
-            Paragraph::new("  No strategies yet. Run \"rara research run\" to start.")
-                .style(theme::muted())
-                .block(block);
+        let empty = Paragraph::new("  No strategies yet. Run \"rara research run\" to start.")
+            .style(theme::muted())
+            .block(block);
         frame.render_widget(empty, area);
         return;
     }
@@ -345,8 +345,12 @@ fn render_research_progress(frame: &mut Frame, app: &App, area: Rect) {
         let inner = block.inner(area);
         frame.render_widget(block, area);
 
-        let panes = Layout::vertical([Constraint::Length(1), Constraint::Length(1), Constraint::Min(0)])
-            .split(inner);
+        let panes = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Min(0),
+        ])
+        .split(inner);
 
         // Summary line
         let summary = Line::from(vec![
@@ -401,7 +405,8 @@ fn pane_block(title: &str) -> Block<'_> {
         .style(ratatui::style::Style::default().bg(theme::BASE))
 }
 
-/// Return a style for `PnL` values: positive → green, negative → red, zero → muted.
+/// Return a style for `PnL` values: positive → green, negative → red, zero →
+/// muted.
 fn pnl_style(pnl: f64) -> ratatui::style::Style {
     if pnl > 0.0 {
         theme::positive()

--- a/crates/rara-tui/src/tabs/research.rs
+++ b/crates/rara-tui/src/tabs/research.rs
@@ -18,13 +18,13 @@
 //!
 //! Keys: `j/k` navigate list, `p` toggle DAG popup, `Esc` close popup.
 
-use ratatui::layout::{Constraint, Layout, Rect};
-use ratatui::style::{Modifier, Style};
-use ratatui::text::{Line, Span};
-use ratatui::widgets::{
-    Block, Borders, Cell, Clear, Gauge, Paragraph, Row, Table, Wrap,
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Cell, Clear, Gauge, Paragraph, Row, Table, Wrap},
 };
-use ratatui::Frame;
 
 use crate::theme;
 
@@ -92,13 +92,13 @@ pub enum HypothesisStatus {
 #[derive(Debug, Clone)]
 pub struct HypothesisEntry {
     /// Unique hypothesis ID.
-    pub id: u32,
+    pub id:          u32,
     /// Short name / label.
-    pub name: String,
+    pub name:        String,
     /// Current status.
-    pub status: HypothesisStatus,
+    pub status:      HypothesisStatus,
     /// Parent hypothesis ID (for DAG lineage).
-    pub parent_id: Option<u32>,
+    pub parent_id:   Option<u32>,
     /// Optional longer description.
     pub description: String,
 }
@@ -107,24 +107,24 @@ pub struct HypothesisEntry {
 #[derive(Debug, Clone)]
 pub struct BacktestEntry {
     /// Timeframe label (e.g. "1h", "4h", "1d").
-    pub timeframe: String,
+    pub timeframe:    String,
     /// Annualized Sharpe ratio.
-    pub sharpe: f64,
+    pub sharpe:       f64,
     /// Maximum drawdown percentage.
     pub max_drawdown: f64,
     /// Win rate percentage.
-    pub win_rate: f64,
+    pub win_rate:     f64,
     /// Total number of trades.
-    pub trade_count: u32,
+    pub trade_count:  u32,
 }
 
 /// Best-known strategy info (State Of The Art).
 #[derive(Debug, Clone)]
 pub struct SotaInfo {
     /// Name of the current SOTA strategy.
-    pub name: String,
+    pub name:         String,
     /// Sharpe ratio of SOTA.
-    pub sharpe: f64,
+    pub sharpe:       f64,
     /// Max drawdown of SOTA.
     pub max_drawdown: f64,
 }
@@ -133,11 +133,11 @@ pub struct SotaInfo {
 #[derive(Debug, Clone)]
 pub struct ResearchProgress {
     /// Current hypothesis index (1-based).
-    pub current: u32,
+    pub current:         u32,
     /// Total planned hypotheses.
-    pub total: u32,
+    pub total:           u32,
     /// Current phase of the active hypothesis.
-    pub phase: ResearchPhase,
+    pub phase:           ResearchPhase,
     /// Name of the active hypothesis.
     pub hypothesis_name: String,
 }
@@ -146,17 +146,17 @@ pub struct ResearchProgress {
 #[derive(Debug, Clone)]
 pub struct ResearchState {
     /// Overall loop progress.
-    pub progress: ResearchProgress,
+    pub progress:       ResearchProgress,
     /// All hypotheses explored so far.
-    pub hypotheses: Vec<HypothesisEntry>,
+    pub hypotheses:     Vec<HypothesisEntry>,
     /// Index of the currently selected hypothesis in the list.
     pub selected_index: usize,
     /// Backtest results for the selected hypothesis.
-    pub backtests: Vec<BacktestEntry>,
+    pub backtests:      Vec<BacktestEntry>,
     /// Current best strategy info.
-    pub sota: Option<SotaInfo>,
+    pub sota:           Option<SotaInfo>,
     /// Whether the DAG popup is visible.
-    pub show_dag: bool,
+    pub show_dag:       bool,
 }
 
 impl ResearchState {
@@ -164,17 +164,17 @@ impl ResearchState {
     #[must_use]
     pub const fn empty() -> Self {
         Self {
-            progress: ResearchProgress {
-                current: 0,
-                total: 0,
-                phase: ResearchPhase::Coding,
+            progress:       ResearchProgress {
+                current:         0,
+                total:           0,
+                phase:           ResearchPhase::Coding,
                 hypothesis_name: String::new(),
             },
-            hypotheses: Vec::new(),
+            hypotheses:     Vec::new(),
             selected_index: 0,
-            backtests: Vec::new(),
-            sota: None,
-            show_dag: false,
+            backtests:      Vec::new(),
+            sota:           None,
+            show_dag:       false,
         }
     }
 
@@ -193,14 +193,10 @@ impl ResearchState {
     }
 
     /// Toggle the DAG popup visibility.
-    pub const fn toggle_dag(&mut self) {
-        self.show_dag = !self.show_dag;
-    }
+    pub const fn toggle_dag(&mut self) { self.show_dag = !self.show_dag; }
 
     /// Close the DAG popup if open.
-    pub const fn close_dag(&mut self) {
-        self.show_dag = false;
-    }
+    pub const fn close_dag(&mut self) { self.show_dag = false; }
 }
 
 // ---------------------------------------------------------------------------
@@ -211,7 +207,7 @@ impl ResearchState {
 pub fn render(frame: &mut Frame, state: &ResearchState, area: Rect) {
     let layout = Layout::vertical([
         Constraint::Length(3), // progress bar
-        Constraint::Min(8),   // main body
+        Constraint::Min(8),    // main body
         Constraint::Length(5), // detail pane
     ])
     .split(area);
@@ -239,10 +235,7 @@ fn render_progress(frame: &mut Frame, state: &ResearchState, area: Rect) {
         .hypotheses
         .iter()
         .find(|h| h.name == p.hypothesis_name)
-        .and_then(|h| {
-            h.parent_id
-                .map(|pid| format!(" (#{}<-#{})", h.id, pid))
-        })
+        .and_then(|h| h.parent_id.map(|pid| format!(" (#{}<-#{})", h.id, pid)))
         .unwrap_or_default();
 
     let label = format!(
@@ -296,18 +289,9 @@ fn render_hypothesis_list(frame: &mut Frame, state: &ResearchState, area: Rect) 
         .enumerate()
         .map(|(i, h)| {
             let (icon, style) = match h.status {
-                HypothesisStatus::InProgress => (
-                    "\u{23f3}",
-                    Style::default().fg(theme::GOLD),
-                ),
-                HypothesisStatus::Accepted => (
-                    "\u{2713}",
-                    Style::default().fg(theme::FOAM),
-                ),
-                HypothesisStatus::Rejected => (
-                    "\u{2717}",
-                    Style::default().fg(theme::LOVE),
-                ),
+                HypothesisStatus::InProgress => ("\u{23f3}", Style::default().fg(theme::GOLD)),
+                HypothesisStatus::Accepted => ("\u{2713}", Style::default().fg(theme::FOAM)),
+                HypothesisStatus::Rejected => ("\u{2717}", Style::default().fg(theme::LOVE)),
             };
 
             let selected_marker = if i == state.selected_index { ">" } else { " " };
@@ -319,7 +303,11 @@ fn render_hypothesis_list(frame: &mut Frame, state: &ResearchState, area: Rect) 
             ]);
 
             if i == state.selected_index {
-                row.style(Style::default().bg(theme::OVERLAY).add_modifier(Modifier::BOLD))
+                row.style(
+                    Style::default()
+                        .bg(theme::OVERLAY)
+                        .add_modifier(Modifier::BOLD),
+                )
             } else {
                 row
             }
@@ -397,33 +385,29 @@ fn render_sota(frame: &mut Frame, state: &ResearchState, area: Rect) {
         },
     );
 
-    let paragraph = Paragraph::new(text)
-        .style(theme::text())
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(theme::muted())
-                .title(" SOTA "),
-        );
+    let paragraph = Paragraph::new(text).style(theme::text()).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(theme::muted())
+            .title(" SOTA "),
+    );
 
     frame.render_widget(paragraph, area);
 }
 
-/// Render the detail pane at the bottom showing selected hypothesis description.
+/// Render the detail pane at the bottom showing selected hypothesis
+/// description.
 fn render_detail(frame: &mut Frame, state: &ResearchState, area: Rect) {
-    let text = state
-        .hypotheses
-        .get(state.selected_index)
-        .map_or_else(
-            || "No hypothesis selected.".to_string(),
-            |h| {
-                if h.description.is_empty() {
-                    format!("#{} {} — no description available.", h.id, h.name)
-                } else {
-                    format!("#{} {} — {}", h.id, h.name, h.description)
-                }
-            },
-        );
+    let text = state.hypotheses.get(state.selected_index).map_or_else(
+        || "No hypothesis selected.".to_string(),
+        |h| {
+            if h.description.is_empty() {
+                format!("#{} {} — no description available.", h.id, h.name)
+            } else {
+                format!("#{} {} — {}", h.id, h.name, h.description)
+            }
+        },
+    );
 
     let paragraph = Paragraph::new(text)
         .style(theme::text())
@@ -465,15 +449,13 @@ fn render_dag_popup(frame: &mut Frame, state: &ResearchState, area: Rect) {
         )));
     }
 
-    let paragraph = Paragraph::new(lines)
-        .style(theme::text())
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(theme::IRIS))
-                .style(Style::default().bg(theme::OVERLAY))
-                .title(" Hypothesis DAG (p to close) "),
-        );
+    let paragraph = Paragraph::new(lines).style(theme::text()).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(theme::IRIS))
+            .style(Style::default().bg(theme::OVERLAY))
+            .title(" Hypothesis DAG (p to close) "),
+    );
 
     frame.render_widget(paragraph, popup);
 }
@@ -519,7 +501,8 @@ fn render_dag_node(
     }
 }
 
-/// Compute a centered rectangle within `area` using percentage width and height.
+/// Compute a centered rectangle within `area` using percentage width and
+/// height.
 fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
     let popup_layout = Layout::vertical([
         Constraint::Percentage((100 - percent_y) / 2),

--- a/crates/rara-tui/src/tabs/strategies.rs
+++ b/crates/rara-tui/src/tabs/strategies.rs
@@ -14,14 +14,18 @@
 //! └───────────────────────────────────────────────────────────────┘
 //! ```
 
-use ratatui::layout::{Constraint, Layout, Rect};
-use ratatui::style::{Modifier, Style};
-use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
-use ratatui::Frame;
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Cell, Paragraph, Row, Table},
+};
 
-use crate::app::{StrategiesState, StrategyLifecycle};
-use crate::theme;
+use crate::{
+    app::{StrategiesState, StrategyLifecycle},
+    theme,
+};
 
 /// Render the full strategies tab into the given area.
 pub fn render(frame: &mut Frame, state: &StrategiesState, area: Rect) {

--- a/crates/rara-tui/src/tabs/trading.rs
+++ b/crates/rara-tui/src/tabs/trading.rs
@@ -6,21 +6,25 @@
 //! 3. Orders table: Time, Symbol, Side, Qty, Price, Status, Strategy, Guard
 //! 4. `PnL` sparkline (4 lines): ratatui `Sparkline` widget
 
-use ratatui::layout::{Alignment, Constraint, Layout, Rect};
-use ratatui::style::{Modifier, Style};
-use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Sparkline, Table};
-use ratatui::Frame;
+use ratatui::{
+    Frame,
+    layout::{Alignment, Constraint, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Cell, Paragraph, Row, Sparkline, Table},
+};
 
-use crate::app::{App, PnlRange, TradingState};
-use crate::theme;
+use crate::{
+    app::{App, PnlRange, TradingState},
+    theme,
+};
 
 /// Render the full trading tab content into the given area.
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     let trading = &app.trading;
 
     let chunks = Layout::vertical([
-        Constraint::Length(1),  // account bar
+        Constraint::Length(1), // account bar
         Constraint::Min(5),    // positions table
         Constraint::Min(8),    // orders table
         Constraint::Length(6), // PnL sparkline
@@ -70,9 +74,11 @@ fn render_positions_table(frame: &mut Frame, state: &TradingState, area: Rect) {
         return;
     }
 
-    let header = Row::new(["Symbol", "Side", "Qty", "Entry", "Current", "PnL", "Strategy"])
-        .style(theme::emphasis())
-        .bottom_margin(0);
+    let header = Row::new([
+        "Symbol", "Side", "Qty", "Entry", "Current", "PnL", "Strategy",
+    ])
+    .style(theme::emphasis())
+    .bottom_margin(0);
 
     let rows = state.positions.iter().map(|p| {
         let pnl_s = pnl_style(p.pnl);

--- a/crates/rara-tui/src/theme.rs
+++ b/crates/rara-tui/src/theme.rs
@@ -37,60 +37,40 @@ pub const IRIS: Color = Color::Rgb(196, 167, 231);
 
 /// Style for positive indicators (connected, `PnL`+, promoted).
 #[must_use]
-pub fn positive() -> Style {
-    Style::default().fg(FOAM)
-}
+pub fn positive() -> Style { Style::default().fg(FOAM) }
 
 /// Style for negative indicators (disconnected, `PnL`-, demoted).
 #[must_use]
-pub fn negative() -> Style {
-    Style::default().fg(LOVE)
-}
+pub fn negative() -> Style { Style::default().fg(LOVE) }
 
 /// Style for warning indicators (reconnecting, hold).
 #[must_use]
-pub fn warning() -> Style {
-    Style::default().fg(GOLD)
-}
+pub fn warning() -> Style { Style::default().fg(GOLD) }
 
 /// Style for informational elements (links, IDs).
 #[must_use]
-pub fn info() -> Style {
-    Style::default().fg(PINE)
-}
+pub fn info() -> Style { Style::default().fg(PINE) }
 
 /// Style for primary text.
 #[must_use]
-pub fn text() -> Style {
-    Style::default().fg(TEXT)
-}
+pub fn text() -> Style { Style::default().fg(TEXT) }
 
 /// Style for muted/secondary text.
 #[must_use]
-pub fn muted() -> Style {
-    Style::default().fg(MUTED)
-}
+pub fn muted() -> Style { Style::default().fg(MUTED) }
 
 /// Style for emphasized/active elements (selected tab, title).
 #[must_use]
-pub fn emphasis() -> Style {
-    Style::default().fg(TEXT).add_modifier(Modifier::BOLD)
-}
+pub fn emphasis() -> Style { Style::default().fg(TEXT).add_modifier(Modifier::BOLD) }
 
 /// Style for highlighted elements.
 #[must_use]
-pub fn highlight() -> Style {
-    Style::default().fg(ROSE)
-}
+pub fn highlight() -> Style { Style::default().fg(ROSE) }
 
 /// Style for the status bar background.
 #[must_use]
-pub fn status_bar_bg() -> Style {
-    Style::default().bg(SURFACE).fg(TEXT)
-}
+pub fn status_bar_bg() -> Style { Style::default().bg(SURFACE).fg(TEXT) }
 
 /// Style for the footer/help bar.
 #[must_use]
-pub fn footer() -> Style {
-    Style::default().bg(SURFACE).fg(SUBTLE)
-}
+pub fn footer() -> Style { Style::default().bg(SURFACE).fg(SUBTLE) }

--- a/crates/rara-tui/src/ui.rs
+++ b/crates/rara-tui/src/ui.rs
@@ -14,23 +14,27 @@
 //! └───────────────────────────────────────────────────────────┘
 //! ```
 
-use ratatui::layout::{Constraint, Layout};
-use ratatui::style::Modifier;
-use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Paragraph, Tabs};
-use ratatui::Frame;
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout},
+    style::Modifier,
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Tabs},
+};
 
-use crate::app::{App, ConnectionStatus, EVENTS_TAB_INDEX, STRATEGIES_TAB, TAB_NAMES, TAB_RESEARCH, TRADING_TAB};
-use crate::tabs;
-use crate::tabs::research;
-use crate::tabs::strategies as strategies_tab;
-use crate::tabs::trading;
-use crate::theme;
+use crate::{
+    app::{
+        App, ConnectionStatus, EVENTS_TAB_INDEX, STRATEGIES_TAB, TAB_NAMES, TAB_RESEARCH,
+        TRADING_TAB,
+    },
+    tabs,
+    tabs::{research, strategies as strategies_tab, trading},
+    theme,
+};
 
 /// Braille spinner animation frames for the startup screen.
 const SPINNER_FRAMES: &[&str] = &[
-    "\u{280b}", "\u{2819}", "\u{2839}", "\u{2838}",
-    "\u{283c}", "\u{2834}", "\u{2826}", "\u{2827}",
+    "\u{280b}", "\u{2819}", "\u{2839}", "\u{2838}", "\u{283c}", "\u{2834}", "\u{2826}", "\u{2827}",
     "\u{2807}", "\u{280f}",
 ];
 
@@ -83,10 +87,7 @@ fn render_status_bar(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) 
         },
     );
 
-    let strategy_count = app
-        .system_status
-        .as_ref()
-        .map_or(0, |s| s.strategy_count);
+    let strategy_count = app.system_status.as_ref().map_or(0, |s| s.strategy_count);
     let uptime = app
         .system_status
         .as_ref()
@@ -156,8 +157,7 @@ fn render_content(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         }
         ConnectionStatus::Disconnected { retry_count } => {
             let content = Paragraph::new(format!(
-                "Connection lost. Reconnecting... (attempt {retry_count})\n\
-                 Server: {}",
+                "Connection lost. Reconnecting... (attempt {retry_count})\nServer: {}",
                 app.server_addr
             ))
             .style(theme::negative())
@@ -180,10 +180,7 @@ fn render_content(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
     } else if app.active_tab == EVENTS_TAB_INDEX {
         tabs::events::render(frame, &app.events_state, area);
     } else {
-        let tab_name = TAB_NAMES
-            .get(app.active_tab)
-            .copied()
-            .unwrap_or("Unknown");
+        let tab_name = TAB_NAMES.get(app.active_tab).copied().unwrap_or("Unknown");
         let content = Paragraph::new(format!(
             "{tab_name}\n\nContent will be implemented in future issues."
         ))
@@ -240,9 +237,7 @@ fn render_startup(frame: &mut Frame, app: &App) {
     frame.render_widget(bg, area);
 
     let (message, attempts) = match &app.phase {
-        crate::app::AppPhase::StartingServer { message, attempts } => {
-            (message.as_str(), *attempts)
-        }
+        crate::app::AppPhase::StartingServer { message, attempts } => (message.as_str(), *attempts),
         crate::app::AppPhase::Ready => return,
     };
 
@@ -250,25 +245,19 @@ fn render_startup(frame: &mut Frame, app: &App) {
 
     let lines = vec![
         Line::from(""),
-        Line::from(vec![
-            Span::styled("  rara-trading", theme::emphasis()),
-        ]),
+        Line::from(vec![Span::styled("  rara-trading", theme::emphasis())]),
         Line::from(""),
         Line::from(vec![
             Span::styled(format!("  {spinner} "), theme::warning()),
             Span::styled(message, theme::text()),
         ]),
         Line::from(""),
-        Line::from(vec![
-            Span::styled(
-                format!("  Connection attempts: {attempts}"),
-                theme::muted(),
-            ),
-        ]),
+        Line::from(vec![Span::styled(
+            format!("  Connection attempts: {attempts}"),
+            theme::muted(),
+        )]),
         Line::from(""),
-        Line::from(vec![
-            Span::styled("  q: Quit", theme::muted()),
-        ]),
+        Line::from(vec![Span::styled("  q: Quit", theme::muted())]),
     ];
 
     let paragraph = Paragraph::new(lines);

--- a/src/accounts_config.rs
+++ b/src/accounts_config.rs
@@ -5,9 +5,7 @@ use std::path::Path;
 use rara_trading_engine::account_config::{AccountsConfig, BrokerConfig};
 
 /// Load accounts from the default path with environment variable overrides.
-pub fn load_accounts() -> AccountsConfig {
-    load_accounts_from_path(&crate::paths::accounts_file())
-}
+pub fn load_accounts() -> AccountsConfig { load_accounts_from_path(&crate::paths::accounts_file()) }
 
 /// Load accounts from a specific path via the `config` crate.
 ///
@@ -17,7 +15,8 @@ pub fn load_accounts() -> AccountsConfig {
 /// - `RARA_ACCOUNT_{ID}_SECRET`
 /// - `RARA_ACCOUNT_{ID}_PASSPHRASE`
 ///
-/// where `{ID}` is the account id uppercased with hyphens replaced by underscores.
+/// where `{ID}` is the account id uppercased with hyphens replaced by
+/// underscores.
 pub fn load_accounts_from_path(path: &Path) -> AccountsConfig {
     let mut cfg: AccountsConfig = if path.exists() {
         let settings = config::Config::builder()
@@ -38,9 +37,7 @@ pub fn load_accounts_from_path(path: &Path) -> AccountsConfig {
 /// Uses the pattern `RARA_ACCOUNT_{ID}_{FIELD}` where ID is the account id
 /// uppercased with hyphens replaced by underscores. This is more user-friendly
 /// than index-based env vars since account order may change.
-fn apply_env_overrides(cfg: &mut AccountsConfig) {
-    apply_env_overrides_with(cfg, std::env::var);
-}
+fn apply_env_overrides(cfg: &mut AccountsConfig) { apply_env_overrides_with(cfg, std::env::var); }
 
 /// Apply overrides using a custom variable lookup function.
 ///
@@ -191,24 +188,22 @@ mod tests {
 
         let mut cfg = AccountsConfig {
             accounts: vec![AccountConfig {
-                id: "binance-main".to_string(),
-                label: None,
+                id:            "binance-main".to_string(),
+                label:         None,
                 broker_config: BrokerConfig::Ccxt(CcxtBrokerConfig {
-                    exchange: "binance".to_string(),
-                    sandbox: false,
-                    api_key: "file-key".to_string(),
-                    secret: "file-secret".to_string(),
+                    exchange:   "binance".to_string(),
+                    sandbox:    false,
+                    api_key:    "file-key".to_string(),
+                    secret:     "file-secret".to_string(),
                     passphrase: None,
                 }),
-                enabled: true,
-                contracts: vec![],
+                enabled:       true,
+                contracts:     vec![],
             }],
         };
 
         apply_env_overrides_with(&mut cfg, |key| {
-            env.get(&key)
-                .cloned()
-                .ok_or(std::env::VarError::NotPresent)
+            env.get(&key).cloned().ok_or(std::env::VarError::NotPresent)
         });
 
         if let BrokerConfig::Ccxt(ref ccxt) = cfg.accounts[0].broker_config {

--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -13,11 +13,11 @@ static APP_CONFIG: OnceLock<AppConfig> = OnceLock::new();
 #[serde(default)]
 pub struct AppConfig {
     /// Agent backend configuration.
-    pub agent: AgentConfig,
+    pub agent:    AgentConfig,
     /// Database configuration.
     pub database: DatabaseConfig,
     /// Trading engine configuration.
-    pub trading: TradingConfig,
+    pub trading:  TradingConfig,
     /// Research loop configuration.
     pub research: ResearchConfig,
     /// Feedback evaluation configuration.
@@ -25,7 +25,7 @@ pub struct AppConfig {
     /// Sentinel monitoring configuration.
     pub sentinel: SentinelConfig,
     /// gRPC server configuration.
-    pub server: ServerConfig,
+    pub server:   ServerConfig,
 }
 
 /// Database connection configuration.
@@ -49,9 +49,9 @@ impl Default for DatabaseConfig {
 #[serde(default)]
 pub struct TradingConfig {
     /// Maximum position size per contract.
-    pub max_position_size: f64,
+    pub max_position_size:        f64,
     /// Maximum total drawdown percentage before halting.
-    pub max_drawdown_pct: f64,
+    pub max_drawdown_pct:         f64,
     /// Maximum number of concurrent positions.
     pub max_concurrent_positions: u32,
 }
@@ -59,8 +59,8 @@ pub struct TradingConfig {
 impl Default for TradingConfig {
     fn default() -> Self {
         Self {
-            max_position_size: 1.0,
-            max_drawdown_pct: 5.0,
+            max_position_size:        1.0,
+            max_drawdown_pct:         5.0,
             max_concurrent_positions: 3,
         }
     }
@@ -71,22 +71,22 @@ impl Default for TradingConfig {
 #[serde(default)]
 pub struct ResearchConfig {
     /// Number of iterations per research run.
-    pub iterations: u32,
+    pub iterations:          u32,
     /// Timeframes to backtest against.
-    pub timeframes: Vec<String>,
+    pub timeframes:          Vec<String>,
     /// Maximum compile retries per hypothesis.
     pub max_compile_retries: u32,
     /// Delay in seconds between research cycles in daemon mode.
-    pub cycle_delay_secs: u64,
+    pub cycle_delay_secs:    u64,
 }
 
 impl Default for ResearchConfig {
     fn default() -> Self {
         Self {
-            iterations: 5,
-            timeframes: vec!["1h".to_string(), "4h".to_string(), "1d".to_string()],
+            iterations:          5,
+            timeframes:          vec!["1h".to_string(), "4h".to_string(), "1d".to_string()],
             max_compile_retries: 3,
-            cycle_delay_secs: 30,
+            cycle_delay_secs:    30,
         }
     }
 }
@@ -96,28 +96,29 @@ impl Default for ResearchConfig {
 #[serde(default)]
 pub struct FeedbackConfig {
     /// Minimum Sharpe ratio for promotion.
-    pub min_sharpe_for_promotion: f64,
+    pub min_sharpe_for_promotion:    f64,
     /// Minimum win rate for promotion.
-    pub min_win_rate: f64,
+    pub min_win_rate:                f64,
     /// Minimum trade count before evaluation.
-    pub min_trades: u32,
+    pub min_trades:                  u32,
     /// Maximum drawdown percentage for retirement.
     pub max_drawdown_for_retirement: f64,
     /// Interval in seconds between feedback evaluation ticks.
-    pub eval_interval_secs: u64,
-    /// Minimum new trades since last evaluation before re-evaluating a strategy.
-    pub min_trades_between_evals: u32,
+    pub eval_interval_secs:          u64,
+    /// Minimum new trades since last evaluation before re-evaluating a
+    /// strategy.
+    pub min_trades_between_evals:    u32,
 }
 
 impl Default for FeedbackConfig {
     fn default() -> Self {
         Self {
-            min_sharpe_for_promotion: 1.0,
-            min_win_rate: 0.45,
-            min_trades: 30,
+            min_sharpe_for_promotion:    1.0,
+            min_win_rate:                0.45,
+            min_trades:                  30,
             max_drawdown_for_retirement: 20.0,
-            eval_interval_secs: 3600,
-            min_trades_between_evals: 100,
+            eval_interval_secs:          3600,
+            min_trades_between_evals:    100,
         }
     }
 }
@@ -127,15 +128,15 @@ impl Default for FeedbackConfig {
 #[serde(default)]
 pub struct SentinelConfig {
     /// Whether sentinel monitoring is enabled.
-    pub enabled: bool,
+    pub enabled:             bool,
     /// Interval in seconds between sentinel poll cycles.
     pub check_interval_secs: u64,
     /// RSS/Atom feed URLs to monitor for market-moving news.
-    pub rss_feeds: Vec<RssFeedEntry>,
+    pub rss_feeds:           Vec<RssFeedEntry>,
     /// Whether the trump-code political signal source is enabled.
-    pub trump_code_enabled: bool,
+    pub trump_code_enabled:  bool,
     /// Base URL of the trump-code API service.
-    pub trump_code_url: String,
+    pub trump_code_url:      String,
 }
 
 /// A single RSS/Atom feed entry for sentinel monitoring.
@@ -144,17 +145,17 @@ pub struct RssFeedEntry {
     /// Human-readable name for this feed.
     pub name: String,
     /// URL of the RSS/Atom feed.
-    pub url: String,
+    pub url:  String,
 }
 
 impl Default for SentinelConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled:             false,
             check_interval_secs: 30,
-            rss_feeds: Vec::new(),
-            trump_code_enabled: false,
-            trump_code_url: "https://trumpcode.washinmura.jp".to_string(),
+            rss_feeds:           Vec::new(),
+            trump_code_enabled:  false,
+            trump_code_url:      "https://trumpcode.washinmura.jp".to_string(),
         }
     }
 }
@@ -166,14 +167,14 @@ pub struct ServerConfig {
     /// gRPC server listen address.
     pub listen_addr: String,
     /// gRPC server port.
-    pub port: u16,
+    pub port:        u16,
 }
 
 impl Default for ServerConfig {
     fn default() -> Self {
         Self {
             listen_addr: "127.0.0.1".to_string(),
-            port: 50051,
+            port:        50051,
         }
     }
 }
@@ -219,7 +220,8 @@ fn apply_env_overrides(cfg: &mut AppConfig) {
     {
         cfg.server.port = port;
     }
-    // RARA_BROKER removed — broker is now configured per-account in accounts.toml
+    // RARA_BROKER removed — broker is now configured per-account in
+    // accounts.toml
 }
 
 /// Save config to TOML file.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -29,7 +29,7 @@ pub enum Command {
     /// Run a prompt through the configured agent backend
     Agent {
         /// The prompt to send to the agent
-        prompt: String,
+        prompt:  String,
         /// Override the backend (e.g., "claude", "codex")
         #[arg(long)]
         backend: Option<String>,
@@ -57,7 +57,7 @@ pub enum Command {
         iterations: u32,
         /// gRPC server listen address.
         #[arg(long, default_value = "0.0.0.0:50051")]
-        grpc_addr: String,
+        grpc_addr:  String,
     },
 
     /// Setup and configuration management.
@@ -82,7 +82,8 @@ pub enum Command {
     /// Launch the TUI dashboard.
     ///
     /// When `--server` is provided, connects to an existing gRPC server.
-    /// When omitted, automatically spawns a server subprocess (standalone mode).
+    /// When omitted, automatically spawns a server subprocess (standalone
+    /// mode).
     Tui {
         /// gRPC server address to connect to. Omit for standalone mode.
         #[arg(long)]
@@ -94,7 +95,6 @@ pub enum Command {
         #[command(subcommand)]
         action: FeedbackAction,
     },
-
 
     /// Paper trading operations.
     Paper {
@@ -119,10 +119,9 @@ pub enum FeedbackAction {
         strategy: Option<String>,
         /// Maximum number of entries to show.
         #[arg(long, default_value = "20")]
-        limit: usize,
+        limit:    usize,
     },
 }
-
 
 /// Paper trading subcommands.
 #[derive(Subcommand, Debug)]
@@ -153,10 +152,10 @@ pub enum DataAction {
         symbol: String,
         /// Start date (YYYY-MM-DD).
         #[arg(long)]
-        start: String,
+        start:  String,
         /// End date (YYYY-MM-DD).
         #[arg(long)]
-        end: String,
+        end:    String,
     },
 
     /// Show data coverage for all stored instruments (JSON output).
@@ -173,20 +172,20 @@ pub enum ResearchAction {
         iterations: u32,
         /// Contract to backtest against.
         #[arg(long, default_value = "BTC-USDT")]
-        contract: String,
+        contract:   String,
         /// Path to trace storage directory.
         #[arg(long)]
-        trace_dir: Option<String>,
+        trace_dir:  Option<String>,
         /// Only output final summary, suppress per-iteration progress.
         #[arg(long)]
-        quiet: bool,
+        quiet:      bool,
     },
 
     /// List experiment history from the trace.
     List {
         /// Maximum number of entries to show.
         #[arg(long, default_value = "20")]
-        limit: usize,
+        limit:     usize,
         /// Path to trace storage directory.
         #[arg(long)]
         trace_dir: Option<String>,
@@ -199,7 +198,7 @@ pub enum ResearchAction {
         experiment_id: String,
         /// Path to trace storage directory.
         #[arg(long)]
-        trace_dir: Option<String>,
+        trace_dir:     Option<String>,
     },
 
     /// List promoted strategies.
@@ -239,7 +238,7 @@ pub enum ConfigAction {
     /// Set a config value
     Set {
         /// Config key (e.g. example.setting)
-        key: String,
+        key:   String,
         /// Config value
         value: String,
     },
@@ -276,24 +275,26 @@ pub enum SetupAccountAction {
     /// Add a trading account.
     ///
     /// EXAMPLES:
-    ///     rara setup account add --id paper-btc --broker paper --contracts BTC-USDT --fill-price 50000
-    ///     rara setup account add --id binance-prod --broker ccxt --exchange binance --api-key "$KEY" --secret "$SECRET" --sandbox
+    ///     rara setup account add --id paper-btc --broker paper --contracts
+    /// BTC-USDT --fill-price 50000     rara setup account add --id
+    /// binance-prod --broker ccxt --exchange binance --api-key "$KEY" --secret
+    /// "$SECRET" --sandbox
     Add {
         /// Account identifier.
         #[arg(long)]
-        id: String,
+        id:         String,
         /// Broker type: "paper" or "ccxt".
         #[arg(long)]
-        broker: String,
+        broker:     String,
         /// Human-readable label.
         #[arg(long)]
-        label: Option<String>,
+        label:      Option<String>,
         /// Contracts to trade (comma-separated).
         #[arg(long, value_delimiter = ',')]
-        contracts: Option<Vec<String>>,
+        contracts:  Option<Vec<String>>,
         /// Enable/disable the account.
         #[arg(long, default_value = "true")]
-        enabled: bool,
+        enabled:    bool,
         // Paper broker options
         /// Fixed fill price (paper broker only).
         #[arg(long)]
@@ -301,19 +302,19 @@ pub enum SetupAccountAction {
         // CCXT broker options
         /// Exchange: "binance", "bybit", "okx" (ccxt only).
         #[arg(long)]
-        exchange: Option<String>,
+        exchange:   Option<String>,
         /// API key (ccxt only).
         #[arg(long)]
-        api_key: Option<String>,
+        api_key:    Option<String>,
         /// API secret (ccxt only).
         #[arg(long)]
-        secret: Option<String>,
+        secret:     Option<String>,
         /// API passphrase, OKX only (ccxt only).
         #[arg(long)]
         passphrase: Option<String>,
         /// Use sandbox/testnet (ccxt only).
         #[arg(long)]
-        sandbox: bool,
+        sandbox:    bool,
     },
     /// List configured accounts.
     List,
@@ -323,7 +324,7 @@ pub enum SetupAccountAction {
     ///     rara setup account remove binance-prod --yes
     Remove {
         /// Account ID to remove.
-        id: String,
+        id:  String,
         /// Skip confirmation.
         #[arg(long)]
         yes: bool,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,53 +1,66 @@
 //! Unified daemon orchestrator — runs research, paper trading, feedback, and
 //! gRPC server as concurrent tokio tasks in a single process.
 
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use chrono::NaiveDate;
+use rara_domain::{event::EventType, research::ResearchStrategyStatus};
+use rara_market_data::stream::{
+    aggregator::CandleAggregator,
+    binance_ws::BinanceWsClient,
+    reconnect::{ReconnectConfig, ReconnectingWsClient},
+};
+use rara_sentinel::{
+    analyzer::SignalAnalyzer,
+    engine::SentinelEngine,
+    source::DataSource,
+    sources::{rss::RssDataSource, trump_code::TrumpCodeDataSource},
+};
+use rara_trading_engine::{
+    brokers::paper::PaperBroker,
+    engine::TradingEngine,
+    guard_pipeline::GuardPipeline,
+    signal_loop::{self, LoadedStrategy},
+};
 use rust_decimal_macros::dec;
 use snafu::ResultExt;
 use tokio::task::JoinSet;
 use tracing::{error, info, warn};
 
-use crate::accounts_config;
-use crate::agent::{CliBackend, CliExecutor};
-use crate::app_config;
-use crate::error::{self, AgentBackendSnafu, EventBusSnafu, MarketStoreSnafu, PromptRendererSnafu, TraceSnafu};
-use crate::event_bus::bus::EventBus;
-use crate::paths;
-use crate::research::barter_backtester::BarterBacktester;
-use crate::research::compiler::StrategyCompiler;
-use crate::research::feedback_gen::FeedbackGenerator;
-use crate::research::hypothesis_gen::HypothesisGenerator;
-use crate::research::prompt_renderer::PromptRenderer;
-use crate::research::research_loop::ResearchLoop;
-use crate::research::strategy_coder::StrategyCoder;
-use crate::research::strategy_store::StrategyStore;
-use crate::research::trace::Trace;
-use crate::research::wasm_executor::WasmExecutor;
-use crate::research::wasm_strategy_manager::WasmStrategyManager;
-
-use rara_domain::event::EventType;
-use rara_sentinel::analyzer::SignalAnalyzer;
-use rara_sentinel::engine::SentinelEngine;
-use rara_sentinel::source::DataSource;
-use rara_sentinel::sources::rss::RssDataSource;
-use rara_sentinel::sources::trump_code::TrumpCodeDataSource;
-
-use crate::app_config::SentinelConfig;
+use crate::{
+    accounts_config,
+    agent::{CliBackend, CliExecutor},
+    app_config,
+    app_config::SentinelConfig,
+    error::{
+        self, AgentBackendSnafu, EventBusSnafu, MarketStoreSnafu, PromptRendererSnafu, TraceSnafu,
+    },
+    event_bus::bus::EventBus,
+    paths,
+    research::{
+        barter_backtester::BarterBacktester, compiler::StrategyCompiler,
+        feedback_gen::FeedbackGenerator, hypothesis_gen::HypothesisGenerator,
+        prompt_renderer::PromptRenderer, research_loop::ResearchLoop,
+        strategy_coder::StrategyCoder, strategy_executor::StrategyExecutor,
+        strategy_store::StrategyStore, trace::Trace, wasm_executor::WasmExecutor,
+        wasm_strategy_manager::WasmStrategyManager,
+    },
+};
 
 /// Run the unified daemon: spawn all trading-loop components as concurrent
 /// tokio tasks and wait for shutdown (Ctrl+C) or a fatal task error.
 ///
-/// Accounts and contracts are loaded from `accounts.toml` rather than CLI flags.
+/// Accounts and contracts are loaded from `accounts.toml` rather than CLI
+/// flags.
 pub async fn run(iterations: u32, grpc_addr: String) -> error::Result<()> {
     // Load accounts from config; collect contracts from all enabled accounts
     let accounts_cfg = accounts_config::load_accounts();
-    let _account_manager = rara_trading_engine::account_manager::AccountManager::from_config(
-        &accounts_cfg.accounts,
-    )
-    .expect("failed to initialize accounts from config");
+    let _account_manager =
+        rara_trading_engine::account_manager::AccountManager::from_config(&accounts_cfg.accounts)
+            .expect("failed to initialize accounts from config");
 
     // Persistent event bus shared across all components
     let trace_path = paths::data_dir().join("trace");
@@ -101,12 +114,13 @@ pub async fn run(iterations: u32, grpc_addr: String) -> error::Result<()> {
     for contract in &contract_list {
         let contract = contract.clone();
         let bus = Arc::clone(&event_bus);
+        let trace_path_clone = paths::data_dir().join("trace");
+        let cfg = app_config::load();
         tasks.spawn(async move {
-            info!(contract = %contract, "paper trading placeholder — wire up WS + aggregator + signal loop");
-            // TODO: connect to exchange WS, run candle aggregator, feed
-            // promoted strategies, and publish fills to event bus.
-            let _ = bus;
-            std::future::pending::<()>().await;
+            info!(contract = %contract, "paper trading task starting");
+            if let Err(e) = run_paper_trading(&contract, bus, &trace_path_clone, cfg).await {
+                error!(contract = %contract, error = %e, "paper trading task failed");
+            }
             Ok::<(), error::AppError>(())
         });
     }
@@ -119,7 +133,9 @@ pub async fn run(iterations: u32, grpc_addr: String) -> error::Result<()> {
             info!("feedback loop starting");
             let evaluator = build_strategy_evaluator(&feedback_cfg);
             let loop_config = rara_feedback::feedback_loop::FeedbackLoopConfig::builder()
-                .eval_interval(std::time::Duration::from_secs(feedback_cfg.eval_interval_secs))
+                .eval_interval(std::time::Duration::from_secs(
+                    feedback_cfg.eval_interval_secs,
+                ))
                 .min_trades_between_evals(feedback_cfg.min_trades_between_evals)
                 .build();
             rara_feedback::feedback_loop::run_feedback_loop(bus, evaluator, loop_config).await;
@@ -188,32 +204,32 @@ async fn build_research_loop(
         .await
         .context(MarketStoreSnafu)?;
 
-    let backtester: Arc<dyn crate::research::backtester::Backtester> =
-        Arc::new(BarterBacktester::builder()
+    let backtester: Arc<dyn crate::research::backtester::Backtester> = Arc::new(
+        BarterBacktester::builder()
             .store(market_store)
             .initial_capital(dec!(10000))
             .fees_percent(dec!(0.1))
             .backtest_start(NaiveDate::from_ymd_opt(2020, 1, 1).expect("valid date"))
             .backtest_end(NaiveDate::from_ymd_opt(2030, 12, 31).expect("valid date"))
-            .build());
+            .build(),
+    );
 
-    let cli_backend =
-        CliBackend::from_agent_config(&cfg.agent).context(AgentBackendSnafu)?;
-    let llm: Arc<dyn crate::infra::llm::LlmClient> =
-        Arc::new(CliExecutor::new(cli_backend));
+    let cli_backend = CliBackend::from_agent_config(&cfg.agent).context(AgentBackendSnafu)?;
+    let llm: Arc<dyn crate::infra::llm::LlmClient> = Arc::new(CliExecutor::new(cli_backend));
 
     let strategy_db_path = trace_path.join("strategy_db");
     let artifact_dir = paths::data_dir().join("artifacts");
     let strategy_store = StrategyStore::open_path(&strategy_db_path, &artifact_dir)
         .expect("failed to open strategy store");
 
-    let strategy_manager: Arc<dyn crate::research::strategy_manager::StrategyManager> =
-        Arc::new(WasmStrategyManager::builder()
+    let strategy_manager: Arc<dyn crate::research::strategy_manager::StrategyManager> = Arc::new(
+        WasmStrategyManager::builder()
             .store(strategy_store)
             .coder(StrategyCoder::new(Arc::clone(&llm)))
             .compiler(compiler)
             .executor(WasmExecutor::builder().build())
-            .build());
+            .build(),
+    );
 
     let feedback_gen = FeedbackGenerator::new(Arc::clone(&llm), prompt_renderer);
     let hypothesis_gen = HypothesisGenerator::new(llm);
@@ -250,7 +266,10 @@ async fn run_research_loop(
         info!(cycle, iterations, "research cycle starting");
         run_research_iterations(research_loop, iterations, contract, cycle_delay).await;
 
-        info!(cycle, "research cycle complete — waiting for retrain signal or periodic timeout");
+        info!(
+            cycle,
+            "research cycle complete — waiting for retrain signal or periodic timeout"
+        );
 
         // Wait for a retrain event or the periodic fallback timer
         loop {
@@ -305,7 +324,11 @@ async fn run_research_iterations(
     let mut error_count: u32 = 0;
 
     for i in 1..=iterations {
-        info!(iteration = i, total = iterations, "research iteration starting");
+        info!(
+            iteration = i,
+            total = iterations,
+            "research iteration starting"
+        );
         match research_loop.run_iteration(contract).await {
             Ok(ir) => {
                 if ir.accepted {
@@ -377,7 +400,6 @@ fn has_pending_retrain_events(event_bus: &EventBus) -> bool {
         .any(|e| e.event_type == EventType::FeedbackResearchRetrainRequested)
 }
 
-
 /// Spawn the sentinel monitoring task if enabled in config.
 ///
 /// When enabled, creates a polling loop that periodically checks all
@@ -394,8 +416,7 @@ fn spawn_sentinel_task(tasks: &mut JoinSet<error::Result<()>>, event_bus: &Arc<E
     let cfg = app_config::load();
     tasks.spawn(async move {
         info!("sentinel monitoring starting");
-        let cli_backend =
-            CliBackend::from_agent_config(&cfg.agent).context(AgentBackendSnafu)?;
+        let cli_backend = CliBackend::from_agent_config(&cfg.agent).context(AgentBackendSnafu)?;
         let llm = CliExecutor::new(cli_backend);
         let sources = build_sentinel_sources(&sentinel_cfg);
         let analyzer = SignalAnalyzer::new(llm);
@@ -475,6 +496,178 @@ async fn run_sentinel_loop<L: rara_infra::llm::LlmClient>(
 
         tokio::time::sleep(interval).await;
     }
+}
+
+/// Run paper trading for a single contract.
+///
+/// Connects to Binance WebSocket for live kline data, aggregates into
+/// multi-timeframe candles, loads promoted strategies from the store,
+/// and runs the signal loop to generate and execute trades through a
+/// paper broker.
+async fn run_paper_trading(
+    contract: &str,
+    event_bus: Arc<EventBus>,
+    trace_path: &Path,
+    cfg: &crate::app_config::AppConfig,
+) -> error::Result<()> {
+    // Load promoted strategies from the store
+    let strategies = load_promoted_strategies(trace_path, contract, cfg)?;
+
+    if strategies.is_empty() {
+        info!(
+            contract = %contract,
+            "no promoted strategies found — paper trading will idle until strategies are promoted"
+        );
+        // Block until cancelled; a future enhancement could poll the store periodically
+        std::future::pending::<()>().await;
+        return Ok(());
+    }
+
+    info!(
+        contract = %contract,
+        strategy_count = strategies.len(),
+        "loaded promoted strategies for paper trading"
+    );
+
+    // Set up candle aggregation (5m, 15m, 1h from 1m klines)
+    let (mut aggregator, candle_rx) = CandleAggregator::with_defaults();
+
+    // Set up reconnecting WebSocket client for this contract's 1m klines
+    let ws_client = BinanceWsClient::new();
+    let reconnect_client = ReconnectingWsClient::new(ws_client, ReconnectConfig::default());
+    let mut kline_rx = reconnect_client.subscribe();
+
+    let subscriptions = vec![(contract.to_string(), "1m".to_string())];
+
+    // Spawn the WebSocket connection loop (runs forever with auto-reconnect)
+    let ws_handle = tokio::spawn(async move {
+        reconnect_client.run(subscriptions).await;
+    });
+
+    // Spawn the kline-to-candle aggregation task
+    let agg_handle = tokio::spawn(async move {
+        loop {
+            match kline_rx.recv().await {
+                Ok(kline) => {
+                    aggregator.process_kline(&kline);
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    warn!(
+                        skipped = n,
+                        "kline aggregation lagged — some 1m candles were dropped"
+                    );
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    info!("kline channel closed — aggregation stopping");
+                    break;
+                }
+            }
+        }
+    });
+
+    // Build paper broker + trading engine
+    let paper_broker = PaperBroker::new(rust_decimal::Decimal::ZERO);
+    let guard_pipeline = GuardPipeline::new(vec![]);
+    let engine = Arc::new(TradingEngine::new(
+        Box::new(paper_broker),
+        guard_pipeline,
+        Arc::clone(&event_bus),
+    ));
+
+    // Run the signal loop (blocks until candle channel closes)
+    signal_loop::run_signal_loop(candle_rx, engine, strategies).await;
+
+    // Clean up background tasks
+    ws_handle.abort();
+    agg_handle.abort();
+
+    Ok(())
+}
+
+/// Load promoted strategies from the strategy store and prepare them for
+/// live signal generation.
+///
+/// Reads all strategies with `Promoted` status, loads their WASM artifacts,
+/// and wraps each in a [`LoadedStrategy`] ready for the signal loop.
+fn load_promoted_strategies(
+    trace_path: &Path,
+    contract: &str,
+    cfg: &crate::app_config::AppConfig,
+) -> error::Result<Vec<LoadedStrategy>> {
+    let strategy_db_path = trace_path.join("strategy_db");
+    let artifact_dir = paths::data_dir().join("artifacts");
+    let store = StrategyStore::open_path(&strategy_db_path, &artifact_dir).map_err(|e| {
+        error::AppError::PaperTrading {
+            message: format!("failed to open strategy store: {e}"),
+        }
+    })?;
+
+    let promoted = store
+        .list(Some(ResearchStrategyStatus::Promoted))
+        .map_err(|e| error::AppError::PaperTrading {
+            message: format!("failed to list promoted strategies: {e}"),
+        })?;
+
+    let executor = WasmExecutor::builder().build();
+    let position_size = rust_decimal::Decimal::try_from(cfg.trading.max_position_size)
+        .expect("max_position_size config must be a valid decimal");
+
+    let mut loaded = Vec::new();
+
+    for strategy in &promoted {
+        let artifact = match store.load_artifact(strategy.id) {
+            Ok(a) => a,
+            Err(e) => {
+                warn!(
+                    strategy_id = %strategy.id,
+                    error = %e,
+                    "skipping promoted strategy — failed to load artifact"
+                );
+                continue;
+            }
+        };
+
+        let mut handle = match executor.load(&artifact) {
+            Ok(h) => h,
+            Err(e) => {
+                warn!(
+                    strategy_id = %strategy.id,
+                    error = %e,
+                    "skipping promoted strategy — failed to load WASM module"
+                );
+                continue;
+            }
+        };
+
+        let meta = match handle.meta() {
+            Ok(m) => m,
+            Err(e) => {
+                warn!(
+                    strategy_id = %strategy.id,
+                    error = %e,
+                    "skipping promoted strategy — failed to read metadata"
+                );
+                continue;
+            }
+        };
+
+        info!(
+            strategy_id = %strategy.id,
+            name = meta.name,
+            version = meta.version,
+            "loaded promoted strategy for paper trading"
+        );
+
+        loaded.push(LoadedStrategy {
+            name: meta.name,
+            version: meta.version,
+            contract_id: contract.to_string(),
+            position_size,
+            handle,
+        });
+    }
+
+    Ok(loaded)
 }
 
 /// Build a [`StrategyEvaluator`](rara_feedback::evaluator::StrategyEvaluator)

--- a/src/error.rs
+++ b/src/error.rs
@@ -82,6 +82,18 @@ pub enum AppError {
     Sentinel {
         source: rara_sentinel::engine::SentinelError,
     },
+    #[snafu(display("strategy store error: {source}"))]
+    StrategyStore {
+        source: crate::research::strategy_store::StrategyStoreError,
+    },
+
+    #[snafu(display("strategy executor error: {source}"))]
+    StrategyExecutor {
+        source: rara_research::strategy_executor::ExecutorError,
+    },
+
+    #[snafu(display("paper trading error: {message}"))]
+    PaperTrading { message: String },
 }
 
 pub type Result<T> = std::result::Result<T, AppError>;

--- a/src/http.rs
+++ b/src/http.rs
@@ -9,7 +9,11 @@ static DOWNLOAD_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 pub fn client() -> &'static reqwest::Client {
     HTTP_CLIENT.get_or_init(|| {
         reqwest::Client::builder()
-            .user_agent(concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")))
+            .user_agent(concat!(
+                env!("CARGO_PKG_NAME"),
+                "/",
+                env!("CARGO_PKG_VERSION")
+            ))
             .timeout(Duration::from_secs(30))
             .build()
             .expect("HTTP client initialization should not fail")
@@ -23,7 +27,11 @@ pub fn client() -> &'static reqwest::Client {
 pub fn download_client() -> &'static reqwest::Client {
     DOWNLOAD_CLIENT.get_or_init(|| {
         reqwest::Client::builder()
-            .user_agent(concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")))
+            .user_agent(concat!(
+                env!("CARGO_PKG_NAME"),
+                "/",
+                env!("CARGO_PKG_VERSION")
+            ))
             .connect_timeout(Duration::from_secs(30))
             .no_gzip()
             .no_brotli()

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -7,18 +7,16 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 use tracing_appender::non_blocking::WorkerGuard;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{EnvFilter, Layer};
+use tracing_subscriber::{EnvFilter, Layer, layer::SubscriberExt, util::SubscriberInitExt};
 
 /// Logging configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct LoggingConfig {
     /// Default log level (trace, debug, info, warn, error).
-    pub level: String,
+    pub level:         String,
     /// Path to log file directory. If set, JSON logs are written here.
-    pub log_dir: Option<String>,
+    pub log_dir:       Option<String>,
     /// Log format for stderr: "pretty" or "json".
     pub stderr_format: String,
 }
@@ -26,8 +24,8 @@ pub struct LoggingConfig {
 impl Default for LoggingConfig {
     fn default() -> Self {
         Self {
-            level: "info".to_string(),
-            log_dir: None,
+            level:         "info".to_string(),
+            log_dir:       None,
             stderr_format: "pretty".to_string(),
         }
     }
@@ -93,9 +91,7 @@ pub fn init_logging(config: &LoggingConfig) -> Option<WorkerGuard> {
 
 /// Build an `EnvFilter` from `RUST_LOG`, falling back to the configured level.
 fn build_env_filter(default_level: &str) -> EnvFilter {
-    EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-        EnvFilter::new(default_level)
-    })
+    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_level))
 }
 
 /// Build a pretty-formatted stderr layer.
@@ -126,9 +122,7 @@ where
 ///
 /// Creates the log directory if it does not exist. Log files are
 /// automatically rotated daily with the prefix `rara-trading`.
-fn build_file_layer<S>(
-    dir: &str,
-) -> (impl Layer<S>, WorkerGuard)
+fn build_file_layer<S>(dir: &str) -> (impl Layer<S>, WorkerGuard)
 where
     S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,27 +1,32 @@
 #![allow(clippy::result_large_err)]
 
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use chrono::NaiveDate;
 use clap::Parser;
+use rara_trading::{
+    accounts_config,
+    agent::{CliBackend, CliExecutor},
+    app_config,
+    cli::{
+        Cli, Command, ConfigAction, DataAction, FeedbackAction, PaperAction, ResearchAction,
+        SetupAccountAction, SetupAction, StrategyAction,
+    },
+    error::{
+        self, AgentBackendSnafu, AgentExecutionSnafu, AppError, ConfigSnafu, DataFetchSnafu,
+        EventBusSnafu, GrpcServeSnafu, IoSnafu, MarketStoreSnafu, PromoterSnafu,
+        PromptRendererSnafu, RegistrySnafu, TraceSnafu,
+    },
+    event_bus::bus::EventBus,
+    logging::{self, LoggingConfig},
+    paths, validation,
+};
 use rust_decimal_macros::dec;
 use serde::Serialize;
 use snafu::ResultExt;
-
-use rara_trading::agent::{CliBackend, CliExecutor};
-use rara_trading::app_config;
-use rara_trading::accounts_config;
-use rara_trading::cli::{Cli, Command, ConfigAction, DataAction, FeedbackAction, PaperAction, ResearchAction, SetupAction, SetupAccountAction, StrategyAction};
-use rara_trading::validation;
-use rara_trading::error::{
-    self, AgentBackendSnafu, AgentExecutionSnafu, AppError, ConfigSnafu, DataFetchSnafu,
-    EventBusSnafu, GrpcServeSnafu, IoSnafu, MarketStoreSnafu, PromoterSnafu,
-    PromptRendererSnafu, RegistrySnafu, TraceSnafu,
-};
-use rara_trading::event_bus::bus::EventBus;
-use rara_trading::logging::{self, LoggingConfig};
-use rara_trading::paths;
 use uuid::Uuid;
 
 // ---------------------------------------------------------------------------
@@ -30,247 +35,247 @@ use uuid::Uuid;
 
 #[derive(Serialize)]
 struct ErrorResponse {
-    ok: bool,
-    error: String,
+    ok:         bool,
+    error:      String,
     #[serde(skip_serializing_if = "Option::is_none")]
     suggestion: Option<String>,
 }
 
 #[derive(Serialize)]
 struct ConfigSetResponse<'a> {
-    ok: bool,
+    ok:     bool,
     action: &'static str,
-    key: &'a str,
-    value: &'a str,
+    key:    &'a str,
+    value:  &'a str,
 }
 
 #[derive(Serialize)]
 struct ConfigGetResponse<'a> {
-    ok: bool,
+    ok:     bool,
     action: &'static str,
-    key: &'a str,
-    value: &'a str,
+    key:    &'a str,
+    value:  &'a str,
 }
 
 #[derive(Serialize)]
 struct ConfigListResponse {
-    ok: bool,
-    action: &'static str,
+    ok:      bool,
+    action:  &'static str,
     entries: serde_json::Map<String, serde_json::Value>,
 }
 
 #[derive(Serialize)]
 struct SetupInitResponse {
-    ok: bool,
-    action: &'static str,
+    ok:      bool,
+    action:  &'static str,
     created: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    reason: Option<String>,
+    reason:  Option<String>,
 }
 
 #[derive(Serialize)]
 struct ValidateCheck {
-    name: String,
-    ok: bool,
+    name:       String,
+    ok:         bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    detail: Option<String>,
+    detail:     Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     suggestion: Option<String>,
 }
 
 #[derive(Serialize)]
 struct SetupValidateResponse {
-    ok: bool,
+    ok:     bool,
     action: &'static str,
     checks: Vec<ValidateCheck>,
 }
 
 #[derive(Serialize)]
 struct SetupAccountAddResponse<'a> {
-    ok: bool,
-    action: &'static str,
-    id: &'a str,
+    ok:      bool,
+    action:  &'static str,
+    id:      &'a str,
     created: bool,
 }
 
 #[derive(Serialize)]
 struct SetupAccountListResponse {
-    ok: bool,
-    action: &'static str,
+    ok:       bool,
+    action:   &'static str,
     accounts: Vec<serde_json::Value>,
 }
 
 #[derive(Serialize)]
 struct SetupAccountRemoveResponse<'a> {
-    ok: bool,
-    action: &'static str,
-    id: &'a str,
+    ok:      bool,
+    action:  &'static str,
+    id:      &'a str,
     removed: bool,
 }
 
 #[derive(Serialize)]
 struct SetupAccountTestResponse<'a> {
-    ok: bool,
-    action: &'static str,
-    id: &'a str,
-    equity: String,
+    ok:             bool,
+    action:         &'static str,
+    id:             &'a str,
+    equity:         String,
     available_cash: String,
 }
 
 #[derive(Serialize)]
 struct HelloResponse<'a> {
-    ok: bool,
-    action: &'static str,
+    ok:       bool,
+    action:   &'static str,
     greeting: &'a str,
 }
 
 #[derive(Serialize)]
 struct AgentResponse<'a> {
-    ok: bool,
-    action: &'static str,
+    ok:        bool,
+    action:    &'static str,
     exit_code: Option<i32>,
     timed_out: bool,
-    output: &'a str,
+    output:    &'a str,
 }
 
 #[derive(Serialize)]
 struct IterationResponse<'a> {
-    iteration: u32,
-    accepted: bool,
+    iteration:  u32,
+    accepted:   bool,
     hypothesis: &'a str,
 }
 
 #[derive(Serialize)]
 struct ResearchRunResponse {
-    ok: bool,
-    action: &'static str,
+    ok:         bool,
+    action:     &'static str,
     iterations: u32,
-    accepted: u32,
-    rejected: u32,
-    errors: u32,
+    accepted:   u32,
+    rejected:   u32,
+    errors:     u32,
 }
 
 #[derive(Serialize)]
 struct DataFetchResponse<'a> {
-    ok: bool,
-    action: &'static str,
-    source: &'a str,
-    symbol: &'a str,
+    ok:      bool,
+    action:  &'static str,
+    source:  &'a str,
+    symbol:  &'a str,
     candles: usize,
 }
 
 #[derive(Serialize)]
 struct DataInfoResponse {
-    ok: bool,
-    action: &'static str,
+    ok:          bool,
+    action:      &'static str,
     instruments: Vec<rara_market_data::store::candle::CandleCoverage>,
 }
 
 #[derive(Serialize)]
 struct ExperimentListItem {
-    index: u64,
+    index:         u64,
     experiment_id: String,
-    hypothesis: String,
-    decision: &'static str,
-    sharpe: Option<f64>,
+    hypothesis:    String,
+    decision:      &'static str,
+    sharpe:        Option<f64>,
 }
 
 #[derive(Serialize)]
 struct ResearchListResponse {
-    ok: bool,
-    action: &'static str,
+    ok:          bool,
+    action:      &'static str,
     experiments: Vec<ExperimentListItem>,
 }
 
 #[derive(Serialize)]
 struct HypothesisDetail {
-    id: String,
-    text: String,
-    reason: String,
+    id:          String,
+    text:        String,
+    reason:      String,
     observation: String,
-    knowledge: String,
-    parent: Option<String>,
+    knowledge:   String,
+    parent:      Option<String>,
 }
 
 #[derive(Serialize)]
 struct FeedbackDetail {
-    experiment_id: String,
-    decision: bool,
-    reason: String,
-    observations: String,
+    experiment_id:         String,
+    decision:              bool,
+    reason:                String,
+    observations:          String,
     hypothesis_evaluation: String,
-    new_hypothesis: Option<String>,
-    code_change_summary: String,
+    new_hypothesis:        Option<String>,
+    code_change_summary:   String,
 }
 
 #[derive(Serialize)]
 struct BacktestDetail {
-    pnl: String,
+    pnl:          String,
     sharpe_ratio: f64,
     max_drawdown: String,
-    win_rate: f64,
-    trade_count: u32,
+    win_rate:     f64,
+    trade_count:  u32,
 }
 
 #[derive(Serialize)]
 struct ExperimentDetail {
-    id: String,
-    hypothesis_id: String,
-    status: String,
-    strategy_code: String,
+    id:              String,
+    hypothesis_id:   String,
+    status:          String,
+    strategy_code:   String,
     backtest_result: Option<BacktestDetail>,
 }
 
 #[derive(Serialize)]
 struct ResearchShowResponse {
-    ok: bool,
-    action: &'static str,
+    ok:         bool,
+    action:     &'static str,
     experiment: ExperimentDetail,
     hypothesis: Option<HypothesisDetail>,
-    feedbacks: Vec<FeedbackDetail>,
+    feedbacks:  Vec<FeedbackDetail>,
 }
 
 #[derive(Serialize)]
 struct PromotedItem {
     experiment_id: String,
     hypothesis_id: String,
-    wasm_path: String,
-    source_path: Option<String>,
-    meta: PromotedMeta,
+    wasm_path:     String,
+    source_path:   Option<String>,
+    meta:          PromotedMeta,
 }
 
 #[derive(Serialize)]
 struct PromotedMeta {
-    name: String,
-    version: u32,
+    name:        String,
+    version:     u32,
     api_version: u32,
     description: String,
 }
 
 #[derive(Serialize)]
 struct ResearchPromotedResponse {
-    ok: bool,
-    action: &'static str,
+    ok:         bool,
+    action:     &'static str,
     strategies: Vec<PromotedItem>,
 }
 
 #[derive(Serialize)]
 struct EvaluationEntry {
-    timestamp: String,
-    strategy_id: String,
-    decision: String,
-    reason: String,
+    timestamp:    String,
+    strategy_id:  String,
+    decision:     String,
+    reason:       String,
     sharpe_ratio: f64,
-    win_rate: f64,
-    trade_count: u64,
-    pnl: String,
+    win_rate:     f64,
+    trade_count:  u64,
+    pnl:          String,
     max_drawdown: String,
 }
 
 #[derive(Serialize)]
 struct FeedbackReportResponse {
-    ok: bool,
-    action: &'static str,
+    ok:          bool,
+    action:      &'static str,
     evaluations: Vec<EvaluationEntry>,
 }
 
@@ -278,50 +283,45 @@ struct FeedbackReportResponse {
 #[derive(Serialize)]
 struct StrategyStatus {
     strategy: String,
-    trades: usize,
-    filled: usize,
+    trades:   usize,
+    filled:   usize,
     rejected: usize,
 }
 
 /// Response payload for `paper status`.
 #[derive(Serialize)]
 struct PaperStatusResponse {
-    ok: bool,
-    action: &'static str,
-    strategies: Vec<StrategyStatus>,
+    ok:           bool,
+    action:       &'static str,
+    strategies:   Vec<StrategyStatus>,
     total_trades: usize,
 }
 
 /// Response payload for `paper stop`.
 #[derive(Serialize)]
 struct PaperStopResponse {
-    ok: bool,
-    action: &'static str,
+    ok:      bool,
+    action:  &'static str,
     message: String,
 }
 
 /// Summary printed after graceful shutdown of paper trading.
 #[derive(Serialize)]
 struct PaperShutdownSummary {
-    ok: bool,
-    action: &'static str,
+    ok:            bool,
+    action:        &'static str,
     duration_secs: u64,
-    total_trades: usize,
+    total_trades:  usize,
 }
 
-use rara_trading::research::barter_backtester::BarterBacktester;
-use rara_trading::research::compiler::StrategyCompiler;
-use rara_trading::research::strategy_executor::StrategyExecutor;
-use rara_trading::research::wasm_executor::WasmExecutor;
-use rara_trading::research::feedback_gen::FeedbackGenerator;
-use rara_trading::research::hypothesis_gen::HypothesisGenerator;
-use rara_trading::research::prompt_renderer::PromptRenderer;
-use rara_trading::research::research_loop::ResearchLoop;
-use rara_trading::research::strategy_coder::StrategyCoder;
-use rara_trading::research::strategy_promoter::PromotedStrategy;
-use rara_trading::research::strategy_store::StrategyStore;
-use rara_trading::research::trace::Trace;
-use rara_trading::research::wasm_strategy_manager::WasmStrategyManager;
+use rara_trading::research::{
+    barter_backtester::BarterBacktester, compiler::StrategyCompiler,
+    feedback_gen::FeedbackGenerator, hypothesis_gen::HypothesisGenerator,
+    prompt_renderer::PromptRenderer, research_loop::ResearchLoop, strategy_coder::StrategyCoder,
+    strategy_executor::StrategyExecutor, strategy_promoter::PromotedStrategy,
+    strategy_store::StrategyStore, trace::Trace, wasm_executor::WasmExecutor,
+    wasm_strategy_manager::WasmStrategyManager,
+};
 
 #[tokio::main]
 async fn main() {
@@ -334,8 +334,8 @@ async fn main() {
         println!(
             "{}",
             serde_json::to_string(&ErrorResponse {
-                ok: false,
-                error: e.to_string(),
+                ok:         false,
+                error:      e.to_string(),
                 suggestion: None,
             })
             .expect("ErrorResponse must serialize")
@@ -358,10 +358,10 @@ async fn run() -> error::Result<()> {
                 println!(
                     "{}",
                     serde_json::to_string(&ConfigSetResponse {
-                        ok: true,
+                        ok:     true,
                         action: "config_set",
-                        key: &key,
-                        value: &value,
+                        key:    &key,
+                        value:  &value,
                     })
                     .expect("ConfigSetResponse must serialize")
                 );
@@ -373,10 +373,10 @@ async fn run() -> error::Result<()> {
                 println!(
                     "{}",
                     serde_json::to_string(&ConfigGetResponse {
-                        ok: true,
+                        ok:     true,
                         action: "config_get",
-                        key: &key,
-                        value: display_value,
+                        key:    &key,
+                        value:  display_value,
                     })
                     .expect("ConfigGetResponse must serialize")
                 );
@@ -391,8 +391,8 @@ async fn run() -> error::Result<()> {
                 println!(
                     "{}",
                     serde_json::to_string(&ConfigListResponse {
-                        ok: true,
-                        action: "config_list",
+                        ok:      true,
+                        action:  "config_list",
                         entries: map,
                     })
                     .expect("ConfigListResponse must serialize")
@@ -405,8 +405,8 @@ async fn run() -> error::Result<()> {
             println!(
                 "{}",
                 serde_json::to_string(&HelloResponse {
-                    ok: true,
-                    action: "hello",
+                    ok:       true,
+                    action:   "hello",
                     greeting: &greeting,
                 })
                 .expect("HelloResponse must serialize")
@@ -424,7 +424,10 @@ async fn run() -> error::Result<()> {
         } => {
             rara_trading::daemon::run(iterations, grpc_addr).await?;
         }
-        Command::Setup { interactive, action } => {
+        Command::Setup {
+            interactive,
+            action,
+        } => {
             if interactive {
                 rara_trading::setup_wizard::run().await?;
             } else if let Some(action) = action {
@@ -440,7 +443,9 @@ async fn run() -> error::Result<()> {
         Command::Tui { server } => {
             rara_tui::event_loop::run(server.as_deref(), crate::paths::strategies_promoted_dir())
                 .await
-                .map_err(|e| AppError::Tui { source: Box::new(e) })?;
+                .map_err(|e| AppError::Tui {
+                    source: Box::new(e),
+                })?;
         }
         Command::Feedback { action } => {
             run_feedback(action)?;
@@ -482,11 +487,11 @@ async fn run() -> error::Result<()> {
             println!(
                 "{}",
                 serde_json::to_string(&AgentResponse {
-                    ok: result.success,
-                    action: "agent_run",
+                    ok:        result.success,
+                    action:    "agent_run",
                     exit_code: result.exit_code,
                     timed_out: result.timed_out,
-                    output: &result.output,
+                    output:    &result.output,
                 })
                 .expect("AgentResponse must serialize")
             );
@@ -555,7 +560,12 @@ fn set_config_field(cfg: &mut app_config::AppConfig, key: &str, value: &str) -> 
         "server.port" => {
             cfg.server.port = value.parse().map_err(|_| parse_err(key, value))?;
         }
-        _ => return ConfigSnafu { message: format!("unknown config key: {key}") }.fail(),
+        _ => {
+            return ConfigSnafu {
+                message: format!("unknown config key: {key}"),
+            }
+            .fail();
+        }
     }
     Ok(())
 }
@@ -590,13 +600,14 @@ fn get_config_field(cfg: &app_config::AppConfig, key: &str) -> error::Result<Opt
         }
         // sentinel
         "sentinel.enabled" => Ok(Some(cfg.sentinel.enabled.to_string())),
-        "sentinel.check_interval_secs" => {
-            Ok(Some(cfg.sentinel.check_interval_secs.to_string()))
-        }
+        "sentinel.check_interval_secs" => Ok(Some(cfg.sentinel.check_interval_secs.to_string())),
         // server
         "server.listen_addr" => Ok(Some(cfg.server.listen_addr.clone())),
         "server.port" => Ok(Some(cfg.server.port.to_string())),
-        _ => ConfigSnafu { message: format!("unknown config key: {key}") }.fail(),
+        _ => ConfigSnafu {
+            message: format!("unknown config key: {key}"),
+        }
+        .fail(),
     }
 }
 
@@ -663,10 +674,7 @@ fn config_as_map(cfg: &app_config::AppConfig) -> Vec<(String, String)> {
             cfg.feedback.max_drawdown_for_retirement.to_string(),
         ),
         // sentinel
-        (
-            "sentinel.enabled".into(),
-            cfg.sentinel.enabled.to_string(),
-        ),
+        ("sentinel.enabled".into(), cfg.sentinel.enabled.to_string()),
         (
             "sentinel.check_interval_secs".into(),
             cfg.sentinel.check_interval_secs.to_string(),
@@ -683,7 +691,6 @@ fn run_feedback(action: FeedbackAction) -> error::Result<()> {
         FeedbackAction::Report { strategy, limit } => {
             run_feedback_report(strategy.as_deref(), limit)
         }
-
     }
 }
 
@@ -704,35 +711,19 @@ fn run_feedback_report(strategy: Option<&str>, limit: usize) -> error::Result<()
 
     let mut entries: Vec<EvaluationEntry> = events
         .into_iter()
-        .filter(|e| {
-            strategy.is_none_or(|s| e.strategy_id.as_deref() == Some(s))
-        })
+        .filter(|e| strategy.is_none_or(|s| e.strategy_id.as_deref() == Some(s)))
         .map(|e| {
             let p = &e.payload;
             EvaluationEntry {
-                timestamp: e.timestamp.to_string(),
-                strategy_id: e
-                    .strategy_id
-                    .unwrap_or_else(|| "unknown".to_owned()),
-                decision: p["decision"]
-                    .as_str()
-                    .unwrap_or("unknown")
-                    .to_owned(),
-                reason: p["reason"]
-                    .as_str()
-                    .unwrap_or("")
-                    .to_owned(),
+                timestamp:    e.timestamp.to_string(),
+                strategy_id:  e.strategy_id.unwrap_or_else(|| "unknown".to_owned()),
+                decision:     p["decision"].as_str().unwrap_or("unknown").to_owned(),
+                reason:       p["reason"].as_str().unwrap_or("").to_owned(),
                 sharpe_ratio: p["sharpe_ratio"].as_f64().unwrap_or(0.0),
-                win_rate: p["win_rate"].as_f64().unwrap_or(0.0),
-                trade_count: p["trade_count"].as_u64().unwrap_or(0),
-                pnl: p["pnl"]
-                    .as_str()
-                    .unwrap_or("0")
-                    .to_owned(),
-                max_drawdown: p["max_drawdown"]
-                    .as_str()
-                    .unwrap_or("0")
-                    .to_owned(),
+                win_rate:     p["win_rate"].as_f64().unwrap_or(0.0),
+                trade_count:  p["trade_count"].as_u64().unwrap_or(0),
+                pnl:          p["pnl"].as_str().unwrap_or("0").to_owned(),
+                max_drawdown: p["max_drawdown"].as_str().unwrap_or("0").to_owned(),
             }
         })
         .collect();
@@ -754,10 +745,7 @@ fn run_feedback_report(strategy: Option<&str>, limit: usize) -> error::Result<()
         // Format PnL with sign
         let pnl = format_pnl(&entry.pnl);
         // Truncate timestamp to minutes
-        let ts = entry
-            .timestamp
-            .get(..16)
-            .unwrap_or(&entry.timestamp);
+        let ts = entry.timestamp.get(..16).unwrap_or(&entry.timestamp);
         eprintln!(
             "{:<24} {:<16} {:<9} {:>7.2} {:>9} {:>7} {:>7} {:>10}",
             ts,
@@ -774,8 +762,8 @@ fn run_feedback_report(strategy: Option<&str>, limit: usize) -> error::Result<()
     println!(
         "{}",
         serde_json::to_string(&FeedbackReportResponse {
-            ok: true,
-            action: "feedback.report",
+            ok:          true,
+            action:      "feedback.report",
             evaluations: entries,
         })
         .expect("FeedbackReportResponse must serialize")
@@ -783,13 +771,15 @@ fn run_feedback_report(strategy: Option<&str>, limit: usize) -> error::Result<()
     Ok(())
 }
 
-/// Format a drawdown decimal string as a negative percentage (e.g. "0.05" -> "-5.0%").
+/// Format a drawdown decimal string as a negative percentage (e.g. "0.05" ->
+/// "-5.0%").
 fn format_drawdown(dd: &str) -> String {
     dd.parse::<f64>()
         .map_or_else(|_| dd.to_owned(), |v| format!("-{:.1}%", v * 100.0))
 }
 
-/// Format a `PnL` string with a sign prefix (e.g. "234.50" -> "+$234", "-124" -> "-$124").
+/// Format a `PnL` string with a sign prefix (e.g. "234.50" -> "+$234", "-124"
+/// -> "-$124").
 fn format_pnl(pnl: &str) -> String {
     pnl.parse::<f64>().map_or_else(
         |_| pnl.to_owned(),
@@ -817,22 +807,15 @@ async fn run_data(action: DataAction) -> error::Result<()> {
 }
 
 /// Fetch historical market data from an exchange into `TimescaleDB`.
-async fn run_data_fetch(
-    source: &str,
-    symbol: &str,
-    start: &str,
-    end: &str,
-) -> error::Result<()> {
-    let start_date = NaiveDate::parse_from_str(start, "%Y-%m-%d").map_err(|_| {
-        error::AppError::Config {
+async fn run_data_fetch(source: &str, symbol: &str, start: &str, end: &str) -> error::Result<()> {
+    let start_date =
+        NaiveDate::parse_from_str(start, "%Y-%m-%d").map_err(|_| error::AppError::Config {
             message: format!("invalid start date: {start}"),
-        }
-    })?;
-    let end_date = NaiveDate::parse_from_str(end, "%Y-%m-%d").map_err(|_| {
-        error::AppError::Config {
+        })?;
+    let end_date =
+        NaiveDate::parse_from_str(end, "%Y-%m-%d").map_err(|_| error::AppError::Config {
             message: format!("invalid end date: {end}"),
-        }
-    })?;
+        })?;
 
     let cfg = app_config::load();
     let store = rara_market_data::store::MarketStore::connect(&cfg.database.url)
@@ -887,8 +870,8 @@ async fn run_data_info() -> error::Result<()> {
     println!(
         "{}",
         serde_json::to_string(&DataInfoResponse {
-            ok: true,
-            action: "data.info",
+            ok:          true,
+            action:      "data.info",
             instruments: coverage,
         })
         .expect("DataInfoResponse must serialize")
@@ -934,19 +917,19 @@ async fn build_research_loop(trace_path: &Path) -> error::Result<ResearchLoop> {
         .await
         .context(MarketStoreSnafu)?;
 
-    let backtester: Arc<dyn rara_trading::research::backtester::Backtester> =
-        Arc::new(BarterBacktester::builder()
+    let backtester: Arc<dyn rara_trading::research::backtester::Backtester> = Arc::new(
+        BarterBacktester::builder()
             .store(market_store)
             .initial_capital(dec!(10000))
             .fees_percent(dec!(0.1))
             .backtest_start(NaiveDate::from_ymd_opt(2020, 1, 1).expect("valid date"))
             .backtest_end(NaiveDate::from_ymd_opt(2030, 12, 31).expect("valid date"))
-            .build());
+            .build(),
+    );
 
     let cli_backend =
         CliBackend::from_agent_config(&cfg.agent).context(error::AgentBackendSnafu)?;
-    let llm: Arc<dyn rara_trading::infra::llm::LlmClient> =
-        Arc::new(CliExecutor::new(cli_backend));
+    let llm: Arc<dyn rara_trading::infra::llm::LlmClient> = Arc::new(CliExecutor::new(cli_backend));
 
     let strategy_db_path = trace_path.join("strategy_db");
     let artifact_dir = paths::data_dir().join("artifacts");
@@ -954,12 +937,14 @@ async fn build_research_loop(trace_path: &Path) -> error::Result<ResearchLoop> {
         .expect("failed to open strategy store");
 
     let strategy_manager: Arc<dyn rara_trading::research::strategy_manager::StrategyManager> =
-        Arc::new(WasmStrategyManager::builder()
-            .store(strategy_store)
-            .coder(StrategyCoder::new(Arc::clone(&llm)))
-            .compiler(compiler)
-            .executor(WasmExecutor::builder().build())
-            .build());
+        Arc::new(
+            WasmStrategyManager::builder()
+                .store(strategy_store)
+                .coder(StrategyCoder::new(Arc::clone(&llm)))
+                .compiler(compiler)
+                .executor(WasmExecutor::builder().build())
+                .build(),
+        );
 
     let feedback_gen = FeedbackGenerator::new(Arc::clone(&llm), prompt_renderer);
     let hypothesis_gen = HypothesisGenerator::new(llm);
@@ -991,7 +976,11 @@ async fn run_research_loop(
     let mut error_count: u32 = 0;
 
     for i in 1..=iterations {
-        tracing::info!(iteration = i, total = iterations, "research iteration starting");
+        tracing::info!(
+            iteration = i,
+            total = iterations,
+            "research iteration starting"
+        );
         let result = research_loop.run_iteration(contract).await;
         match result {
             Ok(ir) => {
@@ -1030,8 +1019,8 @@ async fn run_research_loop(
                 println!(
                     "{}",
                     serde_json::to_string(&IterationResponse {
-                        iteration: i,
-                        accepted: ir.accepted,
+                        iteration:  i,
+                        accepted:   ir.accepted,
                         hypothesis: &ir.hypothesis.text,
                     })
                     .expect("IterationResponse must serialize")
@@ -1053,7 +1042,10 @@ async fn run_research_loop(
     }
 
     eprintln!("=== Research Summary ===");
-    eprintln!("Total: {iterations} | Accepted: {accepted_count} | Rejected: {rejected_count} | Errors: {error_count}");
+    eprintln!(
+        "Total: {iterations} | Accepted: {accepted_count} | Rejected: {rejected_count} | Errors: \
+         {error_count}"
+    );
 
     println!(
         "{}",
@@ -1087,11 +1079,7 @@ fn run_research_list(limit: usize, trace_dir: Option<String>) -> error::Result<(
                 .map_or_else(|| "unknown".to_owned(), |h| h.text);
 
             let decision = fb.as_ref().map_or("no feedback", |f| {
-                if f.decision {
-                    "accepted"
-                } else {
-                    "rejected"
-                }
+                if f.decision { "accepted" } else { "rejected" }
             });
 
             let sharpe = exp
@@ -1112,8 +1100,8 @@ fn run_research_list(limit: usize, trace_dir: Option<String>) -> error::Result<(
     println!(
         "{}",
         serde_json::to_string(&ResearchListResponse {
-            ok: true,
-            action: "research.list",
+            ok:          true,
+            action:      "research.list",
             experiments: items,
         })
         .expect("ResearchListResponse must serialize")
@@ -1146,49 +1134,49 @@ fn run_research_show(experiment_id: &str, trace_dir: Option<String>) -> error::R
         .context(TraceSnafu)?;
 
     let hyp_detail = hypothesis.map(|h| HypothesisDetail {
-        id: h.id.to_string(),
-        text: h.text,
-        reason: h.reason,
+        id:          h.id.to_string(),
+        text:        h.text,
+        reason:      h.reason,
         observation: h.observation,
-        knowledge: h.knowledge,
-        parent: h.parent.map(|p| p.to_string()),
+        knowledge:   h.knowledge,
+        parent:      h.parent.map(|p| p.to_string()),
     });
 
     let fb_details: Vec<FeedbackDetail> = feedbacks
         .iter()
         .map(|fb| FeedbackDetail {
-            experiment_id: fb.experiment_id.to_string(),
-            decision: fb.decision,
-            reason: fb.reason.clone(),
-            observations: fb.observations.clone(),
+            experiment_id:         fb.experiment_id.to_string(),
+            decision:              fb.decision,
+            reason:                fb.reason.clone(),
+            observations:          fb.observations.clone(),
             hypothesis_evaluation: fb.hypothesis_evaluation.clone(),
-            new_hypothesis: fb.new_hypothesis.clone(),
-            code_change_summary: fb.code_change_summary.clone(),
+            new_hypothesis:        fb.new_hypothesis.clone(),
+            code_change_summary:   fb.code_change_summary.clone(),
         })
         .collect();
 
     let backtest_detail = exp.backtest_result.as_ref().map(|br| BacktestDetail {
-        pnl: br.pnl.to_string(),
+        pnl:          br.pnl.to_string(),
         sharpe_ratio: br.sharpe_ratio,
         max_drawdown: br.max_drawdown.to_string(),
-        win_rate: br.win_rate,
-        trade_count: br.trade_count,
+        win_rate:     br.win_rate,
+        trade_count:  br.trade_count,
     });
 
     println!(
         "{}",
         serde_json::to_string(&ResearchShowResponse {
-            ok: true,
-            action: "research.show",
+            ok:         true,
+            action:     "research.show",
             experiment: ExperimentDetail {
-                id: exp.id.to_string(),
-                hypothesis_id: exp.hypothesis_id.to_string(),
-                status: exp.status.to_string(),
-                strategy_code: exp.strategy_code,
+                id:              exp.id.to_string(),
+                hypothesis_id:   exp.hypothesis_id.to_string(),
+                status:          exp.status.to_string(),
+                strategy_code:   exp.strategy_code,
                 backtest_result: backtest_detail,
             },
             hypothesis: hyp_detail,
-            feedbacks: fb_details,
+            feedbacks:  fb_details,
         })
         .expect("ResearchShowResponse must serialize")
     );
@@ -1206,11 +1194,11 @@ fn run_research_promoted(promoted_dir: Option<String>) -> error::Result<()> {
         .map(|p| PromotedItem {
             experiment_id: p.experiment_id().to_string(),
             hypothesis_id: p.hypothesis_id().to_string(),
-            wasm_path: p.wasm_path().to_string_lossy().into_owned(),
-            source_path: p.source_path().map(|s| s.to_string_lossy().into_owned()),
-            meta: PromotedMeta {
-                name: p.meta().name.clone(),
-                version: p.meta().version,
+            wasm_path:     p.wasm_path().to_string_lossy().into_owned(),
+            source_path:   p.source_path().map(|s| s.to_string_lossy().into_owned()),
+            meta:          PromotedMeta {
+                name:        p.meta().name.clone(),
+                version:     p.meta().version,
                 api_version: p.meta().api_version,
                 description: p.meta().description.clone(),
             },
@@ -1220,8 +1208,8 @@ fn run_research_promoted(promoted_dir: Option<String>) -> error::Result<()> {
     println!(
         "{}",
         serde_json::to_string(&ResearchPromotedResponse {
-            ok: true,
-            action: "research.promoted",
+            ok:         true,
+            action:     "research.promoted",
             strategies: items,
         })
         .expect("ResearchPromotedResponse must serialize")
@@ -1235,12 +1223,12 @@ fn run_research_promoted(promoted_dir: Option<String>) -> error::Result<()> {
 /// point: gRPC server + market data WebSocket connection so that all TUI
 /// health indicators reflect real service state.
 async fn run_serve(port: u16) -> error::Result<()> {
-    use std::sync::atomic::AtomicBool;
-    use std::sync::Arc;
+    use std::sync::{Arc, atomic::AtomicBool};
 
-    use rara_server::health::HealthConfig;
-    use rara_server::rara_proto::rara_service_server::RaraServiceServer;
-    use rara_server::service::RaraServiceImpl;
+    use rara_server::{
+        health::HealthConfig, rara_proto::rara_service_server::RaraServiceServer,
+        service::RaraServiceImpl,
+    };
 
     let cfg = crate::app_config::load();
 
@@ -1256,9 +1244,9 @@ async fn run_serve(port: u16) -> error::Result<()> {
         .collect();
 
     let health_config = HealthConfig {
-        database_url: cfg.database.url.clone(),
-        llm_backend: cfg.agent.backend.clone(),
-        ws_connected: Arc::clone(&ws_connected),
+        database_url:   cfg.database.url.clone(),
+        llm_backend:    cfg.agent.backend.clone(),
+        ws_connected:   Arc::clone(&ws_connected),
         contract_count: u32::try_from(contracts.len()).unwrap_or(u32::MAX),
     };
 
@@ -1279,9 +1267,9 @@ async fn run_serve(port: u16) -> error::Result<()> {
     eprintln!("gRPC server listening on {addr}");
 
     tonic::transport::Server::builder()
-        .add_service(RaraServiceServer::new(
-            RaraServiceImpl::with_health(health_config),
-        ))
+        .add_service(RaraServiceServer::new(RaraServiceImpl::with_health(
+            health_config,
+        )))
         .serve(addr)
         .await
         .context(GrpcServeSnafu)?;
@@ -1309,7 +1297,8 @@ async fn run_market_data_ws(contracts: Vec<String>, ws_flag: Arc<std::sync::atom
     let max_backoff = std::time::Duration::from_secs(60);
 
     loop {
-        let sub_refs: Vec<(&str, &str)> = subs.iter().map(|(s, i)| (s.as_str(), i.as_str())).collect();
+        let sub_refs: Vec<(&str, &str)> =
+            subs.iter().map(|(s, i)| (s.as_str(), i.as_str())).collect();
 
         match client.subscribe_klines_multi(&sub_refs).await {
             Ok(mut stream) => {
@@ -1338,7 +1327,6 @@ async fn run_market_data_ws(contracts: Vec<String>, ws_flag: Arc<std::sync::atom
     }
 }
 
-
 /// Execute the paper trading subcommand.
 async fn run_paper(action: PaperAction) -> error::Result<()> {
     match action {
@@ -1356,8 +1344,9 @@ async fn run_paper(action: PaperAction) -> error::Result<()> {
 /// Aggregates order-submitted, order-filled, and order-rejected events by
 /// strategy and prints a summary table to stderr plus JSON to stdout.
 fn run_paper_status() -> error::Result<()> {
-    use rara_domain::event::EventType;
     use std::collections::BTreeMap;
+
+    use rara_domain::event::EventType;
 
     let trace_path = paths::data_dir().join("trace");
     let event_bus_path = trace_path.join("events");
@@ -1367,9 +1356,9 @@ fn run_paper_status() -> error::Result<()> {
         println!(
             "{}",
             serde_json::to_string(&PaperStatusResponse {
-                ok: true,
-                action: "paper.status",
-                strategies: vec![],
+                ok:           true,
+                action:       "paper.status",
+                strategies:   vec![],
                 total_trades: 0,
             })
             .expect("PaperStatusResponse must serialize")
@@ -1378,7 +1367,10 @@ fn run_paper_status() -> error::Result<()> {
     }
 
     let event_bus = EventBus::open(&event_bus_path).context(EventBusSnafu)?;
-    let events = event_bus.store().read_topic("trading", 0, 100_000).context(EventBusSnafu)?;
+    let events = event_bus
+        .store()
+        .read_topic("trading", 0, 100_000)
+        .context(EventBusSnafu)?;
 
     // Aggregate by strategy_id
     let mut stats: BTreeMap<String, (usize, usize, usize)> = BTreeMap::new();
@@ -1444,9 +1436,9 @@ fn run_paper_status() -> error::Result<()> {
 /// the terminal where `paper start` is running. This command simply prints
 /// that guidance.
 fn run_paper_stop() {
-    let message =
-        "Paper trading runs in the foreground. Press Ctrl+C in the terminal where it's running."
-            .to_string();
+    let message = "Paper trading runs in the foreground. Press Ctrl+C in the terminal where it's \
+                   running."
+        .to_string();
     eprintln!("{message}");
     println!(
         "{}",
@@ -1522,23 +1514,23 @@ fn load_strategies_for_contracts(
 #[allow(clippy::too_many_lines)]
 async fn run_paper_start() -> error::Result<()> {
     use futures_util::StreamExt;
-    use rara_trading::trading::engine::TradingEngine;
-    use rara_trading::trading::guard_pipeline::GuardPipeline;
-    use rara_trading::trading::signal_loop::run_signal_loop;
-    use rara_market_data::stream::aggregator::CandleAggregator;
-    use rara_market_data::stream::binance_ws::BinanceWsClient;
+    use rara_market_data::stream::{aggregator::CandleAggregator, binance_ws::BinanceWsClient};
+    use rara_trading::trading::{
+        engine::TradingEngine, guard_pipeline::GuardPipeline, signal_loop::run_signal_loop,
+    };
 
     let cfg = app_config::load();
 
     // Load accounts from config; use AccountManager to create brokers
     let accounts_cfg = accounts_config::load_accounts();
-    let account_manager = rara_trading_engine::account_manager::AccountManager::from_config(
-        &accounts_cfg.accounts,
-    )
-    .expect("failed to initialize accounts from config");
+    let account_manager =
+        rara_trading_engine::account_manager::AccountManager::from_config(&accounts_cfg.accounts)
+            .expect("failed to initialize accounts from config");
 
     if account_manager.size() == 0 {
-        eprintln!("No enabled accounts found in accounts.toml. Run 'rara setup account add' first.");
+        eprintln!(
+            "No enabled accounts found in accounts.toml. Run 'rara setup account add' first."
+        );
         return Ok(());
     }
 
@@ -1579,14 +1571,20 @@ async fn run_paper_start() -> error::Result<()> {
         let fields = first_account.broker_config.to_field_map();
         let type_key = first_account.broker_config.type_key();
         let entry = rara_trading_engine::broker_registry::find_broker(type_key)
-            .ok_or_else(|| rara_trading_engine::broker_registry::BrokerRegistryError::UnknownType {
-                type_key: type_key.to_string(),
-            })
+            .ok_or_else(
+                || rara_trading_engine::broker_registry::BrokerRegistryError::UnknownType {
+                    type_key: type_key.to_string(),
+                },
+            )
             .context(error::BrokerRegistrySnafu)?;
         (entry.create_broker)(&fields).context(error::BrokerRegistrySnafu)?
     };
     let guard_pipeline = GuardPipeline::new(vec![]);
-    let engine = Arc::new(TradingEngine::new(broker, guard_pipeline, Arc::clone(&event_bus)));
+    let engine = Arc::new(TradingEngine::new(
+        broker,
+        guard_pipeline,
+        Arc::clone(&event_bus),
+    ));
 
     // Shutdown signal via watch channel — tasks check this to drain gracefully
     let (shutdown_tx, mut shutdown_rx_agg) = tokio::sync::watch::channel(false);
@@ -1596,12 +1594,13 @@ async fn run_paper_start() -> error::Result<()> {
     let (mut aggregator, candle_rx) = CandleAggregator::with_defaults();
     let ws_client = BinanceWsClient::new();
     let subs: Vec<(&str, &str)> = contracts.iter().map(|c| (c.as_str(), "1m")).collect();
-    let mut kline_stream = ws_client
-        .subscribe_klines_multi(&subs)
-        .await
-        .map_err(|e| error::AppError::Config {
-            message: format!("WebSocket connection failed: {e}"),
-        })?;
+    let mut kline_stream =
+        ws_client
+            .subscribe_klines_multi(&subs)
+            .await
+            .map_err(|e| error::AppError::Config {
+                message: format!("WebSocket connection failed: {e}"),
+            })?;
 
     // Spawn aggregator: forward raw klines into candle aggregator, exit on shutdown
     let agg_handle = tokio::spawn(async move {
@@ -1702,7 +1701,9 @@ async fn run_paper_start() -> error::Result<()> {
 fn list_promoted_from_dir(
     dir: &Path,
 ) -> rara_trading::research::strategy_promoter::Result<Vec<PromotedStrategy>> {
-    use rara_trading::research::strategy_promoter::{IoSnafu as PmIoSnafu, SerializeSnafu as PmSerializeSnafu};
+    use rara_trading::research::strategy_promoter::{
+        IoSnafu as PmIoSnafu, SerializeSnafu as PmSerializeSnafu,
+    };
 
     if !dir.exists() {
         return Ok(vec![]);
@@ -1732,42 +1733,42 @@ fn list_promoted_from_dir(
 
 #[derive(Serialize)]
 struct StrategyListResponse {
-    ok: bool,
-    action: &'static str,
+    ok:         bool,
+    action:     &'static str,
     strategies: Vec<StrategyListItem>,
 }
 
 #[derive(Serialize)]
 struct StrategyListItem {
-    name: String,
+    name:    String,
     version: String,
-    tag: String,
-    size: u64,
+    tag:     String,
+    size:    u64,
 }
 
 #[derive(Serialize)]
 struct StrategyFetchResponse {
-    ok: bool,
-    action: &'static str,
-    name: String,
-    version: String,
+    ok:          bool,
+    action:      &'static str,
+    name:        String,
+    version:     String,
     api_version: u32,
-    wasm_path: String,
+    wasm_path:   String,
 }
 
 #[derive(Serialize)]
 struct StrategyInstalledResponse {
-    ok: bool,
-    action: &'static str,
+    ok:         bool,
+    action:     &'static str,
     strategies: Vec<StrategyInstalledItem>,
 }
 
 #[derive(Serialize)]
 struct StrategyInstalledItem {
-    name: String,
-    version: String,
+    name:        String,
+    version:     String,
     api_version: u32,
-    wasm_path: String,
+    wasm_path:   String,
 }
 
 async fn run_strategy(action: StrategyAction) -> error::Result<()> {
@@ -1789,18 +1790,18 @@ async fn run_strategy_list(repo: &str) -> error::Result<()> {
     let items: Vec<StrategyListItem> = entries
         .iter()
         .map(|e| StrategyListItem {
-            name: e.name.clone(),
+            name:    e.name.clone(),
             version: e.version.clone(),
-            tag: e.tag.clone(),
-            size: e.size,
+            tag:     e.tag.clone(),
+            size:    e.size,
         })
         .collect();
 
     println!(
         "{}",
         serde_json::to_string(&StrategyListResponse {
-            ok: true,
-            action: "strategy.list",
+            ok:         true,
+            action:     "strategy.list",
             strategies: items,
         })
         .expect("StrategyListResponse must serialize")
@@ -1823,12 +1824,12 @@ async fn run_strategy_fetch(name: &str, repo: &str) -> error::Result<()> {
     println!(
         "{}",
         serde_json::to_string(&StrategyFetchResponse {
-            ok: true,
-            action: "strategy.fetch",
-            name: fetched.meta.name,
-            version: format!("v{}", fetched.meta.version),
+            ok:          true,
+            action:      "strategy.fetch",
+            name:        fetched.meta.name,
+            version:     format!("v{}", fetched.meta.version),
             api_version: fetched.meta.api_version,
-            wasm_path: fetched.wasm_path.display().to_string(),
+            wasm_path:   fetched.wasm_path.display().to_string(),
         })
         .expect("StrategyFetchResponse must serialize")
     );
@@ -1846,18 +1847,18 @@ fn run_strategy_installed() -> error::Result<()> {
     let items: Vec<StrategyInstalledItem> = installed
         .iter()
         .map(|s| StrategyInstalledItem {
-            name: s.meta.name.clone(),
-            version: format!("v{}", s.meta.version),
+            name:        s.meta.name.clone(),
+            version:     format!("v{}", s.meta.version),
             api_version: s.meta.api_version,
-            wasm_path: s.wasm_path.display().to_string(),
+            wasm_path:   s.wasm_path.display().to_string(),
         })
         .collect();
 
     println!(
         "{}",
         serde_json::to_string(&StrategyInstalledResponse {
-            ok: true,
-            action: "strategy.installed",
+            ok:         true,
+            action:     "strategy.installed",
             strategies: items,
         })
         .expect("StrategyInstalledResponse must serialize")
@@ -1941,9 +1942,9 @@ async fn run_setup_validate() -> error::Result<()> {
     let config_path = paths::config_file();
     let config_exists = config_path.exists();
     checks.push(ValidateCheck {
-        name: "config.toml".to_string(),
-        ok: config_exists,
-        detail: if config_exists {
+        name:       "config.toml".to_string(),
+        ok:         config_exists,
+        detail:     if config_exists {
             None
         } else {
             has_errors = true;
@@ -1960,9 +1961,9 @@ async fn run_setup_validate() -> error::Result<()> {
     let accounts_path = paths::accounts_file();
     let accounts_exists = accounts_path.exists();
     checks.push(ValidateCheck {
-        name: "accounts.toml".to_string(),
-        ok: accounts_exists,
-        detail: if accounts_exists {
+        name:       "accounts.toml".to_string(),
+        ok:         accounts_exists,
+        detail:     if accounts_exists {
             None
         } else {
             has_errors = true;
@@ -1986,9 +1987,9 @@ async fn run_setup_validate() -> error::Result<()> {
     }
     let no_dupes = duplicates.is_empty();
     checks.push(ValidateCheck {
-        name: "unique_account_ids".to_string(),
-        ok: no_dupes,
-        detail: if no_dupes {
+        name:       "unique_account_ids".to_string(),
+        ok:         no_dupes,
+        detail:     if no_dupes {
             None
         } else {
             has_errors = true;
@@ -2004,9 +2005,9 @@ async fn run_setup_validate() -> error::Result<()> {
     // Count enabled accounts
     let enabled_count = accounts_cfg.accounts.iter().filter(|a| a.enabled).count();
     checks.push(ValidateCheck {
-        name: "enabled_accounts".to_string(),
-        ok: true,
-        detail: Some(format!("{enabled_count} account(s) enabled")),
+        name:       "enabled_accounts".to_string(),
+        ok:         true,
+        detail:     Some(format!("{enabled_count} account(s) enabled")),
         suggestion: None,
     });
 
@@ -2017,17 +2018,17 @@ async fn run_setup_validate() -> error::Result<()> {
         for e in &startup_errors {
             has_errors = true;
             checks.push(ValidateCheck {
-                name: "startup".to_string(),
-                ok: false,
-                detail: Some(e.to_string()),
+                name:       "startup".to_string(),
+                ok:         false,
+                detail:     Some(e.to_string()),
                 suggestion: None,
             });
         }
         if startup_errors.is_empty() {
             checks.push(ValidateCheck {
-                name: "startup".to_string(),
-                ok: true,
-                detail: None,
+                name:       "startup".to_string(),
+                ok:         true,
+                detail:     None,
                 suggestion: None,
             });
         }
@@ -2037,7 +2038,11 @@ async fn run_setup_validate() -> error::Result<()> {
         if check.ok {
             eprintln!("OK: {}", check.name);
         } else {
-            eprintln!("FAIL: {} — {}", check.name, check.detail.as_deref().unwrap_or(""));
+            eprintln!(
+                "FAIL: {} — {}",
+                check.name,
+                check.detail.as_deref().unwrap_or("")
+            );
         }
     }
 
@@ -2086,9 +2091,9 @@ async fn run_setup_account(action: SetupAccountAction) -> error::Result<()> {
                 println!(
                     "{}",
                     serde_json::to_string(&SetupAccountAddResponse {
-                        ok: true,
-                        action: "account.add",
-                        id: &id,
+                        ok:      true,
+                        action:  "account.add",
+                        id:      &id,
                         created: false,
                     })
                     .expect("SetupAccountAddResponse must serialize")
@@ -2103,9 +2108,11 @@ async fn run_setup_account(action: SetupAccountAction) -> error::Result<()> {
                         println!(
                             "{}",
                             serde_json::to_string(&ErrorResponse {
-                                ok: false,
-                                error: "--exchange is required for ccxt broker".to_string(),
-                                suggestion: Some("add --exchange binance (or bybit, okx)".to_string()),
+                                ok:         false,
+                                error:      "--exchange is required for ccxt broker".to_string(),
+                                suggestion: Some(
+                                    "add --exchange binance (or bybit, okx)".to_string()
+                                ),
                             })
                             .expect("ErrorResponse must serialize")
                         );
@@ -2123,10 +2130,8 @@ async fn run_setup_account(action: SetupAccountAction) -> error::Result<()> {
                     println!(
                         "{}",
                         serde_json::to_string(&ErrorResponse {
-                            ok: false,
-                            error: format!(
-                                "unknown broker type \"{other}\""
-                            ),
+                            ok:         false,
+                            error:      format!("unknown broker type \"{other}\""),
                             suggestion: Some("use --broker paper or --broker ccxt".to_string()),
                         })
                         .expect("ErrorResponse must serialize")
@@ -2149,9 +2154,9 @@ async fn run_setup_account(action: SetupAccountAction) -> error::Result<()> {
             println!(
                 "{}",
                 serde_json::to_string(&SetupAccountAddResponse {
-                    ok: true,
-                    action: "account.add",
-                    id: &id,
+                    ok:      true,
+                    action:  "account.add",
+                    id:      &id,
                     created: true,
                 })
                 .expect("SetupAccountAddResponse must serialize")
@@ -2185,8 +2190,8 @@ async fn run_setup_account(action: SetupAccountAction) -> error::Result<()> {
                 println!(
                     "{}",
                     serde_json::to_string(&ErrorResponse {
-                        ok: false,
-                        error: "--yes flag is required to confirm removal".to_string(),
+                        ok:         false,
+                        error:      "--yes flag is required to confirm removal".to_string(),
                         suggestion: Some("add --yes to confirm removal".to_string()),
                     })
                     .expect("ErrorResponse must serialize")
@@ -2202,9 +2207,11 @@ async fn run_setup_account(action: SetupAccountAction) -> error::Result<()> {
                 println!(
                     "{}",
                     serde_json::to_string(&ErrorResponse {
-                        ok: false,
-                        error: format!("account \"{id}\" not found"),
-                        suggestion: Some("run 'rara setup account list' to see available accounts".to_string()),
+                        ok:         false,
+                        error:      format!("account \"{id}\" not found"),
+                        suggestion: Some(
+                            "run 'rara setup account list' to see available accounts".to_string()
+                        ),
                     })
                     .expect("ErrorResponse must serialize")
                 );
@@ -2217,9 +2224,9 @@ async fn run_setup_account(action: SetupAccountAction) -> error::Result<()> {
             println!(
                 "{}",
                 serde_json::to_string(&SetupAccountRemoveResponse {
-                    ok: true,
-                    action: "account.remove",
-                    id: &id,
+                    ok:      true,
+                    action:  "account.remove",
+                    id:      &id,
                     removed: true,
                 })
                 .expect("SetupAccountRemoveResponse must serialize")
@@ -2232,8 +2239,8 @@ async fn run_setup_account(action: SetupAccountAction) -> error::Result<()> {
                 println!(
                     "{}",
                     serde_json::to_string(&ErrorResponse {
-                        ok: false,
-                        error: format!("account \"{id}\" not found"),
+                        ok:         false,
+                        error:      format!("account \"{id}\" not found"),
                         suggestion: Some(
                             "run 'rara setup account list' to see available accounts".to_string(),
                         ),
@@ -2247,8 +2254,10 @@ async fn run_setup_account(action: SetupAccountAction) -> error::Result<()> {
                 let fields = acc.broker_config.to_field_map();
                 let type_key = acc.broker_config.type_key();
                 let entry = rara_trading_engine::broker_registry::find_broker(type_key)
-                    .ok_or_else(|| rara_trading_engine::broker_registry::BrokerRegistryError::UnknownType {
-                        type_key: type_key.to_string(),
+                    .ok_or_else(|| {
+                        rara_trading_engine::broker_registry::BrokerRegistryError::UnknownType {
+                            type_key: type_key.to_string(),
+                        }
                     })
                     .context(error::BrokerRegistrySnafu)?;
                 (entry.create_broker)(&fields).context(error::BrokerRegistrySnafu)?
@@ -2258,10 +2267,10 @@ async fn run_setup_account(action: SetupAccountAction) -> error::Result<()> {
                     println!(
                         "{}",
                         serde_json::to_string(&SetupAccountTestResponse {
-                            ok: true,
-                            action: "account.test",
-                            id: &id,
-                            equity: info.total_equity.to_string(),
+                            ok:             true,
+                            action:         "account.test",
+                            id:             &id,
+                            equity:         info.total_equity.to_string(),
                             available_cash: info.available_cash.to_string(),
                         })
                         .expect("SetupAccountTestResponse must serialize")
@@ -2271,8 +2280,8 @@ async fn run_setup_account(action: SetupAccountAction) -> error::Result<()> {
                     println!(
                         "{}",
                         serde_json::to_string(&ErrorResponse {
-                            ok: false,
-                            error: format!("connectivity test failed: {e}"),
+                            ok:         false,
+                            error:      format!("connectivity test failed: {e}"),
                             suggestion: Some(
                                 "check API credentials and network connectivity".to_string(),
                             ),

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,7 +1,8 @@
 //! Centralized path management for application data directories.
 //!
 //! All paths derive from a single data root, resolved once via `OnceLock`.
-//! The root can be overridden by setting the `APP_DATA_DIR` environment variable.
+//! The root can be overridden by setting the `APP_DATA_DIR` environment
+//! variable.
 
 use std::{
     path::{Path, PathBuf},

--- a/src/setup_wizard.rs
+++ b/src/setup_wizard.rs
@@ -4,25 +4,25 @@
 use std::collections::HashMap;
 
 use dialoguer::{Confirm, Input, Password, Select};
+use rara_trading_engine::{
+    account_config::AccountConfig,
+    broker_registry::{BROKER_REGISTRY, BrokerRegistryEntry, ConfigField, ConfigFieldType},
+};
 use snafu::ResultExt;
 
-use crate::accounts_config;
-use crate::app_config::{self, AppConfig};
-use crate::error::{self, IoSnafu};
-use crate::paths;
-use crate::validation;
-
-use rara_trading_engine::account_config::AccountConfig;
-use rara_trading_engine::broker_registry::{
-    BrokerRegistryEntry, ConfigField, ConfigFieldType, BROKER_REGISTRY,
+use crate::{
+    accounts_config,
+    app_config::{self, AppConfig},
+    error::{self, IoSnafu},
+    paths, validation,
 };
 
 // ---------------------------------------------------------------------------
 // Dialoguer helpers
 // ---------------------------------------------------------------------------
 
-/// Convert `dialoguer::Error` (which wraps `std::io::Error`) into `std::io::Error`
-/// so it can be used with `IoSnafu`.
+/// Convert `dialoguer::Error` (which wraps `std::io::Error`) into
+/// `std::io::Error` so it can be used with `IoSnafu`.
 fn dialog_io(e: dialoguer::Error) -> std::io::Error {
     match e {
         dialoguer::Error::IO(io) => io,
@@ -39,17 +39,15 @@ fn confirm(prompt: &str, default: bool) -> error::Result<bool> {
         .context(IoSnafu)
 }
 
-/// Helper to run a dialoguer `Input<String>` prompt with consistent error handling.
+/// Helper to run a dialoguer `Input<String>` prompt with consistent error
+/// handling.
 fn input(prompt: &str, default: Option<&str>) -> error::Result<String> {
     let builder = Input::new().with_prompt(prompt);
     let builder = match default {
         Some(d) => builder.default(d.to_string()),
         None => builder,
     };
-    builder
-        .interact_text()
-        .map_err(dialog_io)
-        .context(IoSnafu)
+    builder.interact_text().map_err(dialog_io).context(IoSnafu)
 }
 
 /// Helper to run a dialoguer `Password` prompt with consistent error handling.
@@ -246,7 +244,11 @@ async fn step_accounts() -> error::Result<Vec<String>> {
         eprintln!("  You have {existing_count} account(s) configured:");
         for acc in &existing.accounts {
             let status = if acc.enabled { "enabled" } else { "disabled" };
-            eprintln!("    - {} ({}, {status})", acc.id, acc.broker_config.type_key());
+            eprintln!(
+                "    - {} ({}, {status})",
+                acc.id,
+                acc.broker_config.type_key()
+            );
         }
     } else {
         eprintln!("  No accounts configured yet.");
@@ -278,7 +280,8 @@ async fn step_accounts() -> error::Result<Vec<String>> {
     Ok(added)
 }
 
-/// Test broker connectivity by creating a broker instance and calling `account_info`.
+/// Test broker connectivity by creating a broker instance and calling
+/// `account_info`.
 async fn test_broker_connection(
     entry: &BrokerRegistryEntry,
     fields: &HashMap<String, String>,
@@ -289,9 +292,10 @@ async fn test_broker_connection(
 
 /// Prompt the user interactively for account details and save to accounts.toml.
 ///
-/// Uses a broker-first flow: select broker type, collect broker-specific config,
-/// then suggest a short account ID derived from broker context (e.g. `bybit`
-/// for CCXT/Bybit, `paper` for Paper). Tests the connection before saving.
+/// Uses a broker-first flow: select broker type, collect broker-specific
+/// config, then suggest a short account ID derived from broker context (e.g.
+/// `bybit` for CCXT/Bybit, `paper` for Paper). Tests the connection before
+/// saving.
 async fn add_account_interactive() -> error::Result<Option<String>> {
     // 1. Broker type selection
     let registry = &*BROKER_REGISTRY;
@@ -317,8 +321,8 @@ async fn add_account_interactive() -> error::Result<Option<String>> {
             break candidate;
         }
         eprintln!(
-            "  \"{candidate}\" already exists — try a different name \
-             (e.g. {suggested_id}-demo, {suggested_id}-test)."
+            "  \"{candidate}\" already exists — try a different name (e.g. {suggested_id}-demo, \
+             {suggested_id}-test)."
         );
     };
 
@@ -467,7 +471,11 @@ fn print_summary(cfg: &AppConfig, added_accounts: &[String]) {
     eprintln!("  Accounts:    {total} configured");
 
     if !added_accounts.is_empty() {
-        eprintln!("               ({} new: {})", added_accounts.len(), added_accounts.join(", "));
+        eprintln!(
+            "               ({} new: {})",
+            added_accounts.len(),
+            added_accounts.join(", ")
+        );
     }
 
     eprintln!();

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -11,18 +11,16 @@ use snafu::{ResultExt, Snafu};
 pub enum ValidationError {
     /// Database connection failed.
     #[snafu(display(
-        "database connection failed: {source}\n\n\
-         Fix: check that PostgreSQL/TimescaleDB is running and the URL is correct.\n  \
-         Current URL: {url}\n  \
-         Override with: RARA_DB_URL=postgres://user:pass@host:5432/db"
+        "database connection failed: {source}\n\nFix: check that PostgreSQL/TimescaleDB is \
+         running and the URL is correct.\n  Current URL: {url}\n  Override with: \
+         RARA_DB_URL=postgres://user:pass@host:5432/db"
     ))]
     DatabaseConnection { url: String, source: sqlx::Error },
 
     /// LLM backend not available in PATH.
     #[snafu(display(
-        "LLM backend '{backend}' is not available\n\n\
-         Fix: ensure the agent backend is installed and accessible in PATH.\n  \
-         Override with: RARA_LLM_BACKEND=claude"
+        "LLM backend '{backend}' is not available\n\nFix: ensure the agent backend is installed \
+         and accessible in PATH.\n  Override with: RARA_LLM_BACKEND=claude"
     ))]
     LlmBackendUnavailable { backend: String },
 }
@@ -44,7 +42,8 @@ pub async fn validate_database(url: &str) -> Result<()> {
     Ok(())
 }
 
-/// Validate LLM backend availability by checking whether the command exists in PATH.
+/// Validate LLM backend availability by checking whether the command exists in
+/// PATH.
 pub fn validate_llm_backend(backend: &str) -> Result<()> {
     match which::which(backend) {
         Ok(_) => Ok(()),

--- a/tests/e2e_smoke.rs
+++ b/tests/e2e_smoke.rs
@@ -4,25 +4,29 @@
 //! These tests exercise real implementations (sled stores, paper broker, guard
 //! pipeline) with temporary directories — no mocks.
 
+use rara_domain::{
+    event::{Event, EventType},
+    research::{
+        BacktestResult, Experiment, Hypothesis, HypothesisFeedback, ResearchStrategy,
+        ResearchStrategyStatus,
+    },
+    trading::{ActionType, OrderType, Side, StagedAction, TradingCommit},
+};
+use rara_event_bus::bus::EventBus;
+use rara_research::{
+    strategy_store::StrategyStore,
+    trace::{DagSelection, Trace},
+};
+use rara_trading_engine::{
+    broker::{Broker, OrderStatus},
+    brokers::paper::PaperBroker,
+    guard_pipeline::GuardPipeline,
+    guards::{GuardResult, symbol_whitelist::SymbolWhitelist},
+};
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use serde_json::json;
 use uuid::Uuid;
-
-use rara_domain::event::{Event, EventType};
-use rara_domain::research::{
-    BacktestResult, Experiment, Hypothesis, HypothesisFeedback, ResearchStrategy,
-    ResearchStrategyStatus,
-};
-use rara_domain::trading::{ActionType, OrderType, Side, StagedAction, TradingCommit};
-use rara_event_bus::bus::EventBus;
-use rara_research::strategy_store::StrategyStore;
-use rara_research::trace::{DagSelection, Trace};
-use rara_trading_engine::broker::{Broker, OrderStatus};
-use rara_trading_engine::brokers::paper::PaperBroker;
-use rara_trading_engine::guard_pipeline::GuardPipeline;
-use rara_trading_engine::guards::symbol_whitelist::SymbolWhitelist;
-use rara_trading_engine::guards::GuardResult;
 
 // ---------------------------------------------------------------------------
 // Helpers — reusable experiment/hypothesis builders for the research DAG
@@ -124,11 +128,7 @@ fn seed_research_trace(
         .observations("Only 30 trades, likely curve-fitted")
         .build();
     trace
-        .record(
-            &exp_rejected,
-            &fb_rejected,
-            &DagSelection::Specific(idx0),
-        )
+        .record(&exp_rejected, &fb_rejected, &DagSelection::Specific(idx0))
         .unwrap();
 
     (
@@ -165,7 +165,8 @@ fn research_trace_dag_and_sota_selection() {
     assert_eq!(chain[0].id, refined_hyp.id);
     assert_eq!(chain[1].id, root_hyp.id);
 
-    // SOTA should pick exp_v2 (highest Sharpe among accepted, ignoring rejected 4.5)
+    // SOTA should pick exp_v2 (highest Sharpe among accepted, ignoring rejected
+    // 4.5)
     let sota = trace.get_sota().unwrap().expect("should have a SOTA");
     assert_eq!(
         sota.0.id, exp_v2.id,
@@ -206,7 +207,7 @@ fn research_trace_dag_and_sota_selection() {
 #[test]
 fn strategy_store_sota_promotion_lifecycle() {
     let dir = tempfile::tempdir().unwrap();
-    let (trace, _, refined_hyp, _, exp_v2, _, _, _) = seed_research_trace(dir.path());
+    let (trace, _, refined_hyp, _, exp_v2, ..) = seed_research_trace(dir.path());
 
     let db = sled::open(dir.path().join("strategy_db")).unwrap();
     let store = StrategyStore::open(&db, &dir.path().join("artifacts")).unwrap();
@@ -239,9 +240,7 @@ fn strategy_store_sota_promotion_lifecycle() {
         ResearchStrategyStatus::Promoted
     );
 
-    let promoted_list = store
-        .list(Some(ResearchStrategyStatus::Promoted))
-        .unwrap();
+    let promoted_list = store.list(Some(ResearchStrategyStatus::Promoted)).unwrap();
     assert_eq!(promoted_list.len(), 1);
     assert_eq!(promoted_list[0].id, promoted.id);
 }
@@ -485,13 +484,15 @@ async fn paper_broker_batch_and_guard_pipeline() {
         .message("Buy BTC per momentum signal")
         .strategy_id("strat-momentum")
         .strategy_version(1)
-        .actions(vec![StagedAction::builder()
-            .action_type(ActionType::PlaceOrder)
-            .contract_id("BTC-USD")
-            .side(Side::Buy)
-            .quantity(dec!(1.0))
-            .order_type(OrderType::Market)
-            .build()])
+        .actions(vec![
+            StagedAction::builder()
+                .action_type(ActionType::PlaceOrder)
+                .contract_id("BTC-USD")
+                .side(Side::Buy)
+                .quantity(dec!(1.0))
+                .order_type(OrderType::Market)
+                .build(),
+        ])
         .build();
 
     let allow_pipeline = GuardPipeline::new(vec![Box::new(SymbolWhitelist::new(vec![


### PR DESCRIPTION
## Summary
- Replace paper trading placeholder in `daemon.rs` with full WS-to-signal pipeline
- Connect to Binance WebSocket for 1m klines per contract, aggregate into 5m/15m/1h candles
- Load promoted strategies from the strategy store, execute signals through PaperBroker, publish fills to event bus
- Gracefully handle edge cases: no promoted strategies (idle), failed artifact loads (skip), WS disconnects (auto-reconnect)

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` — all 7 e2e tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)