### PR TITLE
feat(cli): add strategy backtest command (#182)

### DIFF
--- a/crates/rara-market-data/src/fetcher/binance.rs
+++ b/crates/rara-market-data/src/fetcher/binance.rs
@@ -6,9 +6,11 @@
 //! so re-runs with an earlier start date correctly backfill missing history.
 
 use async_trait::async_trait;
-use binance_sdk::common::config::ConfigurationRestApi;
-use binance_sdk::spot::rest_api::{
-    ExchangeInfoParams, KlinesIntervalEnum, KlinesItemInner, KlinesParams, RestApi,
+use binance_sdk::{
+    common::config::ConfigurationRestApi,
+    spot::rest_api::{
+        ExchangeInfoParams, KlinesIntervalEnum, KlinesItemInner, KlinesParams, RestApi,
+    },
 };
 use chrono::{DateTime, Days, NaiveDate, NaiveTime, Utc};
 use snafu::ResultExt;
@@ -34,7 +36,7 @@ fn create_client() -> Result<RestApi> {
 /// Fetches historical 1m klines from Binance using the official SDK.
 pub struct BinanceFetcher {
     /// Binance REST API client.
-    api: RestApi,
+    api:        RestApi,
     /// Binance symbol, e.g. `"BTCUSDT"`.
     pub symbol: String,
 }
@@ -43,7 +45,7 @@ impl BinanceFetcher {
     /// Create a new fetcher for the given Binance symbol.
     pub fn new(symbol: impl Into<String>) -> Self {
         Self {
-            api: create_client().expect("Binance client must build"),
+            api:    create_client().expect("Binance client must build"),
             symbol: symbol.into(),
         }
     }
@@ -57,7 +59,12 @@ impl BinanceFetcher {
             .start_time(0_i64)
             .limit(1)
             .build()
-            .map_err(|e| ParseSnafu { message: e.to_string() }.build())?;
+            .map_err(|e| {
+                ParseSnafu {
+                    message: e.to_string(),
+                }
+                .build()
+            })?;
 
         let resp = self.api.klines(params).await.map_err(|e| {
             ParseSnafu {
@@ -80,17 +87,18 @@ impl BinanceFetcher {
     }
 
     /// Fetch one page of klines via the SDK.
-    async fn fetch_page(
-        &self,
-        start_ms: i64,
-        end_ms: i64,
-    ) -> Result<Vec<Vec<KlinesItemInner>>> {
+    async fn fetch_page(&self, start_ms: i64, end_ms: i64) -> Result<Vec<Vec<KlinesItemInner>>> {
         let params = KlinesParams::builder(self.symbol.clone(), KlinesIntervalEnum::Interval1m)
             .start_time(start_ms)
             .end_time(end_ms)
             .limit(PAGE_LIMIT)
             .build()
-            .map_err(|e| ParseSnafu { message: e.to_string() }.build())?;
+            .map_err(|e| {
+                ParseSnafu {
+                    message: e.to_string(),
+                }
+                .build()
+            })?;
 
         let resp = self.api.klines(params).await.map_err(|e| {
             ParseSnafu {
@@ -146,8 +154,14 @@ impl BinanceFetcher {
             .timestamp_millis()
             - 1;
 
-        let stored_min = store.min_ts(instrument_id, "1m").await.context(StoreSnafu)?;
-        let stored_max = store.max_ts(instrument_id, "1m").await.context(StoreSnafu)?;
+        let stored_min = store
+            .min_ts(instrument_id, "1m")
+            .await
+            .context(StoreSnafu)?;
+        let stored_max = store
+            .max_ts(instrument_id, "1m")
+            .await
+            .context(StoreSnafu)?;
 
         let mut total = 0usize;
 
@@ -156,16 +170,15 @@ impl BinanceFetcher {
             let min_ms = min_ts.timestamp_millis();
             if range_start_ms < min_ms {
                 let head_end = min_ms - 1; // up to just before the first stored candle
-                info!(
-                    "binance: head gap detected, fetching {range_start_ms} → {head_end}"
-                );
+                info!("binance: head gap detected, fetching {range_start_ms} → {head_end}");
                 total += self
                     .fetch_range(store, instrument_id, range_start_ms, head_end, on_progress)
                     .await?;
             }
         }
 
-        // Tail gap: resume from last stored candle + 1 minute (or from start if no data)
+        // Tail gap: resume from last stored candle + 1 minute (or from start if no
+        // data)
         let tail_start = stored_max.map_or(range_start_ms, |ts| ts.timestamp_millis() + 60_000);
         if tail_start <= range_end_ms {
             total += self
@@ -229,9 +242,12 @@ impl BinanceFetcher {
 /// (case-insensitive). Returns matching symbol names.
 pub async fn search_symbols(query: &str) -> Result<Vec<String>> {
     let api = create_client()?;
-    let params = ExchangeInfoParams::builder()
+    let params = ExchangeInfoParams::builder().build().map_err(|e| {
+        ParseSnafu {
+            message: e.to_string(),
+        }
         .build()
-        .map_err(|e| ParseSnafu { message: e.to_string() }.build())?;
+    })?;
 
     let resp = api.exchange_info(params).await.map_err(|e| {
         ParseSnafu {
@@ -297,16 +313,15 @@ fn parse_sdk_kline(row: &[KlinesItemInner], instrument_id: &str) -> Option<Candl
     let trade_count = extract_i64(row, 8).unwrap_or(0);
 
     Some(CandleRow {
-        ts:            DateTime::from_timestamp_millis(open_time_ms)
-            .unwrap_or(DateTime::<Utc>::MIN_UTC),
+        ts: DateTime::from_timestamp_millis(open_time_ms).unwrap_or(DateTime::<Utc>::MIN_UTC),
         instrument_id: instrument_id.to_string(),
-        interval:      "1m".to_string(),
+        interval: "1m".to_string(),
         open,
         high,
         low,
         close,
         volume,
-        trade_count:   i32::try_from(trade_count).unwrap_or(i32::MAX),
+        trade_count: i32::try_from(trade_count).unwrap_or(i32::MAX),
     })
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -236,6 +236,18 @@ pub enum StrategyAction {
 
     /// List locally installed strategies fetched from the registry.
     Installed,
+
+    /// Run a backtest on a fetched strategy against historical data.
+    Backtest {
+        /// Strategy name (e.g. "btc-momentum").
+        name:      String,
+        /// Contract/instrument to backtest against (e.g. "BTCUSDT").
+        #[arg(long)]
+        contract:  String,
+        /// Timeframe for the backtest (e.g. "1h", "4h", "1d").
+        #[arg(long, default_value = "1h")]
+        timeframe: String,
+    },
 }
 
 /// Event bus query subcommands.
@@ -297,16 +309,16 @@ pub enum SetupAction {
     Data {
         /// Data source: "binance" or "yahoo".
         #[arg(long, default_value = "binance")]
-        source: String,
+        source:  String,
         /// Search for a symbol (e.g. "SOL", "DOGE").
         #[arg(long)]
-        search: Option<String>,
+        search:  Option<String>,
         /// Start date (YYYY-MM-DD). Defaults to earliest available on exchange.
         #[arg(long)]
-        start: Option<String>,
+        start:   Option<String>,
         /// End date (YYYY-MM-DD). Defaults to today.
         #[arg(long)]
-        end: Option<String>,
+        end:     Option<String>,
         /// Symbols to download (e.g. BTCUSDT ETHUSDT). Defaults to BTC + ETH.
         symbols: Vec<String>,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,6 @@ use rara_trading::{
 use rust_decimal_macros::dec;
 use serde::Serialize;
 use snafu::ResultExt;
-
 use uuid::Uuid;
 
 // ---------------------------------------------------------------------------
@@ -1785,6 +1784,11 @@ async fn run_strategy(action: StrategyAction) -> error::Result<()> {
         StrategyAction::List { repo } => run_strategy_list(&repo).await,
         StrategyAction::Fetch { name, repo } => run_strategy_fetch(&name, &repo).await,
         StrategyAction::Installed => run_strategy_installed(),
+        StrategyAction::Backtest {
+            name,
+            contract,
+            timeframe,
+        } => run_strategy_backtest(&name, &contract, &timeframe).await,
     }
 }
 
@@ -1876,6 +1880,119 @@ fn run_strategy_installed() -> error::Result<()> {
     Ok(())
 }
 
+#[derive(Serialize)]
+struct BacktestResponse {
+    ok:           bool,
+    action:       &'static str,
+    strategy:     String,
+    contract:     String,
+    timeframe:    String,
+    pnl:          String,
+    sharpe_ratio: f64,
+    max_drawdown: String,
+    win_rate:     f64,
+    trade_count:  u32,
+}
+
+/// Run a backtest on a fetched WASM strategy against historical market data.
+async fn run_strategy_backtest(
+    name: &str,
+    contract: &str,
+    timeframe_str: &str,
+) -> error::Result<()> {
+    use rara_trading::research::{
+        backtester::Backtester, barter_backtester::BarterBacktester, wasm_executor::WasmExecutor,
+    };
+    use rust_decimal_macros::dec;
+    use tracing::info;
+
+    let timeframe: rara_domain::timeframe::Timeframe =
+        timeframe_str.parse().map_err(|_| error::AppError::Config {
+            message: format!("invalid timeframe: {timeframe_str}"),
+        })?;
+
+    // Load WASM from promoted directory
+    let wasm_path = paths::strategies_promoted_dir().join(format!("{name}.wasm"));
+    if !wasm_path.exists() {
+        return Err(error::AppError::Config {
+            message: format!(
+                "strategy '{name}' not found at {}. Run `rara strategy fetch {name}` first.",
+                wasm_path.display()
+            ),
+        });
+    }
+
+    let wasm_bytes = std::fs::read(&wasm_path).map_err(|e| error::AppError::Config {
+        message: format!("failed to read {}: {e}", wasm_path.display()),
+    })?;
+
+    let executor = WasmExecutor::builder().build();
+    let handle = executor
+        .load(&wasm_bytes)
+        .map_err(|e| error::AppError::Config {
+            message: format!("failed to load WASM module: {e}"),
+        })?;
+
+    let meta = {
+        let mut h = executor
+            .load(&wasm_bytes)
+            .map_err(|e| error::AppError::Config {
+                message: format!("failed to load WASM for metadata: {e}"),
+            })?;
+        h.meta().map_err(|e| error::AppError::Config {
+            message: format!("failed to read strategy metadata: {e}"),
+        })?
+    };
+
+    info!(
+        strategy = meta.name,
+        version = meta.version,
+        contract,
+        %timeframe,
+        "starting backtest"
+    );
+
+    // Build backtester
+    let cfg = app_config::load();
+    let market_store = rara_market_data::store::MarketStore::connect(&cfg.database.url)
+        .await
+        .context(MarketStoreSnafu)?;
+
+    let backtester = BarterBacktester::builder()
+        .store(market_store)
+        .initial_capital(dec!(10000))
+        .fees_percent(dec!(0.1))
+        .backtest_start(chrono::NaiveDate::from_ymd_opt(2020, 1, 1).expect("valid date"))
+        .backtest_end(chrono::NaiveDate::from_ymd_opt(2030, 12, 31).expect("valid date"))
+        .build();
+
+    let result = backtester
+        .run(handle, contract, timeframe)
+        .await
+        .map_err(|e| error::AppError::Config {
+            message: format!("backtest failed: {e}"),
+        })?;
+
+    println!(
+        "{}",
+        serde_json::to_string(&BacktestResponse {
+            ok:           true,
+            action:       "strategy.backtest",
+            strategy:     meta.name,
+            contract:     contract.to_string(),
+            timeframe:    timeframe_str.to_string(),
+            pnl:          result.pnl.to_string(),
+            sharpe_ratio: result.sharpe_ratio,
+            max_drawdown: result.max_drawdown.to_string(),
+            win_rate:     result.win_rate,
+            trade_count:  result.trade_count,
+        })
+        .expect("BacktestResponse must serialize")
+    );
+
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Setup command handlers
 // ---------------------------------------------------------------------------
@@ -1914,7 +2031,10 @@ async fn run_setup_data(
         })
     };
 
-    let start = start.as_deref().map(|s| parse_date(s, "start")).transpose()?;
+    let start = start
+        .as_deref()
+        .map(|s| parse_date(s, "start"))
+        .transpose()?;
     let end = end.as_deref().map(|s| parse_date(s, "end")).transpose()?;
 
     // Symbol search mode (Binance only)

--- a/src/setup_wizard.rs
+++ b/src/setup_wizard.rs
@@ -3,13 +3,13 @@
 
 use std::collections::HashMap;
 
+use chrono::{NaiveDate, Utc};
 use dialoguer::{Confirm, Input, Password, Select};
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use rara_trading_engine::{
     account_config::AccountConfig,
     broker_registry::{BROKER_REGISTRY, BrokerRegistryEntry, ConfigField, ConfigFieldType},
 };
-use chrono::{NaiveDate, Utc};
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use snafu::ResultExt;
 
 use crate::{
@@ -175,10 +175,7 @@ const DATA_SOURCE_OPTIONS: &[&str] = &["binance", "yahoo"];
 /// backtesting. Lets the user pick a data source, then downloads BTC + ETH
 /// in parallel with progress bars.
 async fn step_market_data(database_url: &str) -> error::Result<()> {
-    if !confirm(
-        "  Download historical market data for backtesting?",
-        true,
-    )? {
+    if !confirm("  Download historical market data for backtesting?", true)? {
         eprintln!("  Skipped. You can add data later with: rara setup data");
         eprintln!();
         return Ok(());
@@ -187,10 +184,7 @@ async fn step_market_data(database_url: &str) -> error::Result<()> {
     let source_idx = select("  Data source", DATA_SOURCE_OPTIONS, 0)?;
     let source = DATA_SOURCE_OPTIONS[source_idx];
 
-    let symbols_raw = input(
-        "  Symbols (comma-separated)",
-        Some("BTCUSDT,ETHUSDT"),
-    )?;
+    let symbols_raw = input("  Symbols (comma-separated)", Some("BTCUSDT,ETHUSDT"))?;
     let symbols: Vec<String> = symbols_raw
         .split(',')
         .map(|s| s.trim().to_uppercase())
@@ -203,20 +197,28 @@ async fn step_market_data(database_url: &str) -> error::Result<()> {
         return Ok(());
     }
 
-    let date_mode_options = &["Auto-detect (earliest available per symbol)", "Custom range"];
+    let date_mode_options = &[
+        "Auto-detect (earliest available per symbol)",
+        "Custom range",
+    ];
     let date_mode = select("  Date range", date_mode_options, 0)?;
 
     let (start, end) = if date_mode == 1 {
         let start_str = input("  Start date (YYYY-MM-DD)", Some("2020-01-01"))?;
-        let end_str = input("  End date (YYYY-MM-DD)", Some(&Utc::now().format("%Y-%m-%d").to_string()))?;
-        let start = NaiveDate::parse_from_str(&start_str, "%Y-%m-%d")
-            .map_err(|_| error::AppError::Config {
+        let end_str = input(
+            "  End date (YYYY-MM-DD)",
+            Some(&Utc::now().format("%Y-%m-%d").to_string()),
+        )?;
+        let start = NaiveDate::parse_from_str(&start_str, "%Y-%m-%d").map_err(|_| {
+            error::AppError::Config {
                 message: format!("invalid start date: {start_str}"),
-            })?;
-        let end = NaiveDate::parse_from_str(&end_str, "%Y-%m-%d")
-            .map_err(|_| error::AppError::Config {
+            }
+        })?;
+        let end = NaiveDate::parse_from_str(&end_str, "%Y-%m-%d").map_err(|_| {
+            error::AppError::Config {
                 message: format!("invalid end date: {end_str}"),
-            })?;
+            }
+        })?;
         (Some(start), Some(end))
     } else {
         (None, None)
@@ -272,10 +274,12 @@ pub async fn download_symbols_parallel(
             // Auto-detect start date if not provided
             let sym_start = match start {
                 Some(d) => d,
-                None => detect_start_date(&source, &symbol).await.unwrap_or_else(|_| {
-                    // Fallback: 2017-01-01 covers most major symbols
-                    NaiveDate::from_ymd_opt(2017, 1, 1).expect("valid date")
-                }),
+                None => detect_start_date(&source, &symbol)
+                    .await
+                    .unwrap_or_else(|_| {
+                        // Fallback: 2017-01-01 covers most major symbols
+                        NaiveDate::from_ymd_opt(2017, 1, 1).expect("valid date")
+                    }),
             };
 
             let est_total =
@@ -283,8 +287,7 @@ pub async fn download_symbols_parallel(
             pb.set_length(est_total);
             pb.set_message(format!("{sym_start} → {end}"));
 
-            let result =
-                fetch_symbol(&source, &store, &symbol, sym_start, end, &pb_clone).await;
+            let result = fetch_symbol(&source, &store, &symbol, sym_start, end, &pb_clone).await;
 
             match &result {
                 Ok(count) => pb.finish_with_message(format!("{count} total")),
@@ -314,10 +317,12 @@ pub async fn download_symbols_parallel(
     eprintln!();
     eprintln!("  Data coverage:");
     for c in &coverage {
-        let min =
-            c.min_ts.map_or_else(|| "-".into(), |t| t.format("%Y-%m-%d").to_string());
-        let max =
-            c.max_ts.map_or_else(|| "-".into(), |t| t.format("%Y-%m-%d").to_string());
+        let min = c
+            .min_ts
+            .map_or_else(|| "-".into(), |t| t.format("%Y-%m-%d").to_string());
+        let max = c
+            .max_ts
+            .map_or_else(|| "-".into(), |t| t.format("%Y-%m-%d").to_string());
         eprintln!(
             "    {} ({}): {} candles  [{} → {}]",
             c.instrument_id, c.interval, c.count, min, max
@@ -372,11 +377,9 @@ async fn fetch_symbol(
             let fetcher = rara_market_data::fetcher::yahoo::YahooFetcher::new(symbol);
             fetcher.fetch_and_store(store, symbol, start, end).await
         }
-        _ => {
-            Err(rara_market_data::fetcher::FetchError::Parse {
-                message: format!("unknown source: {source}, expected 'binance' or 'yahoo'"),
-            })
-        }
+        _ => Err(rara_market_data::fetcher::FetchError::Parse {
+            message: format!("unknown source: {source}, expected 'binance' or 'yahoo'"),
+        }),
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `rara strategy backtest <name> --contract <symbol> --timeframe <tf>` CLI command
- Loads WASM from promoted directory, runs through BarterBacktester
- Outputs JSON: PnL, Sharpe, drawdown, win rate, trade count

Tested: `strategy backtest btc-momentum --contract BTCUSDT --timeframe 1h` runs successfully.

Closes #182

## Test plan
- [x] `cargo check` / `cargo clippy` / `cargo +nightly fmt --check` pass
- [x] Manual test: backtest runs against BTCUSDT 1h data (130K candles)