### PR TITLE
feat(engine): CCXT async order status polling (#158)

### DIFF
--- a/crates/rara-trading-engine/src/brokers/ccxt.rs
+++ b/crates/rara-trading-engine/src/brokers/ccxt.rs
@@ -4,6 +4,7 @@
 //! across multiple cryptocurrency exchanges (Binance, OKX, Bybit).
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use bon::Builder;
@@ -24,6 +25,36 @@ use crate::broker_registry::{
     BrokerRegistryEntry, BrokerRegistryError, ConfigField, ConfigFieldType, InvalidValueSnafu,
     MissingFieldSnafu, SelectOption,
 };
+
+/// Default interval between order status polls.
+const DEFAULT_POLL_INTERVAL_MS: u64 = 1000;
+
+/// Default maximum number of polling attempts before returning last known status.
+const DEFAULT_MAX_POLL_RETRIES: u32 = 30;
+
+/// Configuration for order status polling after submission.
+///
+/// Controls how frequently and how long the broker will poll an exchange
+/// for a terminal order status (filled, cancelled, expired, rejected)
+/// after placing an order.
+#[derive(Debug, Clone, Builder)]
+pub struct OrderPollConfig {
+    /// Interval between poll attempts in milliseconds.
+    #[builder(default = DEFAULT_POLL_INTERVAL_MS)]
+    pub poll_interval_ms: u64,
+    /// Maximum number of poll attempts before returning last known status.
+    #[builder(default = DEFAULT_MAX_POLL_RETRIES)]
+    pub max_retries: u32,
+}
+
+impl Default for OrderPollConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval_ms: DEFAULT_POLL_INTERVAL_MS,
+            max_retries: DEFAULT_MAX_POLL_RETRIES,
+        }
+    }
+}
 
 /// Supported exchange identifiers.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -234,6 +265,19 @@ impl ExchangeClient {
         }
     }
 
