### PR TITLE
fix(research): align strategy artifact paths and backtest contract (#176)

### DIFF
--- a/crates/rara-research/src/research_loop.rs
+++ b/crates/rara-research/src/research_loop.rs
@@ -145,6 +145,9 @@ pub struct ResearchLoop {
     /// Timeframes to evaluate each hypothesis on.
     #[builder(default = vec![Timeframe::Hour1, Timeframe::Hour4, Timeframe::Day1])]
     timeframes:          Vec<Timeframe>,
+    /// Contract/instrument name used for backtesting (e.g. "BTCUSDT").
+    #[builder(default = "default".to_string(), into)]
+    contract:            String,
 }
 
 impl ResearchLoop {
@@ -380,7 +383,7 @@ impl ResearchLoop {
             .load_handle(strategy_id)
             .context(StrategyManagerSnafu)?;
         self.backtester
-            .run(handle, "default", timeframe)
+            .run(handle, &self.contract, timeframe)
             .await
             .context(BacktestSnafu)
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -94,7 +94,8 @@ pub async fn run(iterations: u32, grpc_addr: String) -> error::Result<()> {
         let cycle_delay = std::time::Duration::from_secs(cfg.research.cycle_delay_secs);
         tasks.spawn(async move {
             info!(iterations, contract = %contract, "research loop starting");
-            let research_loop = build_research_loop(&trace_path, Arc::clone(&bus)).await?;
+            let research_loop =
+                build_research_loop(&trace_path, Arc::clone(&bus), &contract).await?;
             run_research_loop(&research_loop, &bus, iterations, &contract, cycle_delay).await
         });
     }
@@ -175,6 +176,7 @@ pub async fn run(iterations: u32, grpc_addr: String) -> error::Result<()> {
 async fn build_research_loop(
     trace_path: &Path,
     event_bus: Arc<EventBus>,
+    contract: &str,
 ) -> error::Result<ResearchLoop> {
     let template_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("strategies/template");
     let prompts_dir =
@@ -232,6 +234,7 @@ async fn build_research_loop(
         .trace(trace)
         .event_bus(event_bus)
         .generated_dir(paths::strategies_generated_dir())
+        .contract(contract)
         .build())
 }
 
@@ -682,7 +685,83 @@ fn load_promoted_strategies(
         });
     }
 
+    // Fallback: also check the promoted directory where `strategy fetch` saves
+    // downloaded WASM files, so externally fetched strategies are usable too.
+    if loaded.is_empty() {
+        let promoted_dir = paths::strategies_promoted_dir();
+        if promoted_dir.exists() {
+            load_wasm_from_dir(
+                &promoted_dir,
+                contract,
+                position_size,
+                &executor,
+                &mut loaded,
+            );
+        }
+    }
+
     Ok(loaded)
+}
+
+/// Load `.wasm` files directly from a directory as fallback strategies.
+fn load_wasm_from_dir(
+    dir: &Path,
+    contract: &str,
+    position_size: rust_decimal::Decimal,
+    executor: &WasmExecutor,
+    loaded: &mut Vec<LoadedStrategy>,
+) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) => {
+            warn!(dir = %dir.display(), error = %e, "failed to read promoted directory");
+            return;
+        }
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "wasm") {
+            let wasm_bytes = match std::fs::read(&path) {
+                Ok(b) => b,
+                Err(e) => {
+                    warn!(path = %path.display(), error = %e, "failed to read WASM file");
+                    continue;
+                }
+            };
+
+            let mut handle = match executor.load(&wasm_bytes) {
+                Ok(h) => h,
+                Err(e) => {
+                    warn!(path = %path.display(), error = %e, "failed to load WASM module");
+                    continue;
+                }
+            };
+
+            let meta = match handle.meta() {
+                Ok(m) => m,
+                Err(e) => {
+                    warn!(path = %path.display(), error = %e, "failed to read WASM metadata");
+                    continue;
+                }
+            };
+
+            info!(
+                name = meta.name,
+                version = meta.version,
+                path = %path.display(),
+                "loaded fetched strategy from promoted directory"
+            );
+
+            loaded.push(LoadedStrategy {
+                name: meta.name,
+                version: meta.version,
+                contract_id: contract.to_string(),
+                position_size,
+                handle,
+            });
+        }
+    }
 }
 
 /// Build a [`StrategyEvaluator`](rara_feedback::evaluator::StrategyEvaluator)

--- a/src/main.rs
+++ b/src/main.rs
@@ -901,7 +901,7 @@ async fn run_research(action: ResearchAction) -> error::Result<()> {
 }
 
 /// Build the `ResearchLoop` from config, trace path, and DB connection.
-async fn build_research_loop(trace_path: &Path) -> error::Result<ResearchLoop> {
+async fn build_research_loop(trace_path: &Path, contract: &str) -> error::Result<ResearchLoop> {
     let template_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("strategies/template");
     let prompts_dir =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("crates/rara-research/src/prompts");
@@ -961,6 +961,7 @@ async fn build_research_loop(trace_path: &Path) -> error::Result<ResearchLoop> {
         .trace(trace)
         .event_bus(event_bus)
         .generated_dir(paths::strategies_generated_dir())
+        .contract(contract)
         .build())
 }
 
@@ -972,7 +973,7 @@ async fn run_research_loop(
     quiet: bool,
 ) -> error::Result<()> {
     let trace_path = trace_dir.map_or_else(|| paths::data_dir().join("trace"), PathBuf::from);
-    let research_loop = build_research_loop(&trace_path).await?;
+    let research_loop = build_research_loop(&trace_path, contract).await?;
 
     let mut accepted_count: u32 = 0;
     let mut rejected_count: u32 = 0;
@@ -1719,7 +1720,11 @@ fn list_promoted_from_dir(
         let entry = entry.context(PmIoSnafu)?;
         let path = entry.path();
 
-        if path.extension().is_some_and(|ext| ext == "json") {
+        if path.extension().is_some_and(|ext| ext == "json")
+            && !path
+                .file_name()
+                .is_some_and(|n| n.to_string_lossy().ends_with(".registry.json"))
+        {
             let contents = std::fs::read_to_string(&path).context(PmIoSnafu)?;
             let strategy: PromotedStrategy =
                 serde_json::from_str(&contents).context(PmSerializeSnafu)?;


### PR DESCRIPTION
## Summary
- Filter `.registry.json` from promoted strategy scanning — fixes C2
- Fallback to `strategies/promoted` dir for fetched WASM files — fixes C3
- Add `contract` field to `ResearchLoop`, pass to backtester — fixes C5

## Files changed
- `src/main.rs` — filter registry.json, wire contract to builder
- `src/daemon.rs` — fallback loader, wire contract to builder
- `crates/rara-research/src/research_loop.rs` — add contract field

Closes #176

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy` — 0 warnings
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo test` — all 7 tests pass