### PR TITLE
feat(tui): implement dashboard with live gRPC data (#168)

### DIFF
--- a/crates/rara-tui/src/app.rs
+++ b/crates/rara-tui/src/app.rs
@@ -491,3 +491,120 @@ fn load_installed_strategies(promoted_dir: PathBuf) -> Vec<StrategyEntry> {
         }
     }
 }
+
+/// Maximum number of events to retain in the events buffer.
+const MAX_EVENTS: usize = 1000;
+
+/// Maximum number of recent events shown on the overview tab.
+const MAX_RECENT_EVENTS: usize = 50;
+
+impl App {
+    /// Ingest a gRPC [`EventMessage`] into the application state.
+    ///
+    /// Converts the message into an [`EventEntry`] for the Events tab and a
+    /// [`RecentEvent`] for the Overview tab. Older events are evicted when the
+    /// buffer exceeds [`MAX_EVENTS`].
+    pub fn push_event(&mut self, msg: rara_server::rara_proto::EventMessage) {
+        // Derive topic from the dotted event_type (e.g. "trading.order.filled" ->
+        // "trading")
+        let topic = msg
+            .event_type
+            .split('.')
+            .next()
+            .unwrap_or("unknown")
+            .to_string();
+
+        // Build a one-line summary from the payload JSON (first 80 chars)
+        let summary = build_summary(&msg.payload_json);
+
+        let strategy_id = if msg.strategy_id.is_empty() {
+            None
+        } else {
+            Some(msg.strategy_id.clone())
+        };
+
+        // Truncate timestamp to HH:MM:SS for display
+        let time = truncate_timestamp(&msg.timestamp);
+
+        let entry = EventEntry {
+            seq: msg.sequence,
+            time: time.clone(),
+            topic: topic.clone(),
+            event_type: msg.event_type.clone(),
+            summary: summary.clone(),
+            strategy_id,
+            payload: msg.payload_json,
+        };
+
+        self.events_state.events.push(entry);
+
+        // Evict oldest events when buffer is full
+        if self.events_state.events.len() > MAX_EVENTS {
+            let drain_count = self.events_state.events.len() - MAX_EVENTS;
+            self.events_state.events.drain(..drain_count);
+        }
+
+        // Auto-scroll: keep selected_index at the end
+        if self.events_state.auto_scroll && !self.events_state.events.is_empty() {
+            let filtered_len = crate::tabs::events::filtered_count(&self.events_state);
+            if filtered_len > 0 {
+                self.events_state.selected_index = filtered_len - 1;
+            }
+        }
+
+        // Mirror to recent_events for the Overview tab
+        let event_type_tag = topic.to_uppercase();
+        self.recent_events.push(RecentEvent {
+            time,
+            event_type: event_type_tag,
+            summary,
+        });
+        if self.recent_events.len() > MAX_RECENT_EVENTS {
+            let drain_count = self.recent_events.len() - MAX_RECENT_EVENTS;
+            self.recent_events.drain(..drain_count);
+        }
+    }
+}
+
+/// Extract a short display timestamp from an ISO-8601 or similar string.
+///
+/// Looks for a `T` separator and takes the time portion up to the first dot
+/// (fractional seconds) or end. Falls back to the first 8 characters.
+fn truncate_timestamp(ts: &str) -> String {
+    ts.split('T')
+        .nth(1)
+        .unwrap_or(ts)
+        .split('.')
+        .next()
+        .unwrap_or(ts)
+        .chars()
+        .take(8)
+        .collect()
+}
+
+/// Build a one-line summary from a JSON payload string.
+///
+/// Attempts to extract a "message" or "msg" field; otherwise truncates the
+/// raw JSON to 80 characters.
+fn build_summary(payload_json: &str) -> String {
+    // Quick extraction without full JSON parse for performance
+    for key in &["\"message\":", "\"msg\":"] {
+        if let Some(pos) = payload_json.find(key) {
+            let after = &payload_json[pos + key.len()..];
+            let trimmed = after.trim_start();
+            if let Some(inner) = trimmed.strip_prefix('"') {
+                // Extract string value between quotes
+                if let Some(end) = inner.find('"') {
+                    return inner[..end].to_string();
+                }
+            }
+        }
+    }
+    // Fallback: truncate raw payload
+    let truncated: String = payload_json.chars().take(80).collect();
+    if payload_json.len() > 80 {
+        format!("{truncated}...")
+    } else {
+        truncated
+    }
+}

--- a/crates/rara-tui/src/event_loop.rs
+++ b/crates/rara-tui/src/event_loop.rs
@@ -1,7 +1,8 @@
 //! Terminal event loop driving the TUI application.
 //!
-//! Handles crossterm input events, periodic status polling via gRPC, and
-//! terminal setup/teardown.
+//! Handles crossterm input events, periodic status polling via gRPC,
+//! real-time event streaming via `StreamEvents`, and terminal
+//! setup/teardown.
 
 use std::{io, path::PathBuf, time::Duration};
 