+    /// Fetch a single order by ID and symbol.
+    async fn fetch_order(
+        &self,
+        id: &str,
+        symbol: &str,
+    ) -> Result<ccxt_rust::prelude::Order, ccxt_rust::prelude::Error> {
+        match self {
+            Self::Binance(ex) => ex.fetch_order(id, symbol).await,
+            Self::Okx(ex) => ex.fetch_order(id, symbol).await,
+            Self::Bybit(ex) => ex.fetch_order(id, symbol).await,
+        }
+    }
+
     /// Cancel an order by ID.
     async fn cancel_order(
         &self,
@@ -289,6 +333,8 @@ impl ExchangeClient {
 ///
 /// Supports Binance, OKX, and Bybit exchanges through the ccxt-rust library.
 /// Use the builder to construct an instance with exchange credentials.
+/// After submitting an order, the broker polls `fetch_order` until a terminal
+/// status is reached or the maximum number of retries is exhausted.
 #[derive(Builder)]
 pub struct CcxtBroker {
     /// Exchange identifier (e.g., "binance", "okx", "bybit").
@@ -306,6 +352,9 @@ pub struct CcxtBroker {
     /// Whether to use the exchange's sandbox/testnet environment.
     #[builder(default = false)]
     sandbox: bool,
+    /// Configuration for post-submission order status polling.
+    #[builder(default)]
+    poll_config: OrderPollConfig,
 }
 
 impl std::fmt::Debug for CcxtBroker {
@@ -313,6 +362,7 @@ impl std::fmt::Debug for CcxtBroker {
         f.debug_struct("CcxtBroker")
             .field("exchange_id", &self.exchange_id)
             .field("sandbox", &self.sandbox)
+            .field("poll_config", &self.poll_config)
             .finish_non_exhaustive()
     }
 }
@@ -360,6 +410,94 @@ impl CcxtBroker {
             }
         }
     }
+
+    /// Poll the exchange for a terminal order status after submission.
+    ///
+    /// Repeatedly calls `fetch_order` at the configured interval until the order
+    /// reaches a terminal state (closed, cancelled, expired, rejected) or the
+    /// maximum number of retries is exhausted. On timeout, returns the last known
+    /// order state so callers always get a result rather than an error.
+    ///
+    /// Individual fetch failures are logged and retried — a single transient
+    /// network error does not abort the polling loop.
+    async fn poll_order_status(
+        &self,
+        client: &ExchangeClient,
+        order: ccxt_rust::prelude::Order,
+        symbol: &str,
+    ) -> ccxt_rust::prelude::Order {
+        // Already terminal — skip polling entirely
+        if is_terminal_ccxt_status(order.status) {
+            return order;
+        }
+
+        let interval = Duration::from_millis(self.poll_config.poll_interval_ms);
+        let mut latest = order;
+
+        for attempt in 1..=self.poll_config.max_retries {
+            tokio::time::sleep(interval).await;
+
+            match client.fetch_order(&latest.id, symbol).await {
+                Ok(refreshed) => {
+                    debug!(
+                        order_id = %refreshed.id,
+                        status = ?refreshed.status,
+                        filled = ?refreshed.filled,
+                        attempt,
+                        "polled order status"
+                    );
+                    latest = refreshed;
+                    if is_terminal_ccxt_status(latest.status) {
+                        return latest;
+                    }
+                }
+                Err(err) => {
+                    // Transient failure — log and keep retrying
+                    warn!(
+                        order_id = %latest.id,
+                        attempt,
+                        error = %err,
+                        "fetch_order failed during polling, will retry"
+                    );
+                }
+            }
+        }
+
+        warn!(
+            order_id = %latest.id,
+            status = ?latest.status,
+            max_retries = self.poll_config.max_retries,
+            "order polling exhausted retries, returning last known status"
+        );
+        latest
+    }
+}
+
+/// Whether a ccxt `OrderStatus` represents a terminal (non-transitional) state.
+const fn is_terminal_ccxt_status(status: CcxtOrderStatus) -> bool {
+    matches!(
+        status,
+        CcxtOrderStatus::Closed
+            | CcxtOrderStatus::Cancelled
+            | CcxtOrderStatus::Expired
+            | CcxtOrderStatus::Rejected
+    )
+}
+
+/// Build an `OrderResult` from a ccxt `Order`, using the action's fields as
+/// fallbacks for values the exchange may not yet have populated.
+fn order_to_result(
+    order: &ccxt_rust::prelude::Order,
+    action: &StagedAction,
+) -> OrderResult {
+    OrderResult::builder()
+        .order_id(&order.id)
+        .contract_id(&action.contract_id)
+        .status(from_ccxt_order_status(order.status))
+        .side(action.side)
+        .quantity(order.filled.unwrap_or(action.quantity))
+        .price(order.average.or(order.price).unwrap_or(Decimal::ZERO))
+        .build()
 }
 
 /// Map our `Side` to ccxt `OrderSide`.
