### PR TITLE
refactor(market-data): replace hand-rolled HTTP with official binance-sdk (#173)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,6 +443,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
+name = "binance-sdk"
+version = "44.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05ccc2e1ba092fa6ef496d73b2eed9248186e31cb00e207f77436ffa6ff8ea8"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64",
+ "derive_builder",
+ "ed25519-dalek",
+ "flate2",
+ "futures",
+ "hex",
+ "hmac",
+ "http",
+ "once_cell",
+ "rand 0.8.5",
+ "regex",
+ "reqwest 0.12.28",
+ "reqwest-middleware",
+ "rust_decimal",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite 0.26.2",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,7 +541,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -854,7 +892,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -1390,12 +1428,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
+dependencies = [
+ "darling_core 0.12.4",
+ "darling_macro 0.12.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1407,8 +1469,19 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
+dependencies = [
+ "darling_core 0.12.4",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1417,7 +1490,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -1469,6 +1542,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d13202debe11181040ae9063d739fa32cfcaaebe2275fe387703460ae2365b30"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e616858f6187ed828df7c64a6d71720d83767a7f19740b2d1b6fe6327b36e5"
+dependencies = [
+ "darling 0.12.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58a94ace95092c5acb1e97a7e846b310cfbd499652f72297da7493f618a98d73"
+dependencies = [
+ "derive_builder_core",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2373,6 +2477,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2589,7 +2709,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "indoc",
  "proc-macro2",
  "quote",
@@ -3074,6 +3194,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -4059,6 +4189,7 @@ name = "rara-market-data"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "binance-sdk",
  "bon",
  "chrono",
  "futures-util",
@@ -4412,15 +4543,23 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "mime_guess",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4431,6 +4570,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tower",
  "tower-http",
@@ -4483,6 +4623,21 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest 0.12.28",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
 ]
 
 [[package]]
@@ -4594,6 +4749,7 @@ dependencies = [
  "num-traits",
  "rand 0.8.5",
  "rkyv",
+ "rust_decimal_macros",
  "serde",
  "serde_json",
 ]
@@ -4894,6 +5050,17 @@ dependencies = [
  "percent-encoding",
  "serde",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5390,6 +5557,12 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -5757,6 +5930,7 @@ dependencies = [
  "log",
  "native-tls",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-native-tls",
@@ -5791,6 +5965,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
+ "slab",
  "tokio",
 ]
 
@@ -6155,6 +6330,12 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/crates/rara-market-data/Cargo.toml
+++ b/crates/rara-market-data/Cargo.toml
@@ -20,6 +20,7 @@ reqwest.workspace = true
 sqlx.workspace = true
 tokio-tungstenite.workspace = true
 futures-util.workspace = true
+binance-sdk = { version = "44.0.1", default-features = false, features = ["spot", "rustls-tls"] }
 
 [lints]
 workspace = true

--- a/crates/rara-market-data/src/fetcher/binance.rs
+++ b/crates/rara-market-data/src/fetcher/binance.rs
@@ -1,38 +1,39 @@
 //! Binance historical kline fetcher.
 //!
-//! Uses the public `/api/v3/klines` endpoint (no authentication required).
+//! Uses the official `binance-sdk` crate to access the public Binance API.
 //! Paginates at 1000 candles per request (~16.6 hours of 1m data).
 //! Resumes from the latest stored candle via `MAX(ts)` query.
 
 use async_trait::async_trait;
+use binance_sdk::common::config::ConfigurationRestApi;
+use binance_sdk::spot::rest_api::{
+    ExchangeInfoParams, KlinesIntervalEnum, KlinesItemInner, KlinesParams, RestApi,
+};
 use chrono::{DateTime, Days, NaiveDate, NaiveTime, Utc};
 use snafu::ResultExt;
 use tracing::info;
 
-use super::{HistoryFetcher, HttpSnafu, ParseSnafu, Result, StoreSnafu};
+use super::{HistoryFetcher, ParseSnafu, Result, StoreSnafu};
 use crate::store::{MarketStore, candle::CandleRow};
 
 /// Maximum candles per Binance klines request.
-const PAGE_LIMIT: u64 = 1000;
+const PAGE_LIMIT: i32 = 1000;
 
-/// Binance public API base URL.
-const BASE_URL: &str = "https://api.binance.com";
-
-/// Raw candle parsed from Binance JSON before DB insertion.
-struct RawKline {
-    open_time_ms: i64,
-    open:         f64,
-    high:         f64,
-    low:          f64,
-    close:        f64,
-    volume:       f64,
-    trade_count:  u32,
+/// Create a Binance REST API client (no auth needed for market data).
+fn create_client() -> Result<RestApi> {
+    let config = ConfigurationRestApi::builder().build().map_err(|e| {
+        ParseSnafu {
+            message: format!("failed to build Binance config: {e}"),
+        }
+        .build()
+    })?;
+    Ok(RestApi::new(config))
 }
 
-/// Fetches historical 1m klines from Binance public API.
+/// Fetches historical 1m klines from Binance using the official SDK.
 pub struct BinanceFetcher {
-    /// HTTP client.
-    pub client: reqwest::Client,
+    /// Binance REST API client.
+    api: RestApi,
     /// Binance symbol, e.g. `"BTCUSDT"`.
     pub symbol: String,
 }
@@ -41,7 +42,7 @@ impl BinanceFetcher {
     /// Create a new fetcher for the given Binance symbol.
     pub fn new(symbol: impl Into<String>) -> Self {
         Self {
-            client: reqwest::Client::new(),
+            api: create_client().expect("Binance client must build"),
             symbol: symbol.into(),
         }
     }
@@ -51,56 +52,61 @@ impl BinanceFetcher {
     /// Fetches a single candle starting from epoch to discover when Binance
     /// first has data for the symbol. Returns `None` if no data exists.
     pub async fn earliest_available(&self) -> Result<Option<NaiveDate>> {
-        let url = format!(
-            "{BASE_URL}/api/v3/klines?symbol={}&interval=1m&startTime=0&limit=1",
-            self.symbol
-        );
-        let resp = self
-            .client
-            .get(&url)
-            .send()
-            .await
-            .context(HttpSnafu)?
-            .error_for_status()
-            .context(HttpSnafu)?;
-        let rows = resp
-            .json::<Vec<Vec<serde_json::Value>>>()
-            .await
-            .context(HttpSnafu)?;
+        let params = KlinesParams::builder(self.symbol.clone(), KlinesIntervalEnum::Interval1m)
+            .start_time(0_i64)
+            .limit(1)
+            .build()
+            .map_err(|e| ParseSnafu { message: e.to_string() }.build())?;
 
-        Ok(rows
-            .first()
-            .and_then(|row| parse_binance_kline(row).ok())
-            .and_then(|k| {
-                DateTime::from_timestamp_millis(k.open_time_ms).map(|dt| dt.date_naive())
-            }))
+        let resp = self.api.klines(params).await.map_err(|e| {
+            ParseSnafu {
+                message: format!("klines request failed: {e}"),
+            }
+            .build()
+        })?;
+
+        let klines = resp.data().await.map_err(|e| {
+            ParseSnafu {
+                message: format!("klines parse failed: {e}"),
+            }
+            .build()
+        })?;
+
+        Ok(klines.first().and_then(|row| {
+            extract_open_time(row)
+                .and_then(|ms| DateTime::from_timestamp_millis(ms).map(|dt| dt.date_naive()))
+        }))
     }
 
-    /// Fetch one page of klines.
-    async fn fetch_page(&self, start_ms: i64, end_ms: i64) -> Result<Vec<RawKline>> {
-        let url = format!(
-            "{BASE_URL}/api/v3/klines?symbol={}&interval=1m&startTime={start_ms}&endTime={end_ms}&\
-             limit={PAGE_LIMIT}",
-            self.symbol
-        );
-        let resp = self
-            .client
-            .get(&url)
-            .send()
-            .await
-            .context(HttpSnafu)?
-            .error_for_status()
-            .context(HttpSnafu)?;
+    /// Fetch one page of klines via the SDK.
+    async fn fetch_page(
+        &self,
+        start_ms: i64,
+        end_ms: i64,
+    ) -> Result<Vec<Vec<KlinesItemInner>>> {
+        let params = KlinesParams::builder(self.symbol.clone(), KlinesIntervalEnum::Interval1m)
+            .start_time(start_ms)
+            .end_time(end_ms)
+            .limit(PAGE_LIMIT)
+            .build()
+            .map_err(|e| ParseSnafu { message: e.to_string() }.build())?;
 
-        let rows = resp
-            .json::<Vec<Vec<serde_json::Value>>>()
-            .await
-            .context(HttpSnafu)?;
-        rows.iter().map(|row| parse_binance_kline(row)).collect()
+        let resp = self.api.klines(params).await.map_err(|e| {
+            ParseSnafu {
+                message: format!("klines request failed: {e}"),
+            }
+            .build()
+        })?;
+
+        let klines = resp.data().await.map_err(|e| {
+            ParseSnafu {
+                message: format!("klines parse failed: {e}"),
+            }
+            .build()
+        })?;
+        Ok(klines)
     }
-}
 
-impl BinanceFetcher {
     /// Fetch and store candles with a per-page progress callback.
     ///
     /// `on_progress` is called after each page with the number of candles
@@ -113,7 +119,8 @@ impl BinanceFetcher {
         end: NaiveDate,
         on_progress: impl Fn(usize) + Send + Sync,
     ) -> Result<usize> {
-        Self::fetch_core(self, store, instrument_id, start, end, &on_progress).await
+        self.fetch_core(store, instrument_id, start, end, &on_progress)
+            .await
     }
 
     /// Core fetch loop shared by trait impl and progress variant.
@@ -156,22 +163,15 @@ impl BinanceFetcher {
                 break;
             }
 
-            cursor_ms = page.last().expect("non-empty page").open_time_ms + 60_001;
+            let last_open_time = page
+                .last()
+                .and_then(|row| extract_open_time(row))
+                .expect("non-empty page must have open_time");
+            cursor_ms = last_open_time + 60_001;
 
             let candle_rows: Vec<CandleRow> = page
                 .iter()
-                .map(|k| CandleRow {
-                    ts:            DateTime::from_timestamp_millis(k.open_time_ms)
-                        .unwrap_or(DateTime::<Utc>::MIN_UTC),
-                    instrument_id: instrument_id.to_string(),
-                    interval:      "1m".to_string(),
-                    open:          k.open,
-                    high:          k.high,
-                    low:           k.low,
-                    close:         k.close,
-                    volume:        k.volume,
-                    trade_count:   k.trade_count.cast_signed(),
-                })
+                .filter_map(|row| parse_sdk_kline(row, instrument_id))
                 .collect();
 
             let count = store
@@ -190,29 +190,40 @@ impl BinanceFetcher {
 
 /// Search Binance for tradeable USDT-margined spot symbols.
 ///
-/// Fetches `/api/v3/exchangeInfo` and filters by `query` substring
+/// Uses the SDK's `exchange_info` endpoint and filters by `query` substring
 /// (case-insensitive). Returns matching symbol names.
 pub async fn search_symbols(query: &str) -> Result<Vec<String>> {
-    let url = format!("{BASE_URL}/api/v3/exchangeInfo?permissions=SPOT");
-    let client = reqwest::Client::new();
-    let resp = client.get(&url).send().await.context(HttpSnafu)?;
-    let body: serde_json::Value = resp.json().await.context(HttpSnafu)?;
+    let api = create_client()?;
+    let params = ExchangeInfoParams::builder()
+        .build()
+        .map_err(|e| ParseSnafu { message: e.to_string() }.build())?;
+
+    let resp = api.exchange_info(params).await.map_err(|e| {
+        ParseSnafu {
+            message: format!("exchange_info request failed: {e}"),
+        }
+        .build()
+    })?;
+
+    let info = resp.data().await.map_err(|e| {
+        ParseSnafu {
+            message: format!("exchange_info parse failed: {e}"),
+        }
+        .build()
+    })?;
 
     let query_upper = query.to_uppercase();
-    let symbols = body["symbols"]
-        .as_array()
-        .unwrap_or(&Vec::new())
-        .iter()
-        .filter_map(|s| {
-            let symbol = s["symbol"].as_str()?;
-            let status = s["status"].as_str()?;
-            let quote = s["quoteAsset"].as_str()?;
-            if status == "TRADING" && quote == "USDT" && symbol.contains(&query_upper) {
-                Some(symbol.to_string())
-            } else {
-                None
-            }
+    let symbols = info
+        .symbols
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|s| {
+            let symbol = s.symbol.as_deref().unwrap_or_default();
+            let status_match = s.status.as_deref() == Some("TRADING");
+            let quote_match = s.quote_asset.as_deref() == Some("USDT");
+            status_match && quote_match && symbol.to_uppercase().contains(&query_upper)
         })
+        .filter_map(|s| s.symbol)
         .collect();
 
     Ok(symbols)
@@ -227,43 +238,58 @@ impl HistoryFetcher for BinanceFetcher {
         start: NaiveDate,
         end: NaiveDate,
     ) -> Result<usize> {
-        Self::fetch_core(self, store, instrument_id, start, end, &|_| {}).await
+        self.fetch_core(store, instrument_id, start, end, &|_| {})
+            .await
     }
 }
 
-/// Parse a single Binance kline JSON array.
-fn parse_binance_kline(row: &[serde_json::Value]) -> Result<RawKline> {
-    let parse_f64 = |idx: usize, name: &str| -> Result<f64> {
-        row.get(idx)
-            .and_then(|v| v.as_str())
-            .and_then(|s| s.parse::<f64>().ok())
-            .ok_or_else(|| {
-                ParseSnafu {
-                    message: format!("missing {name} at index {idx}"),
-                }
-                .build()
-            })
-    };
+/// Extract the open time (ms) from a SDK kline row.
+fn extract_open_time(row: &[KlinesItemInner]) -> Option<i64> {
+    match row.first()? {
+        KlinesItemInner::Integer(ms) => Some(*ms),
+        _ => None,
+    }
+}
 
-    let open_time_ms = row
-        .first()
-        .and_then(serde_json::Value::as_i64)
-        .ok_or_else(|| {
-            ParseSnafu {
-                message: "missing open_time".to_string(),
-            }
-            .build()
-        })?;
+/// Parse a SDK kline row into a `CandleRow`.
+fn parse_sdk_kline(row: &[KlinesItemInner], instrument_id: &str) -> Option<CandleRow> {
+    let open_time_ms = extract_open_time(row)?;
+    let open = extract_f64(row, 1)?;
+    let high = extract_f64(row, 2)?;
+    let low = extract_f64(row, 3)?;
+    let close = extract_f64(row, 4)?;
+    let volume = extract_f64(row, 5)?;
+    let trade_count = extract_i64(row, 8).unwrap_or(0);
 
-    let trade_count = row.get(8).and_then(serde_json::Value::as_u64).unwrap_or(0);
-
-    Ok(RawKline {
-        open_time_ms,
-        open: parse_f64(1, "open")?,
-        high: parse_f64(2, "high")?,
-        low: parse_f64(3, "low")?,
-        close: parse_f64(4, "close")?,
-        volume: parse_f64(5, "volume")?,
-        trade_count: u32::try_from(trade_count).unwrap_or(u32::MAX),
+    Some(CandleRow {
+        ts:            DateTime::from_timestamp_millis(open_time_ms)
+            .unwrap_or(DateTime::<Utc>::MIN_UTC),
+        instrument_id: instrument_id.to_string(),
+        interval:      "1m".to_string(),
+        open,
+        high,
+        low,
+        close,
+        volume,
+        trade_count:   i32::try_from(trade_count).unwrap_or(i32::MAX),
     })
+}
+
+/// Extract an f64 from a kline row (SDK returns strings for decimal values).
+fn extract_f64(row: &[KlinesItemInner], idx: usize) -> Option<f64> {
+    match row.get(idx)? {
+        KlinesItemInner::String(s) => s.parse().ok(),
+        #[allow(clippy::cast_precision_loss)]
+        KlinesItemInner::Integer(n) => Some(*n as f64),
+        KlinesItemInner::Other(v) => v.as_f64(),
+    }
+}
+
+/// Extract an i64 from a kline row.
+fn extract_i64(row: &[KlinesItemInner], idx: usize) -> Option<i64> {
+    match row.get(idx)? {
+        KlinesItemInner::Integer(n) => Some(*n),
+        KlinesItemInner::String(s) => s.parse().ok(),
+        KlinesItemInner::Other(v) => v.as_i64(),
+    }
 }


### PR DESCRIPTION
Closes #173

## Summary
- Replace raw `reqwest` HTTP calls in `BinanceFetcher` with official `binance-sdk` v44
- Uses `spot` + `rustls-tls` features (no openssl dependency)
- `KlinesParams` for klines, `ExchangeInfoParams` for symbol search
- Positions codebase for futures/derivatives via additional feature flags

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test` passes
- [ ] CI green