@@ -10,9 +11,12 @@ use crossterm::{
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
-use rara_server::rara_proto::{Empty, rara_service_client::RaraServiceClient};
+use rara_server::rara_proto::{
+    Empty, EventFilter as ProtoEventFilter, EventMessage, rara_service_client::RaraServiceClient,
+};
 use ratatui::{Terminal, backend::CrosstermBackend};
 use snafu::ResultExt;
+use tokio::sync::mpsc;
 use tonic::transport::Channel;
 use tracing::{info, warn};
 
@@ -34,6 +38,9 @@ const POLL_TIMEOUT: Duration = Duration::from_millis(100);
 
 /// Maximum connection attempts before giving up during startup.
 const MAX_STARTUP_ATTEMPTS: u32 = 60;
+
+/// Channel buffer size for streamed events.
+const EVENT_CHANNEL_SIZE: usize = 256;
 
 /// Run the TUI event loop.
 ///
@@ -86,18 +93,23 @@ pub async fn run(server_addr: Option<&str>, promoted_dir: PathBuf) -> Result<()>
     result
 }
 
-/// Core event loop: poll input, tick status, render.
+/// Core event loop: poll input, tick status, receive streamed events, render.
 ///
 /// During the startup phase, only quit keys are accepted and the loop
 /// periodically attempts to connect to the gRPC server with a health check.
 /// Once the server is confirmed ready, transitions to the normal dashboard
-/// phase.
+/// phase and spawns the event stream subscriber.
 async fn event_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     app: &mut App,
     client: &mut Option<RaraServiceClient<Channel>>,
     last_poll: &mut std::time::Instant,
 ) -> Result<()> {
+    // Channel for receiving streamed events from the background task
+    let (event_tx, mut event_rx) = mpsc::channel::<EventMessage>(EVENT_CHANNEL_SIZE);
+    // Track the stream task so we can detect when it dies and respawn
+    let mut stream_task: Option<tokio::task::JoinHandle<()>> = None;
+
     while app.running {
         // Render
         terminal
@@ -118,6 +130,19 @@ async fn event_loop(
                 }
                 AppPhase::Ready => handle_key(app, key.code),
             }
+        }
+
+        // Drain any streamed events from the background task
+        while let Ok(msg) = event_rx.try_recv() {
+            app.push_event(msg);
+        }
+
+        // Check if the stream task has died and needs respawning
+        if let Some(handle) = &stream_task
+            && handle.is_finished()
+        {
+            warn!("event stream task ended, will respawn on next status poll");
+            stream_task = None;
         }
 
         // Startup phase: try to connect to gRPC server
@@ -159,6 +184,10 @@ async fn event_loop(
                         info!("gRPC server is ready");
                         app.connection_status = ConnectionStatus::Connected;
                         app.phase = AppPhase::Ready;
+
+                        // Spawn event stream subscriber
+                        stream_task = Some(spawn_event_stream(c.clone(), event_tx.clone()));
+
                         *client = Some(c);
                     } else {
                         app.phase = AppPhase::StartingServer {
@@ -180,10 +209,68 @@ async fn event_loop(
         if last_poll.elapsed() >= TICK_RATE {
             *last_poll = std::time::Instant::now();
             poll_status(app, client).await?;
+
+            // Respawn event stream if it died and we have a live client
+            if stream_task.is_none()
+                && let Some(c) = client.as_ref()
+            {
+                info!("respawning event stream subscriber");
+                stream_task = Some(spawn_event_stream(c.clone(), event_tx.clone()));
+            }
         }
     }
 
+    // Cancel the stream task on exit
+    if let Some(handle) = stream_task.take() {
+        handle.abort();
+    }
+
     Ok(())
+}
+
+/// Spawn a background task that subscribes to the gRPC event stream.
+///
+/// Received [`EventMessage`]s are forwarded through `tx`. The task runs
+/// until the stream ends, the channel is closed, or an error occurs.
+fn spawn_event_stream(
+    mut client: RaraServiceClient<Channel>,
+    tx: mpsc::Sender<EventMessage>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let request = ProtoEventFilter {
+            topic: String::new(), // subscribe to all topics
+        };
+
+        let stream_result = client.stream_events(request).await;
+        let mut stream = match stream_result {
+            Ok(response) => response.into_inner(),
+            Err(status) => {
+                warn!("failed to start event stream: {status}");
+                return;
+            }
+        };
+
+        info!("event stream connected, receiving events");
+
+        loop {
+            match stream.message().await {
+                Ok(Some(msg)) => {
+                    if tx.send(msg).await.is_err() {
+                        // Receiver dropped — TUI is shutting down
+                        break;
+                    }
+                }
+                Ok(None) => {
+                    info!("event stream ended (server closed)");
+                    break;
+                }
+                Err(status) => {
+                    warn!("event stream error: {status}");
+                    break;
+                }
+            }
+        }
+    })
 }
 
 /// Handle a key press event, dispatching to tab-specific handlers when needed.


### PR DESCRIPTION
## Summary
- Wire `StreamEvents` gRPC subscription into TUI event loop via tokio spawn + mpsc channel
- Events flow in real-time to Events tab and Overview tab summary
- Auto-spawn/respawn streaming task on disconnect
- Event buffer capped at 1000 entries with auto-eviction

## Files changed
- `crates/rara-tui/src/app.rs` — `push_event()`, `truncate_timestamp()`, `build_summary()` helpers
- `crates/rara-tui/src/event_loop.rs` — `spawn_event_stream()` background task, channel integration

Closes #168

## Test plan
- [x] `cargo check` passes
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — 0 warnings
- [x] `cargo test` — all 7 tests pass