@@ -444,14 +582,11 @@ impl Broker for CcxtBroker {
                         .await
                         .map_err(|e| map_ccxt_error(&e))?;
 
-                    OrderResult::builder()
-                        .order_id(order.id)
-                        .contract_id(&action.contract_id)
-                        .status(from_ccxt_order_status(order.status))
-                        .side(action.side)
-                        .quantity(order.filled.unwrap_or(action.quantity))
-                        .price(order.average.or(order.price).unwrap_or(Decimal::ZERO))
-                        .build()
+                    let order = self
+                        .poll_order_status(&client, order, &action.contract_id)
+                        .await;
+
+                    order_to_result(&order, action)
                 }
                 ActionType::CancelOrder => {
                     debug!(contract = action.contract_id, "cancelling order");
@@ -496,14 +631,11 @@ impl Broker for CcxtBroker {
                         .await
                         .map_err(|e| map_ccxt_error(&e))?;
 
-                    OrderResult::builder()
-                        .order_id(order.id)
-                        .contract_id(&action.contract_id)
-                        .status(from_ccxt_order_status(order.status))
-                        .side(action.side)
-                        .quantity(order.filled.unwrap_or(action.quantity))
-                        .price(order.average.or(order.price).unwrap_or(Decimal::ZERO))
-                        .build()
+                    let order = self
+                        .poll_order_status(&client, order, &action.contract_id)
+                        .await;
+
+                    order_to_result(&order, action)
                 }
                 ActionType::ModifyOrder => {
                     // ccxt-rust Exchange trait has no edit_order, so cancel + re-place
@@ -527,14 +659,11 @@ impl Broker for CcxtBroker {
                         .await
                         .map_err(|e| map_ccxt_error(&e))?;
 
-                    OrderResult::builder()
-                        .order_id(order.id)
-                        .contract_id(&action.contract_id)
-                        .status(from_ccxt_order_status(order.status))
-                        .side(action.side)
-                        .quantity(order.filled.unwrap_or(action.quantity))
-                        .price(order.average.or(order.price).unwrap_or(Decimal::ZERO))
-                        .build()
+                    let order = self
+                        .poll_order_status(&client, order, &action.contract_id)
+                        .await;
+
+                    order_to_result(&order, action)
                 }
             };
 
@@ -801,5 +930,51 @@ mod tests {
         let exchange_err =
             map_ccxt_error(&ccxt_rust::prelude::Error::exchange("exchange", "server error"));
         assert!(matches!(exchange_err, BrokerError::Exchange { .. }));
+    }
+
+    #[test]
+    fn test_terminal_status_detection() {
+        assert!(is_terminal_ccxt_status(CcxtOrderStatus::Closed));
+        assert!(is_terminal_ccxt_status(CcxtOrderStatus::Cancelled));
+        assert!(is_terminal_ccxt_status(CcxtOrderStatus::Expired));
+        assert!(is_terminal_ccxt_status(CcxtOrderStatus::Rejected));
+        assert!(!is_terminal_ccxt_status(CcxtOrderStatus::Open));
+        assert!(!is_terminal_ccxt_status(CcxtOrderStatus::Partial));
+    }
+
+    #[test]
+    fn test_poll_config_defaults() {
+        let config = OrderPollConfig::default();
+        assert_eq!(config.poll_interval_ms, 1000);
+        assert_eq!(config.max_retries, 30);
+    }
+
+    #[test]
+    fn test_poll_config_custom() {
+        let config = OrderPollConfig::builder()
+            .poll_interval_ms(500)
+            .max_retries(10)
+            .build();
+        assert_eq!(config.poll_interval_ms, 500);
+        assert_eq!(config.max_retries, 10);
+    }
+
+    #[test]
+    fn test_broker_with_custom_poll_config() {
+        let broker = CcxtBroker::builder()
+            .exchange_id("binance")
+            .api_key("test")
+            .secret("test")
+            .sandbox(true)
+            .poll_config(
+                OrderPollConfig::builder()
+                    .poll_interval_ms(2000)
+                    .max_retries(60)
+                    .build(),
+            )
+            .build();
+
+        assert_eq!(broker.poll_config.poll_interval_ms, 2000);
+        assert_eq!(broker.poll_config.max_retries, 60);
     }
 }


### PR DESCRIPTION
## Summary
- After `create_order`, polls `fetch_order` at configurable intervals until the order reaches a terminal state (filled/cancelled/expired/rejected)
- New `OrderPollConfig` struct (default: 1s interval, 30 retries) configurable via `CcxtBroker::builder().poll_config(...)`
- Transient `fetch_order` errors are logged and retried; on timeout returns last known status rather than failing

## Test plan
- [x] `cargo check` passes
- [x] `cargo test -p rara-trading-engine` — all 60 unit + 4 integration tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] Manual validation with sandbox exchange (Binance testnet)

